### PR TITLE
[lz4hc] level == 0 means default, not level 1

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -728,7 +728,7 @@ void LZ4_resetStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 
 void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
-    if (compressionLevel < 1) compressionLevel = 1;
+    if (compressionLevel < 1) compressionLevel = LZ4HC_CLEVEL_DEFAULT;
     if (compressionLevel > LZ4HC_CLEVEL_MAX) compressionLevel = LZ4HC_CLEVEL_MAX;
     LZ4_streamHCPtr->internal_donotuse.compressionLevel = compressionLevel;
 }


### PR DESCRIPTION
This changes the behavior back to match `lz4-1.8.0` and before.