### PR TITLE
Add reporting of position where LZ4 stream ends; Checking of macros

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -83,13 +83,13 @@ static U32 g_compressibilityDefault = 50;
 *  console display
 ***************************************/
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
+#define DISPLAYLEVEL(l, ...) do { if (g_displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
 static U32 g_displayLevel = 2;   /* 0 : no display;   1: errors;   2 : + result + interaction + warnings;   3 : + progression;   4 : + information */
 
-#define DISPLAYUPDATE(l, ...) if (g_displayLevel>=l) { \
+#define DISPLAYUPDATE(l, ...) do { if (g_displayLevel>=(l)) \
             if ((clock() - g_time > refreshRate) || (g_displayLevel>=4)) \
             { g_time = clock(); DISPLAY(__VA_ARGS__); \
-            if (g_displayLevel>=4) fflush(stdout); } }
+            if (g_displayLevel>=4) fflush(stdout); } } while(0)
 static const clock_t refreshRate = CLOCKS_PER_SEC * 15 / 100;
 static clock_t g_time = 0;
 
@@ -100,15 +100,15 @@ static clock_t g_time = 0;
 #ifndef DEBUG
 #  define DEBUG 0
 #endif
-#define DEBUGOUTPUT(...) if (DEBUG) DISPLAY(__VA_ARGS__);
+#define DEBUGOUTPUT(...) do { if (DEBUG) DISPLAY(__VA_ARGS__); } while(0)
 #define EXM_THROW(error, ...)                                             \
-{                                                                         \
+do {                                                                      \
     DEBUGOUTPUT("Error defined at %s, line %i : \n", __FILE__, __LINE__); \
-    DISPLAYLEVEL(1, "Error %i : ", error);                                \
+    DISPLAYLEVEL(1, "Error %i : ", (error));                              \
     DISPLAYLEVEL(1, __VA_ARGS__);                                         \
     DISPLAYLEVEL(1, "\n");                                                \
     exit(error);                                                          \
-}
+} while(0)
 
 
 /* *************************************

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -74,7 +74,7 @@
 *  Macros
 ***************************************/
 #define DISPLAY(...)           fprintf(stderr, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...)   if (displayLevel>=l) { DISPLAY(__VA_ARGS__); }
+#define DISPLAYLEVEL(l, ...)   do { if (displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
 static unsigned displayLevel = 2;   /* 0 : no display ; 1: errors only ; 2 : downgradable normal ; 3 : non-downgradable normal; 4 : + information */
 
 
@@ -82,15 +82,15 @@ static unsigned displayLevel = 2;   /* 0 : no display ; 1: errors only ; 2 : dow
 *  Exceptions
 ***************************************/
 #define DEBUG 0
-#define DEBUGOUTPUT(...) if (DEBUG) DISPLAY(__VA_ARGS__);
+#define DEBUGOUTPUT(...) do { if (DEBUG) DISPLAY(__VA_ARGS__); } while(0)
 #define EXM_THROW(error, ...)                                             \
-{                                                                         \
+do {                                                                      \
     DEBUGOUTPUT("Error defined at %s, line %i : \n", __FILE__, __LINE__); \
-    DISPLAYLEVEL(1, "Error %i : ", error);                                \
+    DISPLAYLEVEL(1, "Error %i : ", (error));                              \
     DISPLAYLEVEL(1, __VA_ARGS__);                                         \
     DISPLAYLEVEL(1, "\n");                                                \
     exit(error);                                                          \
-}
+} while(0)
 
 
 /*-************************************

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -99,13 +99,13 @@
 *  Macros
 **************************************/
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
+#define DISPLAYLEVEL(l, ...) do { if (g_displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
 static int g_displayLevel = 0;   /* 0 : no display  ; 1: errors  ; 2 : + result + interaction + warnings ; 3 : + progression; 4 : + information */
 
-#define DISPLAYUPDATE(l, ...) if (g_displayLevel>=l) { \
+#define DISPLAYUPDATE(l, ...) do { if (g_displayLevel>=(l)) \
             if (((clock_t)(g_time - clock()) > refreshRate) || (g_displayLevel>=4)) \
             { g_time = clock(); DISPLAY(__VA_ARGS__); \
-            if (g_displayLevel>=4) fflush(stderr); } }
+            if (g_displayLevel>=4) fflush(stderr); } } while(0)
 static const clock_t refreshRate = CLOCKS_PER_SEC / 6;
 static clock_t g_time = 0;
 
@@ -129,15 +129,15 @@ static int g_contentSizeFlag = 0;
 #ifndef DEBUG
 #  define DEBUG 0
 #endif
-#define DEBUGOUTPUT(...) if (DEBUG) DISPLAY(__VA_ARGS__);
+#define DEBUGOUTPUT(...) do { if (DEBUG) DISPLAY(__VA_ARGS__); } while(0)
 #define EXM_THROW(error, ...)                                             \
-{                                                                         \
+do {                                                                      \
     DEBUGOUTPUT("Error defined at %s, line %i : \n", __FILE__, __LINE__); \
-    DISPLAYLEVEL(1, "Error %i : ", error);                                \
+    DISPLAYLEVEL(1, "Error %i : ", (error));                              \
     DISPLAYLEVEL(1, __VA_ARGS__);                                         \
     DISPLAYLEVEL(1, " \n");                                               \
     exit(error);                                                          \
-}
+} while(0)
 
 
 /**************************************

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -856,7 +856,7 @@ static unsigned long long LZ4IO_passThrough(FILE* finput, FILE* foutput, unsigne
         total += readBytes;
         storedSkips = LZ4IO_fwriteSparse(foutput, buffer, readBytes, storedSkips);
     }
-    if (ferror(finput)) EXM_THROW(51, "Read Error")
+    if (ferror(finput)) EXM_THROW(51, "Read Error");
 
     LZ4IO_fwriteSparseEnd(foutput, storedSkips);
     return total;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -887,6 +887,8 @@ static unsigned long long selectDecoder(dRess_t ress, FILE* finput, FILE* foutpu
     unsigned magicNumber;
     static unsigned nbCalls = 0;
 
+    const long position = ftell(finput);
+
     /* init */
     nbCalls++;
 
@@ -926,7 +928,7 @@ static unsigned long long selectDecoder(dRess_t ress, FILE* finput, FILE* foutpu
             }
             EXM_THROW(44,"Unrecognized header : file cannot be decoded");   /* Wrong magic number at the beginning of 1st stream */
         }
-        DISPLAYLEVEL(2, "Stream followed by undecodable data\n");
+        DISPLAYLEVEL(2, "Stream followed by undecodable data at %ld bytes\n", position);
         return ENDOFSTREAM;
     }
 }

--- a/tests/datagencli.c
+++ b/tests/datagencli.c
@@ -49,7 +49,7 @@
 *  Macros
 **************************************/
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...) if (displayLevel>=l) { DISPLAY(__VA_ARGS__); }
+#define DISPLAYLEVEL(l, ...) do { if (displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
 static unsigned displayLevel = 2;
 
 

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -395,7 +395,7 @@ int basicTests(U32 seed, double compressibility)
     prefs.frameInfo.blockSizeID = LZ4F_max4MB;
     prefs.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;
     {   size_t const dstCapacity = LZ4F_compressFrameBound(testSize, &prefs);
-        DISPLAYLEVEL(4, "dstCapacity = %u  \n", (U32)dstCapacity)
+        DISPLAYLEVEL(4, "dstCapacity = %u  \n", (U32)dstCapacity);
         cSize = LZ4F_compressFrame(compressedBuffer, dstCapacity, CNBuffer, testSize, &prefs);
         if (LZ4F_isError(cSize)) goto _output_error;
         DISPLAYLEVEL(3, "Compressed %u bytes into a %u bytes frame \n", (U32)testSize, (U32)cSize);
@@ -404,7 +404,7 @@ int basicTests(U32 seed, double compressibility)
     DISPLAYLEVEL(3, "without checksum : \n");
     prefs.frameInfo.contentChecksumFlag = LZ4F_noContentChecksum;
     {   size_t const dstCapacity = LZ4F_compressFrameBound(testSize, &prefs);
-        DISPLAYLEVEL(4, "dstCapacity = %u  \n", (U32)dstCapacity)
+        DISPLAYLEVEL(4, "dstCapacity = %u  \n", (U32)dstCapacity);
         cSize = LZ4F_compressFrame(compressedBuffer, dstCapacity, CNBuffer, testSize, &prefs);
         if (LZ4F_isError(cSize)) goto _output_error;
         DISPLAYLEVEL(3, "Compressed %u bytes into a %u bytes frame \n", (U32)testSize, (U32)cSize);

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -78,11 +78,11 @@ static const U32 prime2 = 2246822519U;
 *  Macros
 **************************************/
 #define DISPLAY(...)          fprintf(stderr, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...)  if (displayLevel>=l) { DISPLAY(__VA_ARGS__); }
-#define DISPLAYUPDATE(l, ...) if (displayLevel>=l) { \
+#define DISPLAYLEVEL(l, ...)  do { if (displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
+#define DISPLAYUPDATE(l, ...) do { if (displayLevel>=(l)) \
             if ((FUZ_GetClockSpan(g_clockTime) > refreshRate) || (displayLevel>=4)) \
             { g_clockTime = clock(); DISPLAY(__VA_ARGS__); \
-            if (displayLevel>=4) fflush(stdout); } }
+            if (displayLevel>=4) fflush(stdout); } } while(0)
 static const clock_t refreshRate = CLOCKS_PER_SEC / 6;
 static clock_t g_clockTime = 0;
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -88,7 +88,7 @@ struct chunkParameters
 *  Macros
 **************************************/
 #define DISPLAY(...) fprintf(stderr, __VA_ARGS__)
-#define PROGRESS(...) g_noPrompt ? 0 : DISPLAY(__VA_ARGS__)
+#define PROGRESS(...) ( g_noPrompt ? 0 : DISPLAY(__VA_ARGS__) )
 
 
 /**************************************

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -76,7 +76,7 @@ typedef size_t uintptr_t;   /* true on most systems, except OpenVMS-64 (which do
 *  Macros
 *****************************************/
 #define DISPLAY(...)         fprintf(stdout, __VA_ARGS__)
-#define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
+#define DISPLAYLEVEL(l, ...) do { if (g_displayLevel>=(l)) DISPLAY(__VA_ARGS__); } while(0)
 static int g_displayLevel = 2;
 
 #define MIN(a,b)   ( (a) < (b) ? (a) : (b) )


### PR DESCRIPTION
Reporting how large the output is actually pretty low-value since simply looking at the output file size will tell you that.  In the case where a LZ4 stream has data added on to the end, knowing where the LZ4 stream ends is highly valuable, since it allows recovery of the appended data.  An example of this is Qualcomm-ARM Linux kernels, where hardware data is appended to a LZ4-compressed kernel image.

The implementation is _distinctly_ suboptimal, but sufficient for easy cases.  If input is a pipe, it will merely display "-1" as the point.  Really should have the various portions of the decoder keep track, but that is rather more involved.


The macro fixes were merely something staring me in the face when I was going after the above.  With these changes the various macros won't cause interesting misbehavior.  For example now the code
```
if (<some_condition>) DISPLAYUPDATE(val0|val1, "Something happened!\n");
else a_normal_function();
```
Will compile successfully and behave as expected without the special knowledge of DISPLAYUPDATE() being a macro.