### PR TITLE
Add LZ4F_disableChecksum() function

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1477,3 +1477,16 @@ size_t LZ4F_decompress(LZ4F_decompressionContext_t decompressionContext,
     *dstSizePtr = (dstPtr - dstStart);
     return nextSrcSizeHint;
 }
+
+
+
+/* LZ4F_disableChecksum()
+* Call this function to allow you to read compressed blocks out of order.
+*/
+void LZ4F_disableChecksum(LZ4F_decompressionContext_t decompressionContext)
+{
+    LZ4F_dctx_t* dctxPtr = (LZ4F_dctx_t*)decompressionContext;
+
+    dctxPtr->frameInfo.contentChecksumFlag = LZ4F_noContentChecksum;
+}
+

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -297,6 +297,10 @@ size_t LZ4F_decompress(LZ4F_decompressionContext_t dctx,
  * After a frame is fully decoded, dctx can be used again to decompress another frame.
  */
 
+void LZ4F_disableChecksum(LZ4F_decompressionContext_t decompressionContext);
+/* LZ4F_disableChecksum()
+* Call this function to allow you to read compressed blocks out of order.
+*/
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
This PR adds a variant of a function taken from the lz4tools project[1] to disable checksum checking. This was added to the lz4tools project to allow blocks in a lz4 file to be read out of order.

The lz4tools project was written by @darkdragn

[1] https://github.com/darkdragn/lz4tools
