### PR TITLE
Fixed : shadowed variable issue

### DIFF
--- a/lz4.c
+++ b/lz4.c
@@ -983,9 +983,9 @@ FORCE_INLINE int LZ4_decompress_generic(
                 copySize = length+MINMATCH - copySize;
                 if (copySize > (size_t)((char*)op-dest))   /* overlap */
                 {
-                    BYTE* const cpy = op + copySize;
-                    const BYTE* ref = (BYTE*)dest;
-                    while (op < cpy) *op++ = *ref++;
+                    BYTE* const cpy2 = op + copySize;
+                    const BYTE* ref2 = (BYTE*)dest;
+                    while (op < cpy2) *op++ = *ref2++;
                 }
                 else
                 {


### PR DESCRIPTION
Those 2 variables are not read later until being assigned on the next run
of the for loop.
This can be seen with -Wshadow compiler flag.
