### PR TITLE
Better bench measurements for small inputs

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -221,8 +221,8 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
         U64 const crcOrig = XXH64(srcBuffer, srcSize, 0);
         UTIL_time_t coolTime;
         U64 const maxTime = (g_nbSeconds * TIMELOOP_NANOSEC) + 100;
-        U32 nbCompressionLoops = ((5 MB) / (srcSize+1)) + 1;  /* conservative initial compression speed estimate */
-        U32 nbDecodeLoops = ((200 MB) / (srcSize+1)) + 1;  /* conservative initial decode speed estimate */
+        U32 nbCompressionLoops = (U32)((5 MB) / (srcSize+1)) + 1;  /* conservative initial compression speed estimate */
+        U32 nbDecodeLoops = (U32)((200 MB) / (srcSize+1)) + 1;  /* conservative initial decode speed estimate */
         U64 totalCTime=0, totalDTime=0;
         U32 cCompleted=0, dCompleted=0;
 #       define NB_MARKS 4

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -263,7 +263,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                         if (clockSpan < fastestC * nbCompressionLoops)
                             fastestC = clockSpan / nbCompressionLoops;
                         assert(fastestC > 0);
-                        nbCompressionLoops = (U32)(1000000000/*1sec*/ / fastestC) + 1;  /* aim for ~1sec */
+                        nbCompressionLoops = (U32)(TIMELOOP_NANOSEC / fastestC) + 1;  /* aim for ~1sec */
                     } else {
                         assert(nbCompressionLoops < 40000000);   /* avoid overflow */
                         nbCompressionLoops *= 100;
@@ -307,7 +307,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                         if (clockSpan < fastestD * nbDecodeLoops)
                             fastestD = clockSpan / nbDecodeLoops;
                         assert(fastestD > 0);
-                        nbDecodeLoops = (U32)(1000000000/*1sec*/ / fastestD) + 1;  /* aim for ~1sec */
+                        nbDecodeLoops = (U32)(TIMELOOP_NANOSEC / fastestD) + 1;  /* aim for ~1sec */
                     } else {
                         assert(nbDecodeLoops < 40000000);   /* avoid overflow */
                         nbDecodeLoops *= 100;

--- a/programs/util.h
+++ b/programs/util.h
@@ -180,7 +180,7 @@ extern "C" {
             mach_timebase_info(&rate);
             init = 1;
         }
-        return (((clockEnd - clockStart) * (U64)rate.numer) / ((U64)rate.denom))/1000ULL;
+        return (((clockEnd - clockStart) * (U64)rate.numer) / ((U64)rate.denom)) / 1000ULL;
     }
     UTIL_STATIC U64 UTIL_getSpanTimeNano(UTIL_time_t clockStart, UTIL_time_t clockEnd)
     {
@@ -249,6 +249,12 @@ UTIL_STATIC U64 UTIL_clockSpanMicro(UTIL_time_t clockStart)
     return UTIL_getSpanTimeMicro(clockStart, clockEnd);
 }
 
+/* returns time span in nanoseconds */
+UTIL_STATIC U64 UTIL_clockSpanNano(UTIL_time_t clockStart)
+{
+    UTIL_time_t const clockEnd = UTIL_getTime();
+    return UTIL_getSpanTimeNano(clockStart, clockEnd);
+}
 
 UTIL_STATIC void UTIL_waitForNextTick(void)
 {


### PR DESCRIPTION
`time()` invocation is not free,
and when a unit of work is very small (like compressing / decompressing a small file)
`time()` invocation can actually represent a sizable fraction of workload measured.

The new strategy is to use `time()` only once per batch,
and dynamically resize batch size so that each round lasts approximately 1 second,
starting from a conservative (low) estimate.

This change only matters for small inputs.
Measurement for large files (such as silesia.tar) are much less impacted.
(though decoding speed is so fast that even medium-size files will notice an improvement).