### PR TITLE
fix msvc warning C4804: '/' : unsafe use of type 'bool' in operation

### DIFF
--- a/lz4.c
+++ b/lz4.c
@@ -289,7 +289,7 @@ typedef enum { full = 0, partial = 1 } earlyEnd_directive;
 /**************************************
    Macros
 **************************************/
-#define LZ4_STATIC_ASSERT(c)    { enum { LZ4_static_assert = 1/(!!(c)) }; }   /* use only *after* variable declarations */
+#define LZ4_STATIC_ASSERT(c)    { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
 #if LZ4_ARCH64 || !defined(__GNUC__)
 #  define LZ4_WILDCOPY(d,s,e)   { do { LZ4_COPY8(d,s) } while (d<e); }        /* at the end, d>=e; */
 #else


### PR DESCRIPTION
Hey there.

Minor warning fix for MSVC warning C4804: '/' : unsafe use of type 'bool' in operation.

I cannot give exact reproduction steps as warning pop ups on my compiler from time to time. 
It must be some magical combination of directives and options :-S

Keep up the good work
- rlyeh
