### PR TITLE
Improve Optimal parser

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -15,7 +15,7 @@ They generate and decode data using [LZ4 block format].
 
 For more compression ratio at the cost of compression speed,
 the High Compression variant called **lz4hc** is available.
-Add files **`lz4hc.c`** and **`lz4hc.h`**.
+Add files **`lz4hc.c`**, **`lz4hc.h`** and **`lz4opt.h`**.
 The variant still depends on regular `lib/lz4.*` source files.
 
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -289,6 +289,14 @@ static const int LZ4_minLength = (MFLIMIT+1);
 /*-************************************
 *  Error detection
 **************************************/
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#  include <assert.h>
+#else
+#  ifndef assert
+#    define assert(condition) ((void)0)
+#  endif
+#endif
+
 #define LZ4_STATIC_ASSERT(c)   { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
 
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -324,11 +324,12 @@ static const int LZ4_minLength = (MFLIMIT+1);
 
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)
 #  include <stdio.h>
-#  define DEBUGLOG(l, ...) {                          \
-                if (l<=LZ4_DEBUG) {                   \
-                    fprintf(stderr, __FILE__ ": ");   \
-                    fprintf(stderr, __VA_ARGS__);     \
-                    fprintf(stderr, " \n");           \
+static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...) {                                  \
+                if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
+                    fprintf(stderr, __FILE__ ": ");           \
+                    fprintf(stderr, __VA_ARGS__);             \
+                    fprintf(stderr, " \n");                   \
             }   }
 #else
 #  define DEBUGLOG(l, ...)      {}    /* disabled */
@@ -978,6 +979,7 @@ LZ4_stream_t* LZ4_createStream(void)
 
 void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
 {
+    DEBUGLOG(4, "LZ4_resetStream");
     MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t));
 }
 

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -322,7 +322,7 @@ size_t LZ4F_compressFrame_usingCDict(void* dstBuffer, size_t dstCapacity,
                                const LZ4F_preferences_t* preferencesPtr)
 {
     LZ4F_cctx_t cctxI;
-    LZ4_stream_t lz4ctx;
+    LZ4_stream_t lz4ctx;   /* pretty large on stack */
     LZ4F_preferences_t prefs;
     LZ4F_compressOptions_t options;
     BYTE* const dstStart = (BYTE*) dstBuffer;
@@ -504,15 +504,15 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
     cctxPtr->prefs = *preferencesPtr;
 
     /* Ctx Management */
-    {   U32 const tableID = (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ? 1 : 2;  /* 0:nothing ; 1:LZ4 table ; 2:HC tables */
-        if (cctxPtr->lz4CtxLevel < tableID) {
+    {   U32 const ctxTypeID = (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ? 1 : 2;  /* 0:nothing ; 1:LZ4 table ; 2:HC tables */
+        if (cctxPtr->lz4CtxLevel < ctxTypeID) {
             FREEMEM(cctxPtr->lz4CtxPtr);
             if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN)
                 cctxPtr->lz4CtxPtr = (void*)LZ4_createStream();
             else
                 cctxPtr->lz4CtxPtr = (void*)LZ4_createStreamHC();
             if (cctxPtr->lz4CtxPtr == NULL) return err0r(LZ4F_ERROR_allocation_failed);
-            cctxPtr->lz4CtxLevel = tableID;
+            cctxPtr->lz4CtxLevel = ctxTypeID;
     }   }
 
     /* Buffer Management */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -661,7 +661,6 @@ static int LZ4HC_compress_generic (
             case 11:
                 return LZ4HC_compress_optimal(ctx, src, dst, *srcSizePtr, dstCapacity, limit, 512, 128, 0);
             default:
-                cLevel = 12;
                 /* fall-through */
             case 12:
                 return LZ4HC_compress_optimal(ctx, src, dst, *srcSizePtr, dstCapacity, limit, 1<<13, LZ4_OPT_NUM, 1);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -188,12 +188,15 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
     repeat_state_e repeat = rep_untested;
     size_t srcPatternLength = 0;
 
-
+    DEBUGLOG(7, "LZ4HC_InsertAndGetWiderMatch");
     /* First Match */
     LZ4HC_Insert(hc4, ip);
     matchIndex = HashTable[LZ4HC_hashPtr(ip)];
+    DEBUGLOG(7, "First match at index %u / %u (lowLimit)",
+                matchIndex, lowLimit);
 
     while ((matchIndex>=lowLimit) && (nbAttempts)) {
+        DEBUGLOG(7, "remaining attempts : %i", nbAttempts);
         nbAttempts--;
         if (matchIndex >= dictLimit) {
             const BYTE* const matchPtr = base + matchIndex;
@@ -360,16 +363,18 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
     static const BYTE* start = NULL;
     static U32 totalCost = 0;
+    U32 const pos = (U32)(*anchor - start);
     U32 const ll = (U32)(*ip - *anchor);
     U32 const llAdd = (ll>=15) ? ((ll-15) / 255) + 1 : 0;
     U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
     U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
     if (start==NULL) start = *anchor;  /* only works for single segment */
-    totalCost += cost;
-    DEBUGLOG(2, "pos:%7u -- literals:%3u, match:%4i, offset:%5u, cost:%3u/%7u",
-                (U32)(*anchor - start),
+    //g_debuglog_enable = (pos >= 112705) & (pos <= 112760);
+    DEBUGLOG(2, "pos:%7u -- literals:%3u, match:%4i, offset:%5u, cost:%3u / %u",
+                pos,
                 (U32)(*ip - *anchor), matchLength, (U32)(*ip-match),
                 cost, totalCost);
+    totalCost += cost;
 #endif
 
     /* Encode Literal length */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -195,12 +195,6 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
 
     while ((matchIndex>=lowLimit) && (nbAttempts)) {
         nbAttempts--;
-        int trace = 0;
-        if (nbAttempts==0) {
-            trace = 1;
-            DEBUGLOG(2, "reached max nb of attempts ! : %08X => %08X ",
-                pattern, HASH_FUNCTION(pattern));
-        }
         if (matchIndex >= dictLimit) {
             const BYTE* const matchPtr = base + matchIndex;
             if (*(iLowLimit + longest) == *(matchPtr - delta + longest)) {
@@ -249,7 +243,6 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
         {   U32 const nextOffset = DELTANEXTU16(chainTable, matchIndex);
             matchIndex -= nextOffset;
             if (1 && (nextOffset==1)) {
-                if (trace) DEBUGLOG(2, "check repeat mode : %u", repeat);
                 /* may be a repeated pattern */
                 if (repeat == rep_untested) {
                     if ((pattern & 0xFFFF) == (pattern >> 16)) {   /* is it enough ? */
@@ -261,13 +254,11 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
                 if ( (repeat == rep_confirmed)   /* proven repeated pattern (1-2-4) */
                   && (matchIndex >= dictLimit) ) {   /* same segment only */
                     const BYTE* const matchPtr = base + matchIndex;
-                    if (trace) DEBUGLOG(2, "search direct pattern position");
                     if (LZ4_read32(matchPtr) == pattern) {  /* good candidate */
                         size_t const forwardPatternLength = LZ4HC_countPattern(matchPtr+sizeof(pattern), iHighLimit, pattern) + sizeof(pattern);
                         const BYTE* const maxLowPtr = (lowPrefixPtr + MAX_DISTANCE >= ip) ? lowPrefixPtr : ip - MAX_DISTANCE;
                         size_t const backLength = LZ4HC_reverseCountPattern(matchPtr, maxLowPtr, pattern);
                         size_t const currentSegmentLength = backLength + forwardPatternLength;
-                        if (trace) DEBUGLOG(2, "good start position (match == pattern)");
 
                         if ( (currentSegmentLength >= srcPatternLength)   /* current pattern segment large enough to contain full srcPatternLength */
                           && (forwardPatternLength <= srcPatternLength) ) { /* haven't reached this position yet */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -116,7 +116,7 @@ LZ4_FORCE_INLINE void LZ4HC_Insert (LZ4HC_CCtx_internal* hc4, const BYTE* ip)
     hc4->nextToUpdate = target;
 }
 
-
+#if 0
 LZ4_FORCE_INLINE int LZ4HC_InsertAndFindBestMatch (LZ4HC_CCtx_internal* const hc4,   /* Index table will be updated */
                                                const BYTE* const ip, const BYTE* const iLimit,
                                                const BYTE** matchpos,
@@ -163,7 +163,7 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndFindBestMatch (LZ4HC_CCtx_internal* const hc
 
     return (int)ml;
 }
-
+#endif
 
 LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
     LZ4HC_CCtx_internal* hc4,
@@ -232,6 +232,16 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
     }
 
     return longest;
+}
+
+LZ4_FORCE_INLINE
+int LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index table will be updated */
+                                const BYTE* const ip, const BYTE* const iLimit,
+                                const BYTE** matchpos,
+                                const int maxNbAttempts)
+{
+    const BYTE* uselessPtr = ip;
+    return LZ4HC_InsertAndGetWiderMatch(hc4, ip, ip, iLimit, MINMATCH-1, matchpos, &uselessPtr, maxNbAttempts);
 }
 
 
@@ -353,7 +363,7 @@ static int LZ4HC_compress_hashChain (
     /* Main Loop */
     while (ip < mflimit) {
         ml = LZ4HC_InsertAndFindBestMatch (ctx, ip, matchlimit, (&ref), maxNbAttempts);
-        if (!ml) { ip++; continue; }
+        if (ml<MINMATCH) { ip++; continue; }
 
         /* saved, in case we would skip too much */
         start0 = ip;

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -429,8 +429,6 @@ static int LZ4HC_compress_hashChain (
     if (limit == limitedDestSize) oend -= LASTLITERALS;                  /* Hack for support limitations LZ4 decompressor */
     if (inputSize < LZ4_minLength) goto _last_literals;                  /* Input too small, no compression (all literals) */
 
-    ip++;
-
     /* Main Loop */
     while (ip < mflimit) {
         ml = LZ4HC_InsertAndFindBestMatch (ctx, ip, matchlimit, (&ref), maxNbAttempts);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -119,8 +119,9 @@ LZ4_FORCE_INLINE void LZ4HC_Insert (LZ4HC_CCtx_internal* hc4, const BYTE* ip)
 
 /** LZ4HC_countBack() :
  * @return : negative value, nb of common bytes before ip/match */
-static int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
-                           const BYTE* const iMin, const BYTE* const mMin)
+LZ4_FORCE_INLINE
+int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
+                    const BYTE* const iMin, const BYTE* const mMin)
 {
     int back=0;
     while ( (ip+back > iMin)
@@ -264,7 +265,7 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
 
         {   U32 const nextOffset = DELTANEXTU16(chainTable, matchIndex);
             matchIndex -= nextOffset;
-            if (1 && (nextOffset==1)) {
+            if (nextOffset==1) {
                 /* may be a repeated pattern */
                 if (repeat == rep_untested) {
                     if ((pattern & 0xFFFF) == (pattern >> 16)) {   /* is it enough ? */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -161,17 +161,21 @@ static unsigned LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 c
     return (unsigned)(ip - iStart);
 }
 
+/* LZ4HC_reverseCountPattern() :
+ * pattern must be a sample of repetitive pattern of length 1, 2 or 4 (but not 3!)
+ * read using natural platform endianess */
 static unsigned LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
 {
     const BYTE* const iStart = ip;
 
-    while (likely(ip>=iLow+4)) {
+    while (likely(ip >= iLow+4)) {
         if (LZ4_read32(ip-4) != pattern) break;
         ip -= 4;
     }
     while (likely(ip>iLow)) {
-        if (ip[-1] != (BYTE)pattern) break;
-        ip--;
+        const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianess */
+        if (ip[-1] != *bytePtr) break;
+        ip--; bytePtr--;
     }
 
     return (unsigned)(iStart - ip);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -644,7 +644,7 @@ static int LZ4HC_getSearchNum(int compressionLevel)
 {
     switch (compressionLevel) {
         default: return 0; /* unused */
-        case 11: return 128;
+        case 11: return 256;
         case 12: return 1<<13;
     }
 }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -363,14 +363,14 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
     static const BYTE* start = NULL;
     static U32 totalCost = 0;
-    U32 const pos = (U32)(*anchor - start);
+    U32 const pos = (start==NULL) ? 0 : (U32)(*anchor - start);
     U32 const ll = (U32)(*ip - *anchor);
     U32 const llAdd = (ll>=15) ? ((ll-15) / 255) + 1 : 0;
     U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
     U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
     if (start==NULL) start = *anchor;  /* only works for single segment */
     //g_debuglog_enable = (pos >= 112705) & (pos <= 112760);
-    DEBUGLOG(2, "pos:%7u -- literals:%3u, match:%4i, offset:%5u, cost:%3u / %u",
+    DEBUGLOG(2, "pos:%7u -- literals:%3u, match:%4i, offset:%5u, cost:%3u + %u",
                 pos,
                 (U32)(*ip - *anchor), matchLength, (U32)(*ip-match),
                 cost, totalCost);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -644,7 +644,7 @@ static int LZ4HC_getSearchNum(int compressionLevel)
 {
     switch (compressionLevel) {
         default: return 0; /* unused */
-        case 11: return 256;
+        case 11: return 512;
         case 12: return 1<<13;
     }
 }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -173,12 +173,11 @@ static unsigned LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow
         if (LZ4_read32(ip-4) != pattern) break;
         ip -= 4;
     }
-    while (likely(ip>iLow)) {
-        const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianess */
-        if (ip[-1] != *bytePtr) break;
-        ip--; bytePtr--;
-    }
-
+    {   const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianess */
+        while (likely(ip>iLow)) {
+            if (ip[-1] != *bytePtr) break;
+            ip--; bytePtr--;
+    }   }
     return (unsigned)(iStart - ip);
 }
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -369,7 +369,7 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
     U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
     U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
     if (start==NULL) start = *anchor;  /* only works for single segment */
-    //g_debuglog_enable = (pos >= 112705) & (pos <= 112760);
+    //g_debuglog_enable = (pos >= 2228) & (pos <= 2262);
     DEBUGLOG(2, "pos:%7u -- literals:%3u, match:%4i, offset:%5u, cost:%3u + %u",
                 pos,
                 (U32)(*ip - *anchor), matchLength, (U32)(*ip-match),

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -262,7 +262,6 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
                             matchIndex += (U32)forwardPatternLength - (U32)srcPatternLength;  /* best position, full pattern, might be followed by more match */
                         } else {
                             matchIndex -= (U32)backLength;   /* let's go to farthest segment position, will find a match of length currentSegmentLength + maybe some back */
-                            //matchIndex -= DELTANEXTU16(chainTable, matchIndex);   /* skip directly to following candidate; slightly faster, but miss some rare corner cases (likely when back is useful)*/
                         }
         }   }   }   }
     }  /* while ((matchIndex>=lowLimit) && (nbAttempts)) */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -272,7 +272,7 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
     return longest;
 }
 
-#if 0
+#if 1
 LZ4_FORCE_INLINE
 int LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index table will be updated */
                                 const BYTE* const ip, const BYTE* const iLimit,

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -304,7 +304,7 @@ int LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index tabl
     const BYTE* uselessPtr = ip;
     /* note : LZ4HC_InsertAndGetWiderMatch() is able to modify the starting position of a match (*startpos),
      * but this won't be the case here, as we define iLowLimit==ip,
-     * so LZ4HC_InsertAndGetWiderMatch() will not be allowed to search past ip */
+     * so LZ4HC_InsertAndGetWiderMatch() won't be allowed to search past ip */
     return LZ4HC_InsertAndGetWiderMatch(hc4, ip, ip, iLimit, MINMATCH-1, matchpos, &uselessPtr, maxNbAttempts);
 }
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -49,6 +49,7 @@
 
 
 /*===    Dependency    ===*/
+#define LZ4_HC_STATIC_LINKING_ONLY
 #include "lz4hc.h"
 
 
@@ -726,18 +727,13 @@ void LZ4_resetStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
     LZ4_STATIC_ASSERT(sizeof(LZ4HC_CCtx_internal) <= sizeof(size_t) * LZ4_STREAMHCSIZE_SIZET);   /* if compilation fails here, LZ4_STREAMHCSIZE must be increased */
     LZ4_streamHCPtr->internal_donotuse.base = NULL;
-    if (compressionLevel > LZ4HC_CLEVEL_MAX) compressionLevel = LZ4HC_CLEVEL_MAX;  /* cap compression level */
-    LZ4_streamHCPtr->internal_donotuse.compressionLevel = compressionLevel;
+    LZ4_setCompressionLevel(LZ4_streamHCPtr, compressionLevel);
 }
 
 void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
-    /* note : 1-10 / 11-12 separation might no longer be necessary since optimal parser uses hash chain too */
-    int const currentCLevel = LZ4_streamHCPtr->internal_donotuse.compressionLevel;
-    int const minCLevel = currentCLevel < LZ4HC_CLEVEL_OPT_MIN ? 1 : LZ4HC_CLEVEL_OPT_MIN;
-    int const maxCLevel = currentCLevel < LZ4HC_CLEVEL_OPT_MIN ? LZ4HC_CLEVEL_OPT_MIN-1 : LZ4HC_CLEVEL_MAX;
-    compressionLevel = MIN(compressionLevel, minCLevel);
-    compressionLevel = MAX(compressionLevel, maxCLevel);
+    if (compressionLevel < 1) compressionLevel = 1;
+    if (compressionLevel > LZ4HC_CLEVEL_MAX) compressionLevel = LZ4HC_CLEVEL_MAX;
     LZ4_streamHCPtr->internal_donotuse.compressionLevel = compressionLevel;
 }
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -457,7 +457,6 @@ static int LZ4HC_compress_hashChain (
     if (limit == limitedDestSize && maxOutputSize < 1) return 0;         /* Impossible to store anything */
     if ((U32)inputSize > (U32)LZ4_MAX_INPUT_SIZE) return 0;              /* Unsupported input size, too large (or negative) */
 
-    ctx->end += inputSize;
     if (limit == limitedDestSize) oend -= LASTLITERALS;                  /* Hack for support limitations LZ4 decompressor */
     if (inputSize < LZ4_minLength) goto _last_literals;                  /* Input too small, no compression (all literals) */
 
@@ -651,7 +650,8 @@ static int LZ4HC_compress_generic (
     limitedOutput_directive limit
     )
 {
-    if (cLevel < 1) cLevel = LZ4HC_CLEVEL_DEFAULT;   /* note : convention is different from lz4frame, maybe to reconsider */
+    ctx->end += *srcSizePtr;
+    if (cLevel < 1) cLevel = LZ4HC_CLEVEL_DEFAULT;   /* note : convention is different from lz4frame, maybe something to review */
     if (cLevel > 9) {
         if (limit == limitedDestSize) cLevel = 10;
         switch (cLevel) {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -268,7 +268,8 @@ LZ4_FORCE_INLINE int LZ4HC_InsertAndGetWiderMatch (
             if (nextOffset==1) {
                 /* may be a repeated pattern */
                 if (repeat == rep_untested) {
-                    if ((pattern & 0xFFFF) == (pattern >> 16)) {   /* is it enough ? */
+                    if ( ((pattern & 0xFFFF) == (pattern >> 16))
+                      &  ((pattern & 0xFF)   == (pattern >> 24)) ) {
                         repeat = rep_confirmed;
                         srcPatternLength = LZ4HC_countPattern(ip+4, iHighLimit, pattern) + 4;
                     } else {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -761,10 +761,7 @@ int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr, const char* dictionary, int
     }
     LZ4HC_init (ctxPtr, (const BYTE*)dictionary);
     ctxPtr->end = (const BYTE*)dictionary + dictSize;
-    if (ctxPtr->compressionLevel >= LZ4HC_CLEVEL_OPT_MIN)
-        LZ4HC_updateBinTree(ctxPtr, ctxPtr->end - MFLIMIT, ctxPtr->end - LASTLITERALS);
-    else
-        if (dictSize >= 4) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
+    if (dictSize >= 4) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
     return dictSize;
 }
 
@@ -773,10 +770,7 @@ int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr, const char* dictionary, int
 
 static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBlock)
 {
-    if (ctxPtr->compressionLevel >= LZ4HC_CLEVEL_OPT_MIN)
-        LZ4HC_updateBinTree(ctxPtr, ctxPtr->end - MFLIMIT, ctxPtr->end - LASTLITERALS);
-    else
-        if (ctxPtr->end >= ctxPtr->base + 4) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);   /* Referencing remaining dictionary content */
+    if (ctxPtr->end >= ctxPtr->base + 4) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);   /* Referencing remaining dictionary content */
 
     /* Only one memory segment for extDict, so any previous extDict is lost at this stage */
     ctxPtr->lowLimit  = ctxPtr->dictLimit;

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -265,8 +265,7 @@ int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr,
 
 /*! LZ4_setCompressionLevel() : v1.8.0 (experimental)
  *  It's possible to change compression level between 2 invocations of LZ4_compress_HC_continue*(),
- *  but it requires to stay in the same mode (aka 1-10 or 11-12).
- *  This function ensures this condition.
+ *  though it requires to stay in the same mode (aka fast or HC).
  */
 void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -129,7 +129,7 @@ LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, in
  * They are exposed to allow static allocation of `LZ4_streamHC_t`.
  * Using these definitions makes the code vulnerable to potential API break when upgrading LZ4
  **************************************/
-#define LZ4HC_DICTIONARY_LOGSIZE 17   /* due to btree, hc would only need 16 */
+#define LZ4HC_DICTIONARY_LOGSIZE 16
 #define LZ4HC_MAXD (1<<LZ4HC_DICTIONARY_LOGSIZE)
 #define LZ4HC_MAXD_MASK (LZ4HC_MAXD - 1)
 
@@ -175,7 +175,7 @@ typedef struct
 
 #endif
 
-#define LZ4_STREAMHCSIZE       (4*LZ4HC_HASHTABLESIZE + 2*LZ4HC_MAXD + 56) /* 393268 */
+#define LZ4_STREAMHCSIZE       (4*LZ4HC_HASHTABLESIZE + 2*LZ4HC_MAXD + 56) /* 262200 */
 #define LZ4_STREAMHCSIZE_SIZET (LZ4_STREAMHCSIZE / sizeof(size_t))
 union LZ4_streamHC_u {
     size_t table[LZ4_STREAMHCSIZE_SIZET];

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -152,8 +152,7 @@ typedef struct
     uint32_t   dictLimit;       /* below that point, need extDict */
     uint32_t   lowLimit;        /* below that point, no more dict */
     uint32_t   nextToUpdate;    /* index from which to continue dictionary update */
-    uint32_t   searchNum;       /* only for optimal parser */
-    uint32_t   compressionLevel;
+    int        compressionLevel;
 } LZ4HC_CCtx_internal;
 
 #else
@@ -169,7 +168,6 @@ typedef struct
     unsigned int   dictLimit;        /* below that point, need extDict */
     unsigned int   lowLimit;         /* below that point, no more dict */
     unsigned int   nextToUpdate;     /* index from which to continue dictionary update */
-    unsigned int   searchNum;        /* only for optimal parser */
     int            compressionLevel;
 } LZ4HC_CCtx_internal;
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -39,7 +39,7 @@ extern "C" {
 #endif
 
 /* --- Dependency --- */
-/* note : lz4hc is not an independent module, it requires lz4.h/lz4.c for proper compilation */
+/* note : lz4hc requires lz4.h/lz4.c for compilation */
 #include "lz4.h"   /* stddef, LZ4LIB_API, LZ4_DEPRECATED */
 
 
@@ -54,12 +54,12 @@ extern "C" {
  *  Block Compression
  **************************************/
 /*! LZ4_compress_HC() :
- * Compress data from `src` into `dst`, using the more powerful but slower "HC" algorithm.
+ *  Compress data from `src` into `dst`, using the more powerful but slower "HC" algorithm.
  * `dst` must be already allocated.
- * Compression is guaranteed to succeed if `dstCapacity >= LZ4_compressBound(srcSize)` (see "lz4.h")
- * Max supported `srcSize` value is LZ4_MAX_INPUT_SIZE (see "lz4.h")
- * `compressionLevel` : Recommended values are between 4 and 9, although any value between 1 and LZ4HC_CLEVEL_MAX will work.
- *                      Values >LZ4HC_CLEVEL_MAX behave the same as LZ4HC_CLEVEL_MAX.
+ *  Compression is guaranteed to succeed if `dstCapacity >= LZ4_compressBound(srcSize)` (see "lz4.h")
+ *  Max supported `srcSize` value is LZ4_MAX_INPUT_SIZE (see "lz4.h")
+ * `compressionLevel` : any value between 1 and LZ4HC_CLEVEL_MAX will work.
+ *                      Values > LZ4HC_CLEVEL_MAX behave the same as LZ4HC_CLEVEL_MAX.
  * @return : the number of bytes written into 'dst'
  *           or 0 if compression fails.
  */
@@ -72,12 +72,12 @@ LZ4LIB_API int LZ4_compress_HC (const char* src, char* dst, int srcSize, int dst
 
 
 /*! LZ4_compress_HC_extStateHC() :
- * Same as LZ4_compress_HC(), but using an externally allocated memory segment for `state`.
+ *  Same as LZ4_compress_HC(), but using an externally allocated memory segment for `state`.
  * `state` size is provided by LZ4_sizeofStateHC().
- * Memory segment must be aligned on 8-bytes boundaries (which a normal malloc() will do properly).
+ *  Memory segment must be aligned on 8-bytes boundaries (which a normal malloc() should do properly).
  */
-LZ4LIB_API int LZ4_compress_HC_extStateHC(void* state, const char* src, char* dst, int srcSize, int maxDstSize, int compressionLevel);
 LZ4LIB_API int LZ4_sizeofStateHC(void);
+LZ4LIB_API int LZ4_compress_HC_extStateHC(void* state, const char* src, char* dst, int srcSize, int maxDstSize, int compressionLevel);
 
 
 /*-************************************
@@ -87,10 +87,10 @@ LZ4LIB_API int LZ4_sizeofStateHC(void);
  typedef union LZ4_streamHC_u LZ4_streamHC_t;   /* incomplete type (defined later) */
 
 /*! LZ4_createStreamHC() and LZ4_freeStreamHC() :
- * These functions create and release memory for LZ4 HC streaming state.
- * Newly created states are automatically initialized.
- * Existing states can be re-used several times, using LZ4_resetStreamHC().
- * These methods are API and ABI stable, they can be used in combination with a DLL.
+ *  These functions create and release memory for LZ4 HC streaming state.
+ *  Newly created states are automatically initialized.
+ *  Existing states can be re-used several times, using LZ4_resetStreamHC().
+ *  These methods are API and ABI stable, they can be used in combination with a DLL.
  */
 LZ4LIB_API LZ4_streamHC_t* LZ4_createStreamHC(void);
 LZ4LIB_API int             LZ4_freeStreamHC (LZ4_streamHC_t* streamHCPtr);
@@ -123,12 +123,12 @@ LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, in
 */
 
 
- /*-*************************************
+/*-**************************************************************
  * PRIVATE DEFINITIONS :
  * Do not use these definitions.
  * They are exposed to allow static allocation of `LZ4_streamHC_t`.
  * Using these definitions makes the code vulnerable to potential API break when upgrading LZ4
- **************************************/
+ ****************************************************************/
 #define LZ4HC_DICTIONARY_LOGSIZE 16
 #define LZ4HC_MAXD (1<<LZ4HC_DICTIONARY_LOGSIZE)
 #define LZ4HC_MAXD_MASK (LZ4HC_MAXD - 1)
@@ -195,7 +195,6 @@ union LZ4_streamHC_u {
 /* see lz4.h LZ4_DISABLE_DEPRECATE_WARNINGS to turn off deprecation warnings */
 
 /* deprecated compression functions */
-/* these functions will trigger warning messages in future releases */
 LZ4LIB_API LZ4_DEPRECATED("use LZ4_compress_HC() instead") int LZ4_compressHC               (const char* source, char* dest, int inputSize);
 LZ4LIB_API LZ4_DEPRECATED("use LZ4_compress_HC() instead") int LZ4_compressHC_limitedOutput (const char* source, char* dest, int inputSize, int maxOutputSize);
 LZ4LIB_API LZ4_DEPRECATED("use LZ4_compress_HC() instead") int LZ4_compressHC2 (const char* source, char* dest, int inputSize, int compressionLevel);
@@ -223,14 +222,15 @@ LZ4LIB_API LZ4_DEPRECATED("use LZ4_resetStreamHC() instead")  int   LZ4_resetStr
 
 #endif /* LZ4_HC_H_19834876238432 */
 
-/*-************************************************
+
+/*-**************************************************
  * !!!!!     STATIC LINKING ONLY     !!!!!
  * Following definitions are considered experimental.
  * They should not be linked from DLL,
  * as there is no guarantee of API stability yet.
  * Prototypes will be promoted to "stable" status
  * after successfull usage in real-life scenarios.
- *************************************************/
+ ***************************************************/
 #ifdef LZ4_HC_STATIC_LINKING_ONLY   /* protection macro */
 #ifndef LZ4_HC_SLO_098092834
 #define LZ4_HC_SLO_098092834
@@ -256,16 +256,13 @@ int LZ4_compress_HC_destSize(void* LZ4HC_Data,
  * @return : the number of bytes written into 'dst'
  *           or 0 if compression fails.
  * `srcSizePtr` : value will be updated to indicate how much bytes were read from `src`.
- *  Important : due to limitations, this prototype only works well up to cLevel < LZ4HC_CLEVEL_OPT_MIN
- *              beyond that level, compression performance will be much reduced due to internal incompatibilities
  */
 int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr,
                             const char* src, char* dst,
                             int* srcSizePtr, int targetDstSize);
 
 /*! LZ4_setCompressionLevel() : v1.8.0 (experimental)
- *  It's possible to change compression level between 2 invocations of LZ4_compress_HC_continue*(),
- *  though it requires to stay in the same mode (aka fast or HC).
+ *  It's possible to change compression level between 2 invocations of LZ4_compress_HC_continue*()
  */
 void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -129,7 +129,7 @@ LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, in
  * They are exposed to allow static allocation of `LZ4_streamHC_t`.
  * Using these definitions makes the code vulnerable to potential API break when upgrading LZ4
  **************************************/
-#define LZ4HC_DICTIONARY_LOGSIZE 17   /* because of btopt, hc would only need 16 */
+#define LZ4HC_DICTIONARY_LOGSIZE 17   /* due to btree, hc would only need 16 */
 #define LZ4HC_MAXD (1<<LZ4HC_DICTIONARY_LOGSIZE)
 #define LZ4HC_MAXD_MASK (LZ4HC_MAXD - 1)
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -266,8 +266,8 @@ int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr,
                             int* srcSizePtr, int targetDstSize);
 
 /*! LZ4_setCompressionLevel() : v1.8.0 (experimental)
- *  It's possible to change compression level after LZ4_resetStreamHC(), between 2 invocations of LZ4_compress_HC_continue*(),
- *  but that requires to stay in the same mode (aka 1-10 or 11-12).
+ *  It's possible to change compression level between 2 invocations of LZ4_compress_HC_continue*(),
+ *  but it requires to stay in the same mode (aka 1-10 or 11-12).
  *  This function ensures this condition.
  */
 void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -318,7 +318,7 @@ static int LZ4HC_compress_optimal (
             DEBUGLOG(7, "search at rPos:%u", cur);
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
-            //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur + 1, matches, fullUpdate);   /* only works if last_match_pos is really the last match pos */
+            //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur - 1, matches, fullUpdate);   /* only test matches of a minimum length */
             if (!nb_matches) continue;
 
             if ( ((size_t)matches[nb_matches-1].len > sufficient_len)

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -262,7 +262,7 @@ static int LZ4HC_compress_optimal (
                     SET_PRICE(mlen, mlen, matches[matchNb].off, 0, cost);   /* updates last_match_pos and opt[pos] */
         }   }   }
 
-        if (last_match_pos < MINMATCH) { ip++; continue; }  /* note : on clang at least, this test improves performance */
+        assert(last_match_pos >= MINMATCH);
 
         /* check further positions */
         opt[0].mlen = opt[1].mlen = 1;

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -211,7 +211,7 @@ LZ4_FORCE_INLINE int LZ4HC_HashChain_GetAllMatches (
                         const BYTE* const ip, const BYTE* const iHighLimit,
                         size_t best_mlen, LZ4HC_match_t* matches, const int fullUpdate)
 {
-    const BYTE* matchPtr;
+    const BYTE* matchPtr = NULL;
     int matchLength = LZ4HC_FindLongerMatch(ctx, ip, iHighLimit, (int)best_mlen, &matchPtr, ctx->searchNum);
     if ((size_t)matchLength <= best_mlen) return 0;
     assert(matches != NULL);

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -245,11 +245,11 @@ static int LZ4HC_compress_optimal (
 
         if ((size_t)matches[match_num-1].len > sufficient_len) {
             /* good enough solution : immediate encoding */
-            best_mlen = matches[match_num-1].len;
-            best_off = matches[match_num-1].off;
-            cur = 0;
-            last_pos = 1;
-            goto encode;
+            int const firstML = (int)matches[match_num-1].len;
+            const BYTE* const matchPos = ip - matches[match_num-1].off;
+            if ( LZ4HC_encodeSequence(&ip, &op, &anchor, (int)firstML, matchPos, limit, oend) )   /* updates ip, op and anchor */
+                return 0;  /* error */
+            continue;
         }
 
         /* set prices using matches at position = 0 */

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -184,8 +184,13 @@ static int LZ4HC_compress_optimal (
             DEBUGLOG(7, "rPos:%u[%u] vs [%u]%u",
                     cur, opt[cur].price, opt[cur+1].price, cur+1);
             if (fullUpdate) {
-                if ((opt[cur+1].price <= opt[cur].price) && (opt[cur+MINMATCH].price < opt[cur].price + 3/*min seq price*/)) continue;
+                /* not useful to search here if next position has same (or lower) cost */
+                if ( (opt[cur+1].price <= opt[cur].price)
+                  /* in some cases, next position has same cost, but cost rises sharply after, so a small match would still be beneficial */
+                  && (opt[cur+MINMATCH].price < opt[cur].price + 3/*min seq price*/) )
+                    continue;
             } else {
+                /* not useful to search here if next position has same (or lower) cost */
                 if (opt[cur+1].price <= opt[cur].price) continue;
             }
 

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -127,7 +127,6 @@ static int LZ4HC_compress_optimal (
     /* init */
     DEBUGLOG(5, "LZ4HC_compress_optimal");
     if (sufficient_len >= LZ4_OPT_NUM) sufficient_len = LZ4_OPT_NUM-1;
-    ip++;
 
     /* Main Loop */
     assert(ip - anchor < LZ4_MAX_INPUT_SIZE);

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -91,7 +91,7 @@ int LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,   /* Index table will 
 LZ4_FORCE_INLINE int LZ4HC_HashChain_GetAllMatches (
                         LZ4HC_CCtx_internal* ctx,
                         const BYTE* const ip, const BYTE* const iHighLimit,
-                        size_t best_mlen, LZ4HC_match_t* matches, const int fullUpdate)
+                        size_t best_mlen, LZ4HC_match_t* matches)
 {
     const BYTE* matchPtr = NULL;
     int matchLength = LZ4HC_FindLongerMatch(ctx, ip, iHighLimit, (int)best_mlen, &matchPtr, ctx->searchNum);
@@ -99,7 +99,6 @@ LZ4_FORCE_INLINE int LZ4HC_HashChain_GetAllMatches (
     assert(matches != NULL);
     matches[0].len = matchLength;
     matches[0].off = (int)(ip-matchPtr);
-    (void)fullUpdate;
     return 1;
 }
 
@@ -139,7 +138,7 @@ static int LZ4HC_compress_optimal (
         int best_mlen, best_off;
         int cur, last_match_pos = 0;
 
-        int const nb_matches_initial = LZ4HC_HashChain_GetAllMatches(ctx, ip, matchlimit, MINMATCH-1, matches, fullUpdate);
+        int const nb_matches_initial = LZ4HC_HashChain_GetAllMatches(ctx, ip, matchlimit, MINMATCH-1, matches);
         if (!nb_matches_initial) { ip++; continue; }
 
         if ((size_t)matches[nb_matches_initial-1].len > sufficient_len) {
@@ -205,9 +204,9 @@ static int LZ4HC_compress_optimal (
 
             DEBUGLOG(7, "search at rPos:%u", cur);
             if (fullUpdate)
-                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
+                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches);
             else
-                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur, matches, fullUpdate);   /* only test matches of a minimum length; slightly faster, but misses a few bytes */
+                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur, matches);   /* only test matches of a minimum length; slightly faster, but misses a few bytes */
             if (!nb_matches) continue;
 
             if ( ((size_t)matches[nb_matches-1].len > sufficient_len)

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -301,8 +301,8 @@ static int LZ4HC_compress_optimal (
                                 mlen, cost, mlen);
         }   }   }
         last_match_pos = matches[nb_matches_initial-1].len;
-        opt[last_match_pos-2].toSearch = 1;
-        opt[last_match_pos-1].toSearch = 1;
+        if (fullUpdate) opt[last_match_pos-2].toSearch = 1;   /* 1 byte on calgary */
+        if (fullUpdate) opt[last_match_pos-1].toSearch = 1;   /* 1 byte on calgary */
         opt[last_match_pos].toSearch = 1;
         {   int addLit;
             for (addLit = 1; addLit <= 3; addLit ++) {
@@ -349,7 +349,6 @@ static int LZ4HC_compress_optimal (
                         opt[pos].off = 0;
                         opt[pos].litlen = baseLitlen+litlen;
                         opt[pos].price = price;
-                        opt[pos].toSearch = 1;
                         DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)",
                                     pos, price, opt[pos].litlen);
             }   }   }
@@ -392,8 +391,8 @@ static int LZ4HC_compress_optimal (
                             opt[pos].toSearch = (((ml-18) % 255) == 0);
             }   }   }   }
             /* complete following positions with literals */
-            opt[last_match_pos-2].toSearch = 1;
-            opt[last_match_pos-1].toSearch = 1;
+            if (fullUpdate) opt[last_match_pos-2].toSearch = 1;   /* 2 bytes on enwik7 */
+            if (fullUpdate) opt[last_match_pos-1].toSearch = 1;   /* 53 bytes on enwik7, 13 bytes on calgary */
             opt[last_match_pos].toSearch = 1;
             {   int addLit;
                 for (addLit = 1; addLit <= 3; addLit ++) {
@@ -439,7 +438,7 @@ encode: /* cur, last_match_pos, best_mlen, best_off must be set */
                 if (ml == 1) { ip++; rPos++; continue; }  /* literal; note: can end up with several literals, in which case, skip them */
                 rPos += ml;
                 assert(ml >= MINMATCH);
-                assert((offset >= 1) && (offset <=65535));
+                assert((offset >= 1) && (offset <= MAX_DISTANCE));
                 if ( LZ4HC_encodeSequence(&ip, &op, &anchor, ml, ip - offset, limit, oend) )   /* updates ip, op and anchor */
                     return 0;  /* error */
         }   }

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -299,7 +299,7 @@ static int LZ4HC_compress_optimal (
         }   }   }
         last_match_pos = matches[nb_matches_initial-1].len;
         {   int addLit;
-            for (addLit = 1; addLit <= 2; addLit ++) {
+            for (addLit = 1; addLit <= 3; addLit ++) {
                 opt[last_match_pos+addLit].mlen = 1; /* literal */
                 opt[last_match_pos+addLit].off = 0;
                 opt[last_match_pos+addLit].litlen = addLit;
@@ -315,6 +315,7 @@ static int LZ4HC_compress_optimal (
 
             if (curPtr >= mflimit) break;
 
+            DEBUGLOG(7, "search at rPos:%u", cur);
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur + 1, matches, fullUpdate);   /* only works if last_match_pos is really the last match pos */
@@ -367,7 +368,7 @@ static int LZ4HC_compress_optimal (
                             price = opt[cur].price + LZ4HC_sequencePrice(0, ml);
                         }
 
-                        if (pos > last_match_pos+2 || price <= opt[pos].price) {
+                        if (pos > last_match_pos+3 || price <= opt[pos].price) {
                             DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i)",
                                         pos, price, ml);
                             assert(pos < LZ4_OPT_NUM);
@@ -382,7 +383,7 @@ static int LZ4HC_compress_optimal (
             }   }   }   }
             /* complete following positions with literals */
             {   int addLit;
-                for (addLit = 1; addLit <= 2; addLit ++) {
+                for (addLit = 1; addLit <= 3; addLit ++) {
                     opt[last_match_pos+addLit].mlen = 1; /* literal */
                     opt[last_match_pos+addLit].off = 0;
                     opt[last_match_pos+addLit].litlen = addLit;

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -46,7 +46,6 @@ typedef struct {
     int off;
     int mlen;
     int litlen;
-    int toSearch;
 } LZ4HC_optimal_t;
 
 
@@ -244,6 +243,7 @@ static int LZ4HC_compress_optimal (
     const BYTE* const matchlimit = iend - LASTLITERALS;
     BYTE* op = (BYTE*) dst;
     BYTE* const oend = op + dstCapacity;
+    int const front = fullUpdate ? 2 : 1;
 
     /* init */
     DEBUGLOG(5, "LZ4HC_compress_optimal");
@@ -279,7 +279,6 @@ static int LZ4HC_compress_optimal (
                 opt[rPos].off = 0;
                 opt[rPos].litlen = llen + rPos;
                 opt[rPos].price = cost;
-                opt[rPos].toSearch = 1;
                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
                             rPos, cost, opt[rPos].litlen);
         }   }
@@ -296,21 +295,16 @@ static int LZ4HC_compress_optimal (
                     opt[mlen].off = offset;
                     opt[mlen].litlen = llen;
                     opt[mlen].price = cost;
-                    opt[mlen].toSearch = (((mlen - 18) % 255) == 0);
                     DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i) -- initial setup",
                                 mlen, cost, mlen);
         }   }   }
         last_match_pos = matches[nb_matches_initial-1].len;
-        if (fullUpdate) opt[last_match_pos-2].toSearch = 1;   /* 1 byte on calgary */
-        if (fullUpdate) opt[last_match_pos-1].toSearch = 1;   /* 1 byte on calgary */
-        opt[last_match_pos].toSearch = 1;
         {   int addLit;
             for (addLit = 1; addLit <= 3; addLit ++) {
                 opt[last_match_pos+addLit].mlen = 1; /* literal */
                 opt[last_match_pos+addLit].off = 0;
                 opt[last_match_pos+addLit].litlen = addLit;
                 opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
-                opt[last_match_pos+addLit].toSearch = 1;
                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
                             last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
         }   }
@@ -321,7 +315,9 @@ static int LZ4HC_compress_optimal (
             int nb_matches;
 
             if (curPtr >= mflimit) break;
-            if (opt[cur].toSearch == 0) continue;
+            DEBUGLOG(7, "rPos:%u[%u] vs [%u]%u",
+                    cur, opt[cur].price, opt[cur+1].price, cur+1);
+            if (opt[cur+front].price <= opt[cur].price) continue;
 
             DEBUGLOG(7, "search at rPos:%u", cur);
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
@@ -388,19 +384,14 @@ static int LZ4HC_compress_optimal (
                             opt[pos].off = offset;
                             opt[pos].litlen = ll;
                             opt[pos].price = price;
-                            opt[pos].toSearch = (((ml-18) % 255) == 0);
             }   }   }   }
             /* complete following positions with literals */
-            if (fullUpdate) opt[last_match_pos-2].toSearch = 1;   /* 2 bytes on enwik7 */
-            if (fullUpdate) opt[last_match_pos-1].toSearch = 1;   /* 53 bytes on enwik7, 13 bytes on calgary */
-            opt[last_match_pos].toSearch = 1;
             {   int addLit;
                 for (addLit = 1; addLit <= 3; addLit ++) {
                     opt[last_match_pos+addLit].mlen = 1; /* literal */
                     opt[last_match_pos+addLit].off = 0;
                     opt[last_match_pos+addLit].litlen = addLit;
                     opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
-                    opt[last_match_pos+addLit].toSearch = 1;
                     DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)", last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
             }   }
         }  /* for (cur = 1; cur <= last_match_pos; cur++) */

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -128,7 +128,6 @@ static int LZ4HC_compress_optimal (
     /* init */
     DEBUGLOG(5, "LZ4HC_compress_optimal");
     if (sufficient_len >= LZ4_OPT_NUM) sufficient_len = LZ4_OPT_NUM-1;
-    ctx->end += inputSize;
     ip++;
 
     /* Main Loop */

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -213,7 +213,7 @@ LZ4_FORCE_INLINE int LZ4HC_HashChain_GetAllMatches (
 {
     const BYTE* matchPtr;
     int matchLength = LZ4HC_FindLongerMatch(ctx, ip, iHighLimit, (int)best_mlen, &matchPtr, ctx->searchNum);
-    if (matchLength < MINMATCH) return 0;
+    if ((size_t)matchLength <= best_mlen) return 0;
     assert(matches != NULL);
     matches[0].len = matchLength;
     matches[0].off = (int)(ip-matchPtr);
@@ -327,6 +327,7 @@ static int LZ4HC_compress_optimal (
 
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
+            //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur + 1, matches, fullUpdate);   /* only works if last_match_pos is really the last match pos */
             if ((nb_matches > 0) && (size_t)matches[nb_matches-1].len > sufficient_len) {
                 /* immediate encoding */
                 best_mlen = matches[nb_matches-1].len;

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -324,8 +324,10 @@ static int LZ4HC_compress_optimal (
 
             DEBUGLOG(7, "search at rPos:%u", cur);
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
-            nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
-            //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur, matches, fullUpdate);   /* only test matches of a minimum length */
+            if (fullUpdate)
+                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
+            else
+                nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur, matches, fullUpdate);   /* only test matches of a minimum length; slightly faster, but misses a few bytes */
             if (!nb_matches) continue;
 
             if ( ((size_t)matches[nb_matches-1].len > sufficient_len)

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -35,12 +35,6 @@
 
 #define LZ4_OPT_NUM   (1<<12)
 
-
-typedef struct {
-    int off;
-    int len;
-} LZ4HC_match_t;
-
 typedef struct {
     int price;
     int off;
@@ -88,12 +82,17 @@ int LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,   /* Index table will 
     return LZ4HC_InsertAndGetWiderMatch(ctx, ip, ip, iHighLimit, longest, matchpos, &uselessPtr, maxNbAttempts);
 }
 
+typedef struct {
+    int off;
+    int len;
+} LZ4HC_match_t;
+
 LZ4_FORCE_INLINE
 LZ4HC_match_t LZ4HC_HashChain_GetAllMatches (LZ4HC_CCtx_internal* const ctx,
                         const BYTE* const ip, const BYTE* const iHighLimit,
                         size_t best_mlen, int nbSearches)
 {
-    LZ4HC_match_t match = {0 , 0};
+    LZ4HC_match_t match = { 0 , 0 };
     const BYTE* matchPtr = NULL;
     int matchLength = LZ4HC_FindLongerMatch(ctx, ip, iHighLimit, (int)best_mlen, &matchPtr, nbSearches);
     if ((size_t)matchLength <= best_mlen) return match;

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -160,7 +160,7 @@ static int LZ4HC_compress_optimal (
                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
                             rPos, cost, opt[rPos].litlen);
         }   }
-        /* set prices using matches found for rPos = 0 */
+        /* set prices using initial match */
         {   int mlen = MINMATCH;
             int const matchML = firstMatch.len;   /* necessarily < sufficient_len < LZ4_OPT_NUM */
             int const offset = firstMatch.off;
@@ -215,7 +215,7 @@ static int LZ4HC_compress_optimal (
                 goto encode;
             }
 
-            /* before first match : set price with literals at beginning */
+            /* before match : set price with literals at beginning */
             {   int const baseLitlen = opt[cur].litlen;
                 int litlen;
                 for (litlen = 1; litlen < MINMATCH; litlen++) {
@@ -230,10 +230,10 @@ static int LZ4HC_compress_optimal (
                                     pos, price, opt[pos].litlen);
             }   }   }
 
-            /* set prices using matches at position = cur */
+            /* set prices using match at position = cur */
             {   int const matchML = newMatch.len;
                 int ml = MINMATCH;
-                
+
                 assert(cur + newMatch.len < LZ4_OPT_NUM);
                 for ( ; ml <= matchML ; ml++) {
                     int const pos = cur + ml;
@@ -255,7 +255,7 @@ static int LZ4HC_compress_optimal (
                         DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i)",
                                     pos, price, ml);
                         assert(pos < LZ4_OPT_NUM);
-                        if ( (ml == matchML)  /* last post of last match */
+                        if ( (ml == matchML)  /* last pos of last match */
                           && (last_match_pos < pos) )
                             last_match_pos = pos;
                         opt[pos].mlen = ml;

--- a/lib/lz4opt.h
+++ b/lib/lz4opt.h
@@ -328,7 +328,10 @@ static int LZ4HC_compress_optimal (
             //nb_matches = LZ4HC_BinTree_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, MINMATCH-1, matches, fullUpdate);
             //nb_matches = LZ4HC_HashChain_GetAllMatches(ctx, curPtr, matchlimit, last_match_pos - cur + 1, matches, fullUpdate);   /* only works if last_match_pos is really the last match pos */
-            if ((nb_matches > 0) && (size_t)matches[nb_matches-1].len > sufficient_len) {
+            if (!nb_matches) continue;
+
+            if ( ((size_t)matches[nb_matches-1].len > sufficient_len)
+              || (matches[nb_matches-1].len + cur >= LZ4_OPT_NUM) ) {
                 /* immediate encoding */
                 best_mlen = matches[nb_matches-1].len;
                 best_off = matches[nb_matches-1].off;
@@ -357,6 +360,7 @@ static int LZ4HC_compress_optimal (
                         }
 
                         if (pos > last_match_pos || price < opt[pos].price) {
+                            assert(pos < LZ4_OPT_NUM);
                             while (last_match_pos < pos) opt[++last_match_pos].price = 1<<30;
                             opt[pos].mlen = ml;
                             opt[pos].off = offset;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -376,9 +376,9 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
                 FUZ_CHECKTEST(ret<0, "LZ4_decompress_safe() failed on data compressed by LZ4_compressHC_destSize");
                 FUZ_CHECKTEST(ret!=srcSize, "LZ4_decompress_safe() failed : did not fully decompressed data");
                 FUZ_CHECKTEST(decodedBuffer[srcSize] != canary, "LZ4_decompress_safe() overwrite dst buffer !");
-                { U32 const crcDec = XXH32(decodedBuffer, srcSize, 0);
-                  FUZ_CHECKTEST(crcDec!=crcBase, "LZ4_decompress_safe() corrupted decoded data"); }
-
+                {   U32 const crcDec = XXH32(decodedBuffer, srcSize, 0);
+                    FUZ_CHECKTEST(crcDec!=crcBase, "LZ4_decompress_safe() corrupted decoded data");
+                }
                 DISPLAYLEVEL(5, " OK \n");
             }
             else
@@ -460,8 +460,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
 
         // Test decoding with output size being 10 bytes too short => must fail
         FUZ_DISPLAYTEST;
-        if (blockSize>10)
-        {
+        if (blockSize>10) {
             decodedBuffer[blockSize-10] = 0;
             ret = LZ4_decompress_safe(compressedBuffer, decodedBuffer, compressedSize, blockSize-10);
             FUZ_CHECKTEST(ret>=0, "LZ4_decompress_safe should have failed, due to Output Size being 10 bytes too short");
@@ -632,6 +631,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         if (dict < (char*)CNBuffer) dict = (char*)CNBuffer;
         LZ4_resetStreamHC (&LZ4dictHC, compressionLevel);
         LZ4_loadDictHC(&LZ4dictHC, dict, dictSize);
+        LZ4_setCompressionLevel(&LZ4dictHC, compressionLevel-1);
         blockContinueCompressedSize = LZ4_compress_HC_continue(&LZ4dictHC, block, compressedBuffer, blockSize, (int)compressedBufferSize);
         FUZ_CHECKTEST(blockContinueCompressedSize==0, "LZ4_compress_HC_continue failed");
 
@@ -657,7 +657,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         FUZ_CHECKTEST(crcCheck!=crcOrig, "LZ4_decompress_safe_usingDict corrupted decoded data");
 
         /* Compress HC continue destSize */
-            FUZ_DISPLAYTEST;
+        FUZ_DISPLAYTEST;
         {   int const availableSpace = (FUZ_rand(&randState) % blockSize) + 5;
             int consumedSize = blockSize;
             FUZ_DISPLAYTEST;


### PR DESCRIPTION
The match finder has been changed from binary tree to hash train, requiring a full rewrite of optimal parser. The outcome is a seamless transition between regular HC parser and the new optimal parser.
It saves a bunch of incompatibility issues (`cdict`, `_destSize`), also unlocking ability to change compression level on the fly between blocks.

New optimal parser is faster and compress a little better than v1.8.0.
It also fixes #339.
See https://phabricator.intern.facebook.com/P58578327 for details.