### PR TITLE
Fix dict segfault

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1616,6 +1616,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
     if ( (dctx->frameInfo.blockMode==LZ4F_blockLinked)
       && (dctx->dict != dctx->tmpOutBuffer)
       && (dctx->dStage != dstage_getFrameHeader)
+      && (dctx->dStage != dstage_storeFrameHeader)
       && (!decompressOptionsPtr->stableDst)
       && ((unsigned)(dctx->dStage-1) < (unsigned)(dstage_getSuffix-1)) )
     {


### PR DESCRIPTION
With my forthcoming changes to support using dictionaries from the command line, it's possible to induce a segfault at lz4frame.c:1642 (`memcpy(dctx->tmpOutBuffer, oldDictEnd - newDictSize, newDictSize);`). This is because when reading from a file, the first call to `LZ4F_decompress` is with just the magic number. `dstage_init` isn't reached in that call, so `dctx->tmpOutBuffer` isn't allocated.