### PR TITLE
Fix cli sometimes calling UTIL_setFileStat on /dev/null

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -616,7 +616,7 @@ static int LZ4IO_compressFilename_extRess(cRess_t ress, const char* srcFileName,
 
     /* Copy owner, file permissions and modification time */
     {   stat_t statbuf;
-        if (strcmp (srcFileName, stdinmark) && strcmp (dstFileName, stdoutmark) && UTIL_getFileStat(srcFileName, &statbuf))
+        if (strcmp (srcFileName, stdinmark) && strcmp (dstFileName, stdoutmark) && strcmp (dstFileName, nulmark) && UTIL_getFileStat(srcFileName, &statbuf))
             UTIL_setFileStat(dstFileName, &statbuf);
     }
 


### PR DESCRIPTION
LZ4IO_compressFilename_extRess does not check if dstFileName is /dev/null (nulmark) before calling UTIL_setFileStat on it, which can result in /dev/null being chmodded 644, 600, etc when it's the output file and lz4 is running as root. Fixed that here