### PR TITLE
[cmake] Fix substituting version in liblz4.pc

### DIFF
--- a/contrib/cmake_unofficial/CMakeLists.txt
+++ b/contrib/cmake_unofficial/CMakeLists.txt
@@ -215,4 +215,6 @@ else()
   set(INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 endif()
 
+# for liblz4.pc substitution
+set(VERSION ${LZ4_VERSION_STRING})
 configure_file(${LZ4_LIB_SOURCE_DIR}/liblz4.pc.in liblz4.pc @ONLY)


### PR DESCRIPTION
Otherwise the version in .pc file is empty.

Bug: https://bugs.gentoo.org/608144