### PR TITLE
Docs: describe behavior under nohup

### DIFF
--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -45,6 +45,9 @@ Differences are :
   * As a consequence of previous rules, note the following example :
     `lz4 file | consumer` sends compressed data to `consumer` through `stdout`,
     hence it does _not_ create `file.lz4`.
+  * Another consequence of those rules is that to run `lz4` under `nohup`,
+    you should provide a destination file: `nohup lz4 file file.lz4`,
+    because `nohup` writes the specified command's output to a file.
 
 Default behaviors can be modified by opt-in commands, detailed below.
 


### PR DESCRIPTION
`lz4 -q input.tar` creates a `input.tar.lz4` as expected.
`nohup lz4 -q input.tar` creates a `nohup.out` file containing the binary output of the command.
`nohup lz4 -q input.tar input.tar.lz4` creates the `input.tar.lz4` file and an empty `nohup.out` file, as expected.

This behavior is documented in the man page: "When no destination name is provided, if stdout is not the console, it becomes the output (like a silent -c)", but it's surprising enough for a user who didn't read the man page to warrant describing it explicitly.