### PR TITLE
Fix gcc7 Wimplicit-fallthrough warnings

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1096,7 +1096,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctxPtr,
             if (srcEnd-srcPtr == 0) return minFHSize;   /* 0-size input */
             dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
             dctxPtr->dStage = dstage_storeHeader;
-            /* pass-through */
+            /* fall-through */
 
         case dstage_storeHeader:
             {   size_t sizeToCopy = dctxPtr->tmpInTarget - dctxPtr->tmpInSize;
@@ -1138,7 +1138,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctxPtr,
             dctxPtr->tmpOutSize = 0;
 
             dctxPtr->dStage = dstage_getCBlockSize;
-            /* pass-through */
+            /* fall-through */
 
         case dstage_getCBlockSize:
             if ((size_t)(srcEnd - srcPtr) >= BHSize) {
@@ -1236,8 +1236,8 @@ size_t LZ4F_decompress(LZ4F_dctx* dctxPtr,
                 }
                 selectedIn = dctxPtr->tmpIn;
                 dctxPtr->dStage = dstage_decodeCBlock;
-                /* pass-through */
             }
+            /* fall-through */
 
         case dstage_decodeCBlock:
             if ((size_t)(dstEnd-dstPtr) < dctxPtr->maxBlockSize)   /* not enough place into dst : decode into tmpOut */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -555,7 +555,7 @@ static int LZ4HC_compress_generic (
                 return LZ4HC_compress_optimal(ctx, src, dst, *srcSizePtr, dstCapacity, limit, 128, 0);
             default:
                 cLevel = 12;
-                /* pass-through */
+                /* fall-through */
             case 12:
                 ctx->searchNum = LZ4HC_getSearchNum(cLevel);
                 return LZ4HC_compress_optimal(ctx, src, dst, *srcSizePtr, dstCapacity, limit, LZ4_OPT_NUM, 1);

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -469,8 +469,9 @@ int main(int argc, const char** argv)
 
 #ifdef UTIL_HAS_CREATEFILELIST
                     /* recursive */
-                case 'r': recursive=1;  /* without break */
+                case 'r': recursive=1;
 #endif
+                    /* fall-through */
                     /* Treat non-option args as input files.  See https://code.google.com/p/lz4/issues/detail?id=151 */
                 case 'm': multiple_inputs=1;
                     break;


### PR DESCRIPTION
For the default Wimplicit-fallthrough=3 level,
the comment should start with "fall*"

~~About the fix in lz4cli.c, `gcc 7.1.1` will only suppress the warning when done like this:~~
```c++
#ifdef UTIL_HAS_CREATEFILELIST
                    /* recursive */
                case 'r': recursive=1;  /* without break */
#endif
                    /* fall-through */
```
~~so I opt to use `__attribute__ ((fallthrough));` which can be placed in the `#ifdef` block~~