### PR TITLE
When building with a C++ compiler, remove the 'register' keyword to silent a warning

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -85,6 +85,17 @@
 #endif
 
 
+/*
+ * register is ignored when the code built with a C++ compiler
+ * Remove the keyword when built with C++ to silent the warning
+ */
+#ifdef __cplusplus
+#  define REGISTER
+#else
+#  define REGISTER register
+#endif
+
+
 /*-************************************
 *  Dependency
 **************************************/
@@ -330,7 +341,7 @@ static const int LZ4_minLength = (MFLIMIT+1);
 /*-************************************
 *  Common functions
 **************************************/
-static unsigned LZ4_NbCommonBytes (register reg_t val)
+static unsigned LZ4_NbCommonBytes (REGISTER reg_t val)
 {
     if (LZ4_isLittleEndian()) {
         if (sizeof(val)==8) {

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -86,10 +86,10 @@
 
 
 /*
- * register is ignored when the code built with a C++ compiler
- * Remove the keyword when built with C++ to silent the warning
+ * register is ignored when the code built with a C++-17 compiler
+ * Remove the keyword when built with C++-17 to silent the warning
  */
-#ifdef __cplusplus
+#if defined(__cplusplus) &&  __cplusplus > 201402L
 #  define REGISTER
 #else
 #  define REGISTER register


### PR DESCRIPTION
For example, with clang:

```
lz4.c:XXX:36: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
static unsigned LZ4_NbCommonBytes (register reg_t val)
                                   ^~~~~~~~~
```