### PR TITLE
port lz4 to tms570 (Texas Instuments Compiler, BE), stm32f4 (IAR)

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -72,7 +72,6 @@ const char* LZ4_versionString (void);
  */
 #define LZ4_MEMORY_USAGE 14
 
-
 /**************************************
 *  Simple Functions
 **************************************/
@@ -133,7 +132,6 @@ LZ4_compress_fast() :
     Values <= 0 will be replaced by ACCELERATION_DEFAULT (see lz4.c), which is 1.
 */
 int LZ4_compress_fast (const char* source, char* dest, int sourceSize, int maxDestSize, int acceleration);
-
 
 /*
 LZ4_compress_fast_extState() :
@@ -326,6 +324,10 @@ int LZ4_decompress_fast_usingDict (const char* source, char* dest, int originalS
 #    define LZ4_DEPRECATED(message) __attribute__((deprecated))
 #  elif defined(_MSC_VER)
 #    define LZ4_DEPRECATED(message) __declspec(deprecated(message))
+#  elif defined(__TI_COMPILER_VERSION__)
+#    define LZ4_DEPRECATED(message)  __attribute__((deprecated))
+#  elif defined(__IAR_SYSTEMS_ICC__)
+#    define LZ4_DEPRECATED(message)
 #  else
 #    pragma message("WARNING: You need to implement LZ4_DEPRECATED for this compiler")
 #    define LZ4_DEPRECATED(message)


### PR DESCRIPTION
Port include only lz4.c & lz4.h
- Embedding system usually not use dynamic memory. I hide all dynamic memory calls under HEAPMODE #ifdef
- Add LZ4_DEPRECATED definition for TI compiler. 
- Disable warnings "variable "val" is used before its value is set"
- Disable warning "shift count is too large". On this systems size_t is 32 bit and shift it 32 bites right useless. Maybe you need handle this case
- Add pragmas to temporary disable  missing-prototypes warning
