### PR TITLE
Wrap likely/unlikely macroses with #ifndef

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -147,8 +147,12 @@
 #  define expect(expr,value)    (expr)
 #endif
 
+#ifndef likely
 #define likely(expr)     expect((expr) != 0, 1)
+#endif
+#ifndef unlikely
 #define unlikely(expr)   expect((expr) != 0, 0)
+#endif
 
 
 /*-************************************


### PR DESCRIPTION
It prevent redefine error when project which uses lz4 has its own likely/unlikely
macroses.