### PR TITLE
Fix: Add return statement to main function

### DIFF
--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -309,4 +309,6 @@ int main(int argc, const char **argv) {
         fclose(decFp);
         fclose(inpFp);
     }
+
+    return 0;
 }


### PR DESCRIPTION
The build in the OpenBSD ports tree on the armv7 platform fails because the main function of the frameCompress example is missing the final return statement. Output was:
```./frameCompress Makefile
inp = [Makefile]
lz4 = [Makefile.lz4]
dec = [Makefile.lz4.dec]
compress : Makefile -> Makefile.lz4
Buffer size is 262175 bytes, header size 7 bytes
Writing 1831 bytes
Makefile: 3276 → 1831 bytes, 55.9%
compress : done
decompress : Makefile.lz4 -> Makefile.lz4.dec
Writing 3276 bytes
decompress : done
verify : Makefile <-> Makefile.lz4.dec
verify : OK
gmake[1]: *** [Makefile:89: test] Error 40
gmake[1]: Leaving directory '/usr/ports/pobj/lz4-1.8.0/lz4-1.8.0/examples'
gmake: *** [Makefile:73: examples] Error 2
```