### PR TITLE
Fix formatting of concatenation example in docs

### DIFF
--- a/programs/lz4.1
+++ b/programs/lz4.1
@@ -60,13 +60,15 @@ Consequently, \fBlz4 \-m \-\-rm\fR behaves the same as \fBgzip\fR\.
 .IP "" 0
 .
 .SS "Concatenation of \.lz4 files"
-It is possible to concatenate \fB\.lz4\fR files as is\. \fBlz4\fR will decompress such files as if they were a single \fB\.lz4\fR file\. For example: lz4 file1 > foo\.lz4 lz4 file2 >> foo\.lz4
+It is possible to concatenate \fB\.lz4\fR files as is\. \fBlz4\fR will decompress such files as if they were a single \fB\.lz4\fR file\. For example:
 .
-.P
-then lz4cat foo\.lz4
+.IP "" 4
+lz4 file1 > foo\.lz4
+.br
+lz4 file2 >> foo\.lz4
 .
-.P
-is equivalent to : cat file1 file2
+.IP "" 0
+Then \fBlz4cat foo\.lz4\fR is equivalent to \fBcat file1 file2\fR\.
 .
 .SH "OPTIONS"
 .

--- a/programs/lz4.1
+++ b/programs/lz4.1
@@ -67,7 +67,7 @@ lz4 file1 > foo\.lz4
 .br
 lz4 file2 >> foo\.lz4
 .
-.IP "" 0
+.P
 Then \fBlz4cat foo\.lz4\fR is equivalent to \fBcat file1 file2\fR\.
 .
 .SH "OPTIONS"

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -63,15 +63,11 @@ Default behaviors can be modified by opt-in commands, detailed below.
 It is possible to concatenate `.lz4` files as is.
 `lz4` will decompress such files as if they were a single `.lz4` file.
 For example:
+
     lz4 file1  > foo.lz4
     lz4 file2 >> foo.lz4
 
-then
-    lz4cat foo.lz4
-
-is equivalent to :
-    cat file1 file2
-
+Then `lz4cat foo.lz4` is equivalent to `cat file1 file2`.
 
 OPTIONS
 -------


### PR DESCRIPTION
The formatting in the `lz4.1` man page section "Concatenation of .lz4 files" is somewhat corrupted, with the two example commands run together on one line. Obviously, `lz4 file1 > foo.lz4 lz4 file2 >> foo.lz4` is not a valid shell command. So, at the cost of a little vertical space, I dropped the (two-line) "script" down onto a separate indented paragraph. To recover that lost space, I joined the sentence explaining the equivalency into a single line, with the commands bolded according to the surrounding style.

So this:
<pre>
   <b>Concatenation of .lz4 files</b>
       It  is  possible  to  concatenate <b>.lz4</b> files as is. <b>lz4</b> will decompress
       such files as if they were a single <b>.lz4</b> file. For example: lz4 file1 >
       foo.lz4 lz4 file2 >> foo.lz4

       then lz4cat foo.lz4

       is equivalent to : cat file1 file2
</pre>
becomes this:
<pre>
   <b>Concatenation of .lz4 files</b>
       It  is  possible  to  concatenate <b>.lz4</b> files as is. <b>lz4</b> will decompress
       such files as if they were a single <b>.lz4</b> file. For example:

           lz4 file1 > foo.lz4
           lz4 file2 >> foo.lz4

       Then <b>lz4cat foo.lz4</b> is equivalent to <b>cat file1 file2</b>.
</pre>

I chose not to bold the commands in the intended "script" paragraph as they weren't inline with text, though that kind of feels like dealer's choice re: house style.

...I also updated the Markdown version of the man page to match, as the example's formatting was similarly corrupted there.