### PR TITLE
Return error if input file does not exist.

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -426,9 +426,9 @@ static U32 LZ4_hashSequence64(U64 sequence, tableType_t const tableType)
     static const U64 prime8bytes = 11400714785074694791ULL;
     const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
     if (LZ4_isLittleEndian())
-        return ((sequence << 24) * prime5bytes) >> (64 - hashLog);
+        return (U32)(((sequence << 24) * prime5bytes) >> (64 - hashLog));
     else
-        return ((sequence >> 24) * prime8bytes) >> (64 - hashLog);
+        return (U32)(((sequence >> 24) * prime8bytes) >> (64 - hashLog));
 }
 
 static U32 LZ4_hashSequenceT(size_t sequence, tableType_t const tableType)

--- a/programs/lz4.1
+++ b/programs/lz4.1
@@ -121,7 +121,7 @@ Decompress.
 .B --decompress
 is also the default operation when the input filename has an
 .B .lz4
-extensionq
+extension.
 .TP
 .BR \-t ", " \-\-test
 Test the integrity of compressed

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -550,7 +550,7 @@ int main(int argc, const char** argv)
         if (multiple_inputs)
             operationResult = LZ4IO_decompressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION);
         else
-            DEFAULT_DECOMPRESSOR(input_filename, output_filename);
+            operationResult = DEFAULT_DECOMPRESSOR(input_filename, output_filename);
     } else {
         /* compression is default action */
         if (legacy_format) {
@@ -560,7 +560,7 @@ int main(int argc, const char** argv)
             if (multiple_inputs)
                 operationResult = LZ4IO_compressMultipleFilenames(inFileNames, ifnIdx, LZ4_EXTENSION, cLevel);
             else
-                DEFAULT_COMPRESSOR(input_filename, output_filename, cLevel);
+                operationResult = DEFAULT_COMPRESSOR(input_filename, output_filename, cLevel);
         }
     }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -221,6 +221,11 @@ test-lz4: lz4 datagen test-lz4-basic test-lz4-multiple test-lz4-sparse test-lz4-
 	./datagen | $(PRGDIR)/lz4 -tf            && false || true
 	./datagen | $(PRGDIR)/lz4 -d  > $(VOID)  && false || true
 	./datagen | $(PRGDIR)/lz4 -df > $(VOID)
+	@echo "\n ---- test cli ----"
+	$(PRGDIR)/lz4     file-does-not-exist    && false || true
+	$(PRGDIR)/lz4 -f  file-does-not-exist    && false || true
+	$(PRGDIR)/lz4 -fm file1-dne file2-dne    && false || true
+	$(PRGDIR)/lz4 -fm file1-dne file2-dne    && false || true
 
 test-lz4c: lz4c datagen
 	@echo "\n ---- test lz4c version ----"


### PR DESCRIPTION
Make `lz4 file-does-not-exist` return non-zero.

Fixes #177 
Fixes #167