### PR TITLE
Add failing emscripten test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ bin/
 # Mac
 .DS_Store
 *.dSYM
+
+# Vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,100 @@
+Vagrant.configure('2') do |config|
+  config.vm.box = 'velocity42/xenial64'
+  config.vm.box_version = '1.1.0'
+  config.vm.provision 'shell', privileged: false, inline: <<SCRIPT
+
+  set -e
+  set -x
+  set -o pipefail
+
+  # Install apt source for yarn
+  curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
+  # Install apt source for node
+  curl -sSL https://deb.nodesource.com/setup_8.x | sudo bash
+
+  # Install node and yarn, and other dependencies
+  # See https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
+  sudo apt-get -y install \
+    nodejs \
+    yarn \
+    gconf-service \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libexpat1 \
+    libfontconfig1 \
+    libgcc1 \
+    libgconf-2-4 \
+    libgdk-pixbuf2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libnspr4 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxrandr2 \
+    libxrender1 \
+    libxss1 \
+    libxtst6 \
+    ca-certificates \
+    fonts-liberation \
+    libappindicator1 \
+    libnss3 \
+    lsb-release \
+    xdg-utils \
+    wget
+
+  # Install puppeteer
+  sudo yarn global add puppeteer@0.13
+
+  # Not clear why this is needed, perhaps a bug in yarn?
+  sudo chmod a+r /usr/local/share/.config/yarn/global/node_modules/puppeteer/.local-chromium/linux-515411/chrome-linux/*
+  sudo chmod a+x /usr/local/share/.config/yarn/global/node_modules/puppeteer/.local-chromium/linux-515411/chrome-linux/chrome
+
+  # Install emscripten
+  curl -sSL https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
+      | tar xz
+  (cd emsdk-portable && \
+    ./emsdk install emscripten-1.37.22 && \
+    ./emsdk install clang-e1.37.22-64bit && \
+    ./emsdk activate emscripten-1.37.22 && \
+    ./emsdk activate clang-e1.37.22-64bit)
+
+  # Create chrome headless helper script
+  cat > ~/chrome-headless-wrapper.sh <<EOF
+#!/usr/bin/node
+const puppeteer = require('/usr/local/share/.config/yarn/global/node_modules/puppeteer');
+
+(async() => {
+  const url = process.argv.find(arg => arg.match(/^http/))
+  const browser = await puppeteer.launch();
+  console.log(await browser.version());
+  const page = await browser.newPage();
+  await page.goto(url, {waitUntil: 'domcontentloaded'});
+  await new Promise(resolve => setTimeout(resolve, 100));
+  await page.evaluate(() => true);
+  await browser.close();
+  process.exit(0);
+})();
+EOF
+  chmod +x ~/chrome-headless-wrapper.sh
+
+  # Configure shell
+  echo 'source ~/emsdk-portable/emsdk_env.sh' >> ~/.profile
+  echo 'export EMRUN_FLAGS=--browser=/home/vagrant/chrome-headless-wrapper.sh' >> ~/.profile
+SCRIPT
+end

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -8,6 +8,9 @@ fullbench32
 fuzzer
 fuzzer32
 fasttest
+*.html
+*.html.mem
+*.js
 
 # test artefacts
 tmp*

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,6 +43,7 @@ CFLAGS  += $(MOREFLAGS)
 CPPFLAGS:= -I$(LZ4DIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
 FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
+EMCC_FLAGS = --emrun
 
 # Define *.exe as extension for Windows systems
 ifneq (,$(filter Windows%,$(OS)))
@@ -77,6 +78,9 @@ lz4c unlz4 lz4cat: lz4
 lz4c32:   # create a 32-bits version for 32/64 interop tests
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="-m32 $(CFLAGS)"
 
+emscripten-tests.html: emscripten-tests.c $(LZ4DIR)/lz4.c
+	emcc ${CFLAGS} ${CPPFLAGS} ${EMCC_FLAGS} $^ -o $@
+
 fullbench  : $(LZ4DIR)/lz4.o $(LZ4DIR)/lz4hc.o $(LZ4DIR)/lz4frame.o $(LZ4DIR)/xxhash.o fullbench.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
@@ -100,7 +104,7 @@ datagen : $(PRGDIR)/datagen.c datagencli.c
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
-	@$(RM) core *.o *.test tmp* \
+	@$(RM) core *.o *.test tmp* *.html* \
         fullbench-dll$(EXT) fullbench-lib$(EXT) \
         fullbench$(EXT) fullbench32$(EXT) \
         fuzzer$(EXT) fuzzer32$(EXT) \
@@ -360,6 +364,9 @@ test-fullbench: fullbench
 
 test-fullbench32: CFLAGS += -m32
 test-fullbench32: test-fullbench
+
+test-emscripten: emscripten-tests.html
+	emrun ${EMRUN_FLAGS} $<
 
 test-fuzzer: fuzzer
 	./fuzzer $(FUZZER_TIME)

--- a/tests/emscripten-tests.c
+++ b/tests/emscripten-tests.c
@@ -1,0 +1,157 @@
+/*
+    emscripten-tests.c - Demo program to test lz4 in emscripten
+    Copyright (C) Yann Collet 2012-2016
+
+    GPL v2 License
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    You can contact the author at :
+    - LZ4 source repository : https://github.com/lz4/lz4
+    - LZ4 public forum : https://groups.google.com/forum/#!forum/lz4c
+*/
+
+/**************************************
+*  Includes
+**************************************/
+#include "platform.h"    /* _CRT_SECURE_NO_WARNINGS, Large Files support */
+#include <stdio.h>       /* fprintf, fopen, ftello */
+#include <stdlib.h>      /* rand */
+#include <string.h>      /* memcmp */
+
+#include "lz4.h"
+
+
+/**************************************
+*  Constants
+**************************************/
+#define PROGRAM_DESCRIPTION "LZ4 emscripten testbed"
+#define AUTHOR "Yann Collet"
+#define WELCOME_MESSAGE "*** %s v%s %i-bits, by %s ***\n", PROGRAM_DESCRIPTION, LZ4_VERSION_STRING, (int)(sizeof(void*)*8), AUTHOR
+
+
+/**************************************
+*  Macros
+**************************************/
+#define DISPLAY(...) fprintf(stderr, __VA_ARGS__)
+#define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+
+
+enum {
+    MESSAGE_MAX_BYTES   = 1024,
+    RING_BUFFER_BYTES   = 1024 * 8 + MESSAGE_MAX_BYTES,
+    DECODE_RING_BUFFER  = RING_BUFFER_BYTES + MESSAGE_MAX_BYTES,   /* Intentionally larger, to test unsynchronized ring buffers */
+    ITERATIONS          = 500000,
+};
+
+static int test(char* decBuf, char* inpBuf) {
+    int decOffset = 0;
+    int inpOffset = 0;
+
+    LZ4_stream_t lz4Stream_body = { { 0 } };
+    LZ4_stream_t* lz4Stream = &lz4Stream_body;
+
+    LZ4_streamDecode_t lz4StreamDecode_body = { { 0 } };
+    LZ4_streamDecode_t* lz4StreamDecode = &lz4StreamDecode_body;
+
+    for(int i=0; i<ITERATIONS; ++i) {
+        // Read random length ([1,MESSAGE_MAX_BYTES]) data to the ring buffer.
+        char* const inpPtr = &inpBuf[inpOffset];
+        const int inpBytes = (rand() % MESSAGE_MAX_BYTES) + 1;
+
+        for(int j=0; j<inpBytes; ++j) {
+          inpPtr[j] = (rand() % 10);
+        }
+
+        {
+#define CMPBUFSIZE (LZ4_COMPRESSBOUND(MESSAGE_MAX_BYTES))
+            char cmpBuf[CMPBUFSIZE];
+            const int cmpBytes = LZ4_compress_fast_continue(lz4Stream, inpPtr, cmpBuf, inpBytes, CMPBUFSIZE, 0);
+            if(cmpBytes <= 0) { return 1; }
+
+            inpOffset += inpBytes;
+
+            // Wraparound the ringbuffer offset
+            if(inpOffset >= RING_BUFFER_BYTES - MESSAGE_MAX_BYTES) inpOffset = 0;
+
+            {
+                char* const decPtr = &decBuf[decOffset];
+                const int decBytes = LZ4_decompress_safe_continue(
+                    lz4StreamDecode, cmpBuf, decPtr, cmpBytes, MESSAGE_MAX_BYTES);
+                if(decBytes <= 0) { return 2; }
+                decOffset += decBytes;
+
+                // Wraparound the ringbuffer offset
+                if(decOffset >= DECODE_RING_BUFFER - MESSAGE_MAX_BYTES) decOffset = 0;
+
+                {
+                  if (decBytes != inpBytes) {
+                    return 3;
+                  }
+                  if (memcmp(inpPtr, decPtr, decBytes) != 0) {
+                    return 4;
+                  }
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+// This struct here to force ordering of buffers in memory.
+// emscripten tends to allocate this at low addresses, which can
+// expose bugs.
+//
+// Be careful that adding other test cases linked into this
+// executable might move this, making tests pointless.
+// Probably good to keep this as the only test in this executable
+// and create separate executables for other emscripten tests.
+//
+static struct {
+  char lowBuf[MAX(DECODE_RING_BUFFER, RING_BUFFER_BYTES)];
+  char highBuf[MAX(DECODE_RING_BUFFER, RING_BUFFER_BYTES)];
+} buffers;
+
+
+int test_blockStreaming_ringbuffer_low_dec() {
+    return test(buffers.lowBuf, buffers.highBuf);
+}
+
+int test_blockStreaming_ringbuffer_low_comp() {
+    return test(buffers.highBuf, buffers.lowBuf);
+}
+
+int main() {
+    // Welcome message
+    DISPLAY(WELCOME_MESSAGE);
+
+    DISPLAY("Low decompression buffer address... ");
+    int result_low_dec = test_blockStreaming_ringbuffer_low_dec();
+    if (result_low_dec == 0) {
+        DISPLAY("PASS\n");
+    } else {
+        DISPLAY("FAIL: %d\n", result_low_dec);
+    }
+
+    DISPLAY("Low compression buffer address... ");
+    int result_low_comp = test_blockStreaming_ringbuffer_low_comp();
+    if (result_low_comp == 0) {
+        DISPLAY("PASS\n");
+    } else {
+        DISPLAY("FAIL: %d\n", result_low_comp);
+    }
+
+    return result_low_dec + result_low_comp;
+}


### PR DESCRIPTION
Tests compression and decompression with buffers at very low memory
addresses, triggering issues to do with unsigned pointer arithmetic.

See #397