### PR TITLE
Fix broken frameCompress.c example

### DIFF
--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -53,6 +53,14 @@ static int compress_file(FILE *in, FILE *out, size_t *size_in, size_t *size_out)
 	}
 
 	printf("Buffer size is %zu bytes, header size %zu bytes\n", size, n);
+	k = fwrite(buf, 1, offset, out);
+	if (k < offset) {
+		if (ferror(out))
+			printf("Write failed");
+		else
+			printf("Short write");
+		goto cleanup;
+	}
 
 	for (;;) {
 		k = fread(src, 1, BUF_SIZE, in);


### PR DESCRIPTION
The example to show frame compression was broken, due to not writing out the header [here](https://github.com/lz4/lz4/blob/dev/examples/frameCompress.c#L55).
This is fixing it.