### PR TITLE
Faster decoding xp

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1181,18 +1181,19 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
         unsigned const token = *ip++;
 
         /* shortcut for common case :
-         * in most circumstances, we expect to decode small matches (<= 16 bytes) separated by few literals (<= 14 bytes).
+         * in most circumstances, we expect to decode small matches (<= 18 bytes) separated by few literals (<= 14 bytes).
          * this shortcut was tested on x86 and x64, where it improves decoding speed.
          * it has not yet been benchmarked on ARM, Power, mips, etc. */
-        if (((ip + 14 + 2 <= iend) & (op + 14 + 16 <= oend))
-          & ((token < (15<<ML_BITS)) & ((token & ML_MASK) <= 12)) ) {
+        if (((ip + 14 /*maxLL*/ + 2 /*offset*/ <= iend)
+          & (op + 14 /*maxLL*/ + 18 /*maxML*/ <= oend))
+          & ((token < (15<<ML_BITS)) & ((token & ML_MASK) != 15)) ) {
             size_t const ll = token >> ML_BITS;
             size_t const off = LZ4_readLE16(ip+ll);
             const BYTE* const matchPtr = op + ll - off;  /* pointer underflow risk ? */
-            if ((off >= 16) /* do not deal with overlapping matches */ & (matchPtr >= lowPrefix)) {
+            if ((off >= 18) /* do not deal with overlapping matches */ & (matchPtr >= lowPrefix)) {
                 size_t const ml = (token & ML_MASK) + MINMATCH;
                 memcpy(op, ip, 16); op += ll; ip += ll + 2 /*offset*/;
-                memcpy(op, matchPtr, 16); op += ml;
+                memcpy(op, matchPtr, 18); op += ml;
                 continue;
             }
         }

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1180,6 +1180,22 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
 
         /* get literal length */
         unsigned const token = *ip++;
+
+        if (1)
+        if (ip + 14 + 2 <= iend)
+        if ((token < 15*16) & ((token & 0xF) <= 12)) {
+            size_t const ll = token >> ML_BITS;
+            size_t const off = LZ4_readLE16(ip+ll);   /* check input validity */
+            if (off >= 16) {
+                size_t const ml = (token & 0xF) + MINMATCH;
+                DEBUGLOG(2, "rest:%u, ll:%2u, ml:%2u, off:%u",
+                    (U32)(oend-op), (U32)ll, (U32)ml, (U32)off);
+                memcpy(op, ip, 16); op += ll; ip += ll + 2 /* offset */;
+                memcpy(op, op - off, 16); op += ml;
+                continue;
+            }
+        }
+
         if ((length=(token>>ML_BITS)) == RUN_MASK) {
             unsigned s;
             do {

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1185,12 +1185,12 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
          * this shortcut was tested on x86 and x64, where it improves decoding speed.
          * it has not yet been benchmarked on ARM, Power, mips, etc. */
         if (((ip + 14 + 2 <= iend) & (op + 14 + 16 <= oend))
-          & ((token < (15<<ML_BITS)) & ((token & 0xF) <= 12)) ) {
+          & ((token < (15<<ML_BITS)) & ((token & ML_MASK) <= 12)) ) {
             size_t const ll = token >> ML_BITS;
             size_t const off = LZ4_readLE16(ip+ll);
             const BYTE* const matchPtr = op + ll - off;  /* pointer underflow risk ? */
             if ((off >= 16) /* do not deal with overlapping matches */ & (matchPtr >= lowPrefix)) {
-                size_t const ml = (token & 0xF) + MINMATCH;
+                size_t const ml = (token & ML_MASK) + MINMATCH;
                 memcpy(op, ip, 16); op += ll; ip += ll + 2 /*offset*/;
                 memcpy(op, matchPtr, 16); op += ml;
                 continue;

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1160,8 +1160,8 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
     BYTE* oexit = op + targetOutputSize;
 
     const BYTE* const dictEnd = (const BYTE*)dictStart + dictSize;
-    const unsigned dec32table[] = {0, 1, 2, 1, 4, 4, 4, 4};
-    const int dec64table[] = {0, 0, 0, -1, 0, 1, 2, 3};
+    const unsigned inc32table[8] = {0, 1, 2,  1,  0,  4, 4, 4};
+    const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 
     const int safeDecode = (endOnInput==endOnInputSize);
     const int checkOffset = ((safeDecode) && (dictSize < (int)(64 KB)));
@@ -1276,14 +1276,13 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
         /* copy match within block */
         cpy = op + length;
         if (unlikely(offset<8)) {
-            const int dec64 = dec64table[offset];
             op[0] = match[0];
             op[1] = match[1];
             op[2] = match[2];
             op[3] = match[3];
-            match += dec32table[offset];
+            match += inc32table[offset];
             memcpy(op+4, match, 4);
-            match -= dec64;
+            match -= dec64table[offset];
         } else { LZ4_copy8(op, match); match+=8; }
         op += 8;
 
@@ -1300,7 +1299,7 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
             LZ4_copy8(op, match);
             if (length>16) LZ4_wildCopy(op+8, match+8, cpy);
         }
-        op=cpy;   /* correction */
+        op = cpy;   /* correction */
     }
 
     /* end of decoding */


### PR DESCRIPTION
This modification improves decoding speed by 0-10%, depending on source file.
It was successfully tested on x64 and x86 (32-bits).
I haven't been able to test it on other architectures yet.