### PR TITLE
Add basic, failing test for emscripten

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -548,7 +548,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic(
 
                 match = LZ4_getPositionOnHash(h, cctx->hashTable, tableType, base);
                 if (dict==usingExtDict) {
-                    if ((int)match < (int)source) {
+                    if ((ptrdiff_t)match < (ptrdiff_t)source) {
                         refDelta = dictDelta;
                         lowLimit = dictionary;
                     } else {
@@ -558,13 +558,13 @@ LZ4_FORCE_INLINE int LZ4_compress_generic(
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType, base);
 
-            } while ( ((dictIssue==dictSmall) ? ((int)match < (int)lowRefLimit) : 0)
-                || ((tableType==byU16) ? 0 : ((int)(match + MAX_DISTANCE) < (int)ip))
+            } while ( ((dictIssue==dictSmall) ? ((ptrdiff_t)match < (ptrdiff_t)lowRefLimit) : 0)
+                || ((tableType==byU16) ? 0 : ((ptrdiff_t)(match + MAX_DISTANCE) < (ptrdiff_t)ip))
                 || (LZ4_read32(match+refDelta) != LZ4_read32(ip)) );
         }
 
         /* Catch up */
-        while (((ip>anchor) & ((int)(match+refDelta) > (int)(lowLimit))) && (unlikely(ip[-1]==match[refDelta-1]))) { ip--; match--; }
+        while (((ip>anchor) & ((ptrdiff_t)(match+refDelta) > (ptrdiff_t)lowLimit)) && (unlikely(ip[-1]==match[refDelta-1]))) { ip--; match--; }
 
         /* Encode Literals */
         {   unsigned const litLength = (unsigned)(ip - anchor);
@@ -634,7 +634,7 @@ _next_match:
         /* Test next position */
         match = LZ4_getPosition(ip, cctx->hashTable, tableType, base);
         if (dict==usingExtDict) {
-            if ((int)match < (int)source) {
+            if ((ptrdiff_t)match < (ptrdiff_t)source) {
                 refDelta = dictDelta;
                 lowLimit = dictionary;
             } else {
@@ -642,7 +642,7 @@ _next_match:
                 lowLimit = (const BYTE*)source;
         }   }
         LZ4_putPosition(ip, cctx->hashTable, tableType, base);
-        if ( ((dictIssue==dictSmall) ? ((int)match>=(int)lowRefLimit) : 1)
+        if ( ((dictIssue==dictSmall) ? ((ptrdiff_t)match>=(ptrdiff_t)lowRefLimit) : 1)
             && (match+MAX_DISTANCE>=ip)
             && (LZ4_read32(match+refDelta)==LZ4_read32(ip)) )
         { token=op++; *token=0; goto _next_match; }
@@ -799,7 +799,7 @@ static int LZ4_compress_destSize_generic(
         }
 
         /* Catch up */
-        while ((ip>anchor) && ((int)match > (int)lowLimit) && (unlikely(ip[-1]==match[-1]))) { ip--; match--; }
+        while ((ip>anchor) && ((ptrdiff_t)match > (ptrdiff_t)lowLimit) && (unlikely(ip[-1]==match[-1]))) { ip--; match--; }
 
         /* Encode Literal length */
         {   unsigned litLength = (unsigned)(ip - anchor);
@@ -1184,7 +1184,7 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
         /* get offset */
         offset = LZ4_readLE16(ip); ip+=2;
         match = op - offset;
-        if ((checkOffset) && (unlikely((int)match < (int)lowLimit))) goto _output_error;   /* Error : offset outside buffers */
+        if ((checkOffset) && (unlikely((ptrdiff_t)match < (ptrdiff_t)lowLimit))) goto _output_error;   /* Error : offset outside buffers */
         LZ4_write32(op, (U32)offset);   /* costs ~1%; silence an msan warning when offset==0 */
 
         /* get matchlength */
@@ -1201,7 +1201,7 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
         length += MINMATCH;
 
         /* check external dictionary */
-        if ((dict==usingExtDict) && ((int)match < (int)lowPrefix)) {
+        if ((dict==usingExtDict) && ((ptrdiff_t)match < (ptrdiff_t)lowPrefix)) {
             if (unlikely(op+length > oend-LASTLITERALS)) goto _output_error;   /* doesn't respect parsing restriction */
 
             if (length <= (size_t)(lowPrefix-match)) {

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -8,6 +8,9 @@ fullbench32
 fuzzer
 fuzzer32
 fasttest
+*.html
+*.html.mem
+*.js
 
 # test artefacts
 tmp*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,7 +79,7 @@ lz4c32:   # create a 32-bits version for 32/64 interop tests
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="-m32 $(CFLAGS)"
 
 emscripten-tests.html: emscripten-tests.c $(LZ4DIR)/lz4.c
-	emcc ${CFLAGS} ${CPPFLAGS} ${EMCCFLAGS} $^ -o $@
+	emcc ${CFLAGS} ${CPPFLAGS} ${EMCC_FLAGS} $^ -o $@
 
 fullbench  : $(LZ4DIR)/lz4.o $(LZ4DIR)/lz4hc.o $(LZ4DIR)/lz4frame.o $(LZ4DIR)/xxhash.o fullbench.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
@@ -104,7 +104,7 @@ datagen : $(PRGDIR)/datagen.c datagencli.c
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
-	@$(RM) core *.o *.test tmp* \
+	@$(RM) core *.o *.test tmp* *.html* \
         fullbench-dll$(EXT) fullbench-lib$(EXT) \
         fullbench$(EXT) fullbench32$(EXT) \
         fuzzer$(EXT) fuzzer32$(EXT) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,6 +43,7 @@ CFLAGS  += $(MOREFLAGS)
 CPPFLAGS:= -I$(LZ4DIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
 FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
+EMCC_FLAGS = --emrun
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))
@@ -76,6 +77,9 @@ lz4c unlz4 lz4cat: lz4
 
 lz4c32:   # create a 32-bits version for 32/64 interop tests
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="-m32 $(CFLAGS)"
+
+emscripten-tests.html: emscripten-tests.c $(LZ4DIR)/lz4.c
+	emcc ${CFLAGS} ${CPPFLAGS} ${EMCCFLAGS} $^ -o $@
 
 fullbench  : $(LZ4DIR)/lz4.o $(LZ4DIR)/lz4hc.o $(LZ4DIR)/lz4frame.o $(LZ4DIR)/xxhash.o fullbench.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
@@ -333,6 +337,9 @@ test-fullbench: fullbench
 
 test-fullbench32: CFLAGS += -m32
 test-fullbench32: test-fullbench
+
+test-emscripten: emscripten-tests.html
+	emrun --browser=chrome $<
 
 test-fuzzer: fuzzer
 	./fuzzer $(FUZZER_TIME)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -339,7 +339,7 @@ test-fullbench32: CFLAGS += -m32
 test-fullbench32: test-fullbench
 
 test-emscripten: emscripten-tests.html
-	emrun --browser=chrome $<
+	emrun ${EMRUN_FLAGS} $<
 
 test-fuzzer: fuzzer
 	./fuzzer $(FUZZER_TIME)

--- a/tests/emscripten-tests.c
+++ b/tests/emscripten-tests.c
@@ -1,0 +1,141 @@
+/*
+    emscripten-tests.c - Demo program to test lz4 in emscripten
+    Copyright (C) Yann Collet 2012-2016
+
+    GPL v2 License
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    You can contact the author at :
+    - LZ4 source repository : https://github.com/lz4/lz4
+    - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+
+/**************************************
+*  Includes
+**************************************/
+#include "platform.h"    /* _CRT_SECURE_NO_WARNINGS, Large Files support */
+#include <stdio.h>       /* fprintf, fopen, ftello */
+#include <stdlib.h>      /* rand */
+#include <string.h>      /* memcmp */
+
+#include "lz4.h"
+
+
+/**************************************
+*  Constants
+**************************************/
+#define PROGRAM_DESCRIPTION "LZ4 emscripten testbed"
+#define AUTHOR "Yann Collet"
+#define WELCOME_MESSAGE "*** %s v%s %i-bits, by %s ***\n", PROGRAM_DESCRIPTION, LZ4_VERSION_STRING, (int)(sizeof(void*)*8), AUTHOR
+
+
+/**************************************
+*  Macros
+**************************************/
+#define DISPLAY(...) fprintf(stderr, __VA_ARGS__)
+
+
+enum {
+    MESSAGE_MAX_BYTES   = 1024,
+    RING_BUFFER_BYTES   = 1024 * 8 + MESSAGE_MAX_BYTES,
+    DECODE_RING_BUFFER  = RING_BUFFER_BYTES + MESSAGE_MAX_BYTES   /* Intentionally larger, to test unsynchronized ring buffers */
+};
+
+int test_blockStreaming_ringbuffer() {
+
+    // This struct here to force ordering of buffers in memory.
+    // emscripten tends to allocate this at low addresses, which can
+    // expose bugs. (Remove static modifier to move it up in memory.)
+    // Switch around the order of decBuf and inpBuf to see what happens.
+    //
+    // Be careful that adding other test cases linked into this
+    // executable might move this, making tests pointless.
+    // Probably good to keep this as the only test in this executable
+    // and create separate executables for other emscripten tests.
+    //
+    static struct {
+        char decBuf[DECODE_RING_BUFFER];
+        char inpBuf[RING_BUFFER_BYTES];
+    } buffers;
+
+    int decOffset = 0;
+    int inpOffset = 0;
+
+    LZ4_stream_t lz4Stream_body = { { 0 } };
+    LZ4_stream_t* lz4Stream = &lz4Stream_body;
+
+    LZ4_streamDecode_t lz4StreamDecode_body = { { 0 } };
+    LZ4_streamDecode_t* lz4StreamDecode = &lz4StreamDecode_body;
+
+    for(int i=0; i<5000; ++i) {
+        // Read random length ([1,MESSAGE_MAX_BYTES]) data to the ring buffer.
+        char* const inpPtr = &buffers.inpBuf[inpOffset];
+        const int inpBytes = (rand() % MESSAGE_MAX_BYTES) + 1;
+
+        for(int j=0; j<inpBytes; ++j) {
+          inpPtr[j] = (rand() % 10);
+        }
+
+        {
+#define CMPBUFSIZE (LZ4_COMPRESSBOUND(MESSAGE_MAX_BYTES))
+            char cmpBuf[CMPBUFSIZE];
+            const int cmpBytes = LZ4_compress_fast_continue(lz4Stream, inpPtr, cmpBuf, inpBytes, CMPBUFSIZE, 0);
+            if(cmpBytes <= 0) { return 1; }
+
+            inpOffset += inpBytes;
+
+            // Wraparound the ringbuffer offset
+            if(inpOffset >= RING_BUFFER_BYTES - MESSAGE_MAX_BYTES) inpOffset = 0;
+
+            {
+                char* const decPtr = &buffers.decBuf[decOffset];
+                const int decBytes = LZ4_decompress_safe_continue(
+                    lz4StreamDecode, cmpBuf, decPtr, cmpBytes, MESSAGE_MAX_BYTES);
+                if(decBytes <= 0) { return 2; }
+                decOffset += decBytes;
+
+                // Wraparound the ringbuffer offset
+                if(decOffset >= DECODE_RING_BUFFER - MESSAGE_MAX_BYTES) decOffset = 0;
+
+                {
+                  if (decBytes != inpBytes) {
+                    return 3;
+                  }
+                  if (memcmp(inpPtr, decPtr, decBytes) != 0) {
+                    return 4;
+                  }
+                  DISPLAY("block %d: PASS, decPtr=%p\n", i, decPtr);
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+int main() {
+
+    // Welcome message
+    DISPLAY(WELCOME_MESSAGE);
+
+    int result = test_blockStreaming_ringbuffer();
+    if (result == 0) {
+        DISPLAY("PASS");
+    } else {
+        DISPLAY("FAIL: %d", result);
+    }
+
+    return 0;
+}

--- a/tests/emscripten-tests.c
+++ b/tests/emscripten-tests.c
@@ -137,5 +137,5 @@ int main() {
         DISPLAY("FAIL: %d", result);
     }
 
-    return 0;
+    return result;
 }


### PR DESCRIPTION
See lz4/lz4#397

@Cyan4973 here is a very first iteration on the idea of adding emscripten tests, suitable for testing how lz4 behaves when encode/decode buffers are allocated at low memory locations.

I can run this on my Mac via Homebrew as follows:

```sh
brew install emscripten
export LLVM=/usr/local/Cellar/emscripten/1.37.18/libexec/llvm/bin
export PATH=/usr/local/Cellar/emscripten/1.37.18/libexec/llvm/bin:$PATH
make -C tests test-emscripten
```

You should be able to observe the following:
- The test still fail after applying the first patch from #397 
- Applying the second patch from #397 will make the tests pass
- They will still pass if you increase `MESSAGE_MAX_BYTES` from 1024 to 4096
- However, they will fail again once you switch around `inpBuf` and `decBuf` in
  the `buffers` struct (leaving `MESSAGE_MAX_BYTES` at 4096), suggesting that there is still an issue unaddressed.

Do you think you can take it from here? Let me know if I can be of more help.
