### PR TITLE
Fix test mode and write to null

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -393,7 +393,7 @@ int main(int argc, const char** argv)
                 case 'c': forceStdout=1; output_filename=stdoutmark; displayLevel=1; break;
 
                     /* Test integrity */
-                case 't': decode=1; LZ4IO_setOverwrite(1); output_filename=nulmark; break;
+                case 't': decode=1; LZ4IO_setPassThrough(0); output_filename=nulmark; break;
 
                     /* Overwrite */
                 case 'f': LZ4IO_setOverwrite(1); break;

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -393,7 +393,7 @@ int main(int argc, const char** argv)
                 case 'c': forceStdout=1; output_filename=stdoutmark; displayLevel=1; break;
 
                     /* Test integrity */
-                case 't': decode=1; LZ4IO_setPassThrough(0); output_filename=nulmark; break;
+                case 't': decode=1; LZ4IO_setTestMode(1); output_filename=nulmark; break;
 
                     /* Overwrite */
                 case 'f': LZ4IO_setOverwrite(1); break;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -136,6 +136,7 @@ static clock_t g_time = 0;
 *  Local Parameters
 **************************************/
 static int g_overwrite = 1;
+static int g_passThrough = 1;
 static int g_blockSizeId = LZ4IO_BLOCKSIZEID_DEFAULT;
 static int g_blockChecksum = 0;
 static int g_streamChecksum = 1;
@@ -182,6 +183,13 @@ int LZ4IO_setOverwrite(int yes)
 {
    g_overwrite = (yes!=0);
    return g_overwrite;
+}
+
+/* Default setting : passThrough = 1; return : passThrough mode (0/1) */
+int LZ4IO_setPassThrough(int yes)
+{
+   g_passThrough = (yes!=0);
+   return g_passThrough;
 }
 
 /* blockSizeID : valid values : 4-5-6-7 */
@@ -283,7 +291,7 @@ static int LZ4IO_getFiles(const char* input_filename, const char* output_filenam
     } else {
         /* Check if destination file already exists */
         *pfoutput=0;
-        if (output_filename != nulmark) *pfoutput = fopen( output_filename, "rb" );
+        if (strcmp(output_filename, nulmark)) *pfoutput = fopen( output_filename, "rb" );
         if (*pfoutput!=0) {
             fclose(*pfoutput);
             if (!g_overwrite) {
@@ -908,7 +916,7 @@ static unsigned long long selectDecoder(dRess_t ress, FILE* finput, FILE* foutpu
     EXTENDED_FORMAT;  /* macro extension for custom formats */
     default:
         if (nbCalls == 1) {  /* just started */
-            if (g_overwrite)
+            if (g_passThrough && g_overwrite)
                 return LZ4IO_passThrough(finput, foutput, MNstore);
             EXM_THROW(44,"Unrecognized header : file cannot be decoded");   /* Wrong magic number at the beginning of 1st stream */
         }

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -136,7 +136,7 @@ static clock_t g_time = 0;
 *  Local Parameters
 **************************************/
 static int g_overwrite = 1;
-static int g_passThrough = 1;
+static int g_testMode = 0;
 static int g_blockSizeId = LZ4IO_BLOCKSIZEID_DEFAULT;
 static int g_blockChecksum = 0;
 static int g_streamChecksum = 1;
@@ -185,11 +185,11 @@ int LZ4IO_setOverwrite(int yes)
    return g_overwrite;
 }
 
-/* Default setting : passThrough = 1; return : passThrough mode (0/1) */
-int LZ4IO_setPassThrough(int yes)
+/* Default setting : testMode = 0; return : testMode (0/1) */
+int LZ4IO_setTestMode(int yes)
 {
-   g_passThrough = (yes!=0);
-   return g_passThrough;
+   g_testMode = (yes!=0);
+   return g_testMode;
 }
 
 /* blockSizeID : valid values : 4-5-6-7 */
@@ -916,7 +916,7 @@ static unsigned long long selectDecoder(dRess_t ress, FILE* finput, FILE* foutpu
     EXTENDED_FORMAT;  /* macro extension for custom formats */
     default:
         if (nbCalls == 1) {  /* just started */
-            if (g_passThrough && g_overwrite)
+            if (!g_testMode && g_overwrite)
                 return LZ4IO_passThrough(finput, foutput, MNstore);
             EXM_THROW(44,"Unrecognized header : file cannot be decoded");   /* Wrong magic number at the beginning of 1st stream */
         }

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -63,6 +63,10 @@ int LZ4IO_decompressMultipleFilenames(const char** inFileNamesTable, int ifntSiz
    return : overwrite mode (0/1) */
 int LZ4IO_setOverwrite(int yes);
 
+/* Default setting : passThrough = 1;
+   return : passThrough mode (0/1) */
+int LZ4IO_setPassThrough(int yes);
+
 /* blockSizeID : valid values : 4-5-6-7
    return : -1 if error, blockSize if OK */
 int LZ4IO_setBlockSizeID(int blockSizeID);

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -63,9 +63,9 @@ int LZ4IO_decompressMultipleFilenames(const char** inFileNamesTable, int ifntSiz
    return : overwrite mode (0/1) */
 int LZ4IO_setOverwrite(int yes);
 
-/* Default setting : passThrough = 1;
-   return : passThrough mode (0/1) */
-int LZ4IO_setPassThrough(int yes);
+/* Default setting : testMode = 0;
+   return : testMode (0/1) */
+int LZ4IO_setTestMode(int yes);
 
 /* blockSizeID : valid values : 4-5-6-7
    return : -1 if error, blockSize if OK */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -217,7 +217,10 @@ test-lz4-basic: lz4 datagen
 
 test-lz4: lz4 datagen test-lz4-basic test-lz4-multiple test-lz4-sparse test-lz4-contentSize test-lz4-frame-concatenation
 	@echo "\n ---- test pass-through ----"
-	./datagen | $(PRGDIR)/lz4 -tf
+	./datagen | $(PRGDIR)/lz4 -t             && false || true
+	./datagen | $(PRGDIR)/lz4 -tf            && false || true
+	./datagen | $(PRGDIR)/lz4 -d  > $(VOID)  && false || true
+	./datagen | $(PRGDIR)/lz4 -df > $(VOID)
 
 test-lz4c: lz4c datagen
 	@echo "\n ---- test lz4c version ----"


### PR DESCRIPTION
Fix test mode to not always return success.
Don't ask for permission to overwrite `nulmark`.

Another option, `g_passThrough` is necessary because if the user passes `-t`, we shouldn't silently ignore errors, even if `-f` is passed as well.  Thanks to @t-mat for this part of the patch.

Fixes #199 

Before:

    > echo "hello world" > file
    > lz4 -t file
    successfully decoded 12 bytes
    > lz4 -tf file
    successfully decoded 12 bytes
    > lz4 file null
    Warning : /dev/null already exists
    Overwrite ? (Y/n) : n
    Error 12 : No. Operation aborted : /dev/null already exists
    > lz4 file /dev/null
    Warning : /dev/null already exists
    Overwrite ? (Y/n) : n
    Error 12 : No. Operation aborted : /dev/null already exists

After:

    > lz4 -t file
    Error 44 : Unrecognized header : file cannot be decoded
    > lz4 -tf file
    Error 44 : Unrecognized header : file cannot be decoded
    > lz4 file null
    Compressed 12 bytes into 31 bytes ==> 258.33%
    > lz4 file /dev/null
    Compressed 12 bytes into 31 bytes ==> 258.33%