### PR TITLE
Add Dependency to Fix Parallel `make test` Runs

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -327,7 +327,7 @@ test-lz4-opt-parser: lz4 datagen
 
 test-lz4-essentials : lz4 datagen test-lz4-basic test-lz4-multiple \
                       test-lz4-frame-concatenation test-lz4-testmode \
-                      test-lz4-contentSize
+                      test-lz4-contentSize test-lz4-dict
 	@$(RM) tmp*
 
 test-lz4: lz4 datagen test-lz4-essentials test-lz4-opt-parser \


### PR DESCRIPTION
When run with `-jN`, the `rm tmp*` can run in the middle of the `test-lz4-dict`
job, which will then fail, finding its files to have been axed. This adds a
dependency between the two.