### PR TITLE
Fix lib install name and version numbers on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ endif
 # OS X linker doesn't support -soname, and use different extension
 # see : https://developer.apple.com/library/mac/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html
 ifeq ($(shell uname), Darwin)
-	SONAME_FLAGS =
 	SHARED_EXT = dylib
 	SHARED_EXT_MAJOR = $(LIBVER_MAJOR).$(SHARED_EXT)
 	SHARED_EXT_VER = $(LIBVER).$(SHARED_EXT)
+	SONAME_FLAGS = -install_name $(PREFIX)/lib/liblz4.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR) -current_version $(LIBVER)
 else
 	SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR)
 	SHARED_EXT = so


### PR DESCRIPTION
Hi,

here's a patch to fix the liblz4.dylib's install name, library version number and library compatibility version number on OS X. This is necessary because libraries are always referenced using absolute paths on OS X. Not setting the correct absolute install name requires users to set `DYLD_LIBRARY_PATH` or `DYLD_FALLBACK_LIBRARY_PATH`, somewhat crude alternatives to Linux' `LD_LIBRARY_PATH` that cause lots of problems and are hard to use.

I use this patch downstream in MacPorts where I just updated lz4 to r118 in https://trac.macports.org/changeset/121530. Feel free to list the install method via MacPorts on OS X at https://code.google.com/p/lz4/, too. For users that have MacPorts installed, `sudo port install lz4` will install command line tools, library and headers.
