### PR TITLE
cli: add GNU separator -- specifying that all following arguments are files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 v1.7.6
 cli : fix : do not modify /dev/null permissions, reported by @Maokaman1
+cli : added GNU separator -- specifying that all following arguments are files
 API : added LZ4_compress_HC_destSize(), by Oleg (@remittor)
 API : fix : expose obsolete decoding functions, reported by Chen Yufei
 build : dragonFlyBSD, OpenBSD, NetBSD supported

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -194,6 +194,9 @@ only the latest one will be applied.
 * `--rm` :
   Delete source files on successful compression or decompression
 
+* `--` :
+  Treat all subsequent arguments as files
+
 
 ### Benchmark mode
 

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -271,6 +271,7 @@ int main(int argc, const char** argv)
         forceStdout=0,
         main_pause=0,
         multiple_inputs=0,
+        all_arguments_are_files=0,
         operationResult=0;
     operationMode_e mode = om_auto;
     const char* input_filename = NULL;
@@ -315,7 +316,7 @@ int main(int argc, const char** argv)
         if(!argument) continue;   /* Protection if argument empty */
 
         /* Short commands (note : aggregated short commands are allowed) */
-        if (argument[0]=='-') {
+        if (!all_arguments_are_files && argument[0]=='-') {
             /* '-' means stdin/stdout */
             if (argument[1]==0) {
                 if (!input_filename) input_filename=stdinmark;
@@ -325,6 +326,7 @@ int main(int argc, const char** argv)
 
             /* long commands (--long-word) */
             if (argument[1]=='-') {
+                if (!strcmp(argument,  "--")) { all_arguments_are_files = 1; continue; }
                 if (!strcmp(argument,  "--compress")) { mode = om_compress; continue; }
                 if ((!strcmp(argument, "--decompress"))
                     || (!strcmp(argument, "--uncompress"))) { mode = om_decompress; continue; }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -252,6 +252,14 @@ test-lz4-basic: lz4 datagen unlz4 lz4cat
 	$(DIFF) -q tmp tmp3
 	$(PRGDIR)/lz4cat < tmp > tmp2      # checks lz4cat works with stdin (#285)
 	$(DIFF) -q tmp tmp2
+	cp tmp ./-d
+	$(LZ4) --rm -- -d -d.lz4           # compresses ./d into ./-d.lz4
+	test   -f ./-d.lz4
+	test ! -f ./-d
+	mv ./-d.lz4 ./-z
+	$(LZ4) -d --rm -- -z tmp4          # uncompresses ./-z into tmp4
+	test ! -f ./-z
+	$(DIFF) -q tmp tmp4
 	@$(RM) tmp*
 
 test-lz4-hugefile: lz4 datagen


### PR DESCRIPTION
This option is supported by other compressors with compatible cli,
so add it to lz4 as well for better compatibility.