### PR TITLE
fixed lz4_fast clang performance

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -776,10 +776,10 @@ LZ4_FORCE_INLINE int LZ4_compress_generic(
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
 
-                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) continue;     /* match outside of valid area */
+                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) continue;    /* match outside of valid area */
                 assert(matchIndex < current);
-                if ((tableType != byU16) && (matchIndex+MAX_DISTANCE < current)) continue; /* too far - note: works even if matchIndex overflows */
-                if (tableType == byU16) assert((current - matchIndex) <= MAX_DISTANCE);      /* too_far presumed impossible with byU16 */
+                if ((tableType != byU16) && (matchIndex+MAX_DISTANCE < current)) continue;  /* too far */
+                if (tableType == byU16) assert((current - matchIndex) <= MAX_DISTANCE);     /* too_far presumed impossible with byU16 */
 
                 if (LZ4_read32(match) == LZ4_read32(ip)) {
                     if (maybe_extMem) offset = current - matchIndex;


### PR DESCRIPTION
I had the displeasure to notice that, after update related to support of low memory addresses,
speed of lz4_fast on `clang` was reduced by 10% (note: there is no such impact with `gcc`).

The reason is this trivial change, from
`matchIndex+MAX_DISTANCE < current`
towards
`current - matchIndex > MAX_DISTANCE`

The second version is more robust, as it also survives a situation where `matchIndex > current` due to overflows. So it should be preferable.

However, the speed impact is massive, and cannot be ignored.

To work properly, the first version requires `matchIndex` to not overflow. Hence were added `assert()` conditions.

The only situation where `matchIndex` can overflow is with dictCtx compression,
when the dictionary context is not initialized before loading the dictionary.
Therefore, it's enough to always initialize the context while loading the dictionary.