### PR TITLE
Explicitly create $(DESTDIR)$(LIBDIR)/ at install time

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -143,7 +143,7 @@ liblz4.pc: liblz4.pc.in Makefile
           $< >$@
 
 install: lib liblz4.pc
-	@$(INSTALL) -d -m 755 $(DESTDIR)$(PKGCONFIGDIR)/ $(DESTDIR)$(INCLUDEDIR)/
+	@$(INSTALL) -d -m 755 $(DESTDIR)$(PKGCONFIGDIR)/ $(DESTDIR)$(INCLUDEDIR)/ $(DESTDIR)$(LIBDIR)/
 	@$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(PKGCONFIGDIR)/
 	@echo Installing libraries
 ifeq ($(BUILD_STATIC),yes)


### PR DESCRIPTION
This is needed on systems where it isn't the parent of
$(PKGCONFIGDIR), and so doesn't get created implicitly.