### PR TITLE
Fixed performance issue with LZ4_decompress_fast()

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -181,6 +181,7 @@ uninstall:
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4.h
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4hc.h
 	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4frame.h
+	@$(RM) $(DESTDIR)$(INCLUDEDIR)/lz4frame_static.h
 	@echo lz4 libraries successfully uninstalled
 
 endif

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1536,9 +1536,10 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
          * this shortcut was tested on x86 and x64, where it improves decoding speed.
          * it has not yet been benchmarked on ARM, Power, mips, etc.
          * NOTE: The loop begins with a read, so we must have one byte left at the end. */
-        if (((ip + 14 /*maxLL*/ + 2 /*offset*/ < iend)
-          & (op + 14 /*maxLL*/ + 18 /*maxML*/ <= oend))
-          & ((token < (15<<ML_BITS)) & ((token & ML_MASK) != 15)) ) {
+        if (endOnInput
+          && ((ip + 14 /*maxLL*/ + 2 /*offset*/ < iend)
+            & (op + 14 /*maxLL*/ + 18 /*maxML*/ <= oend))
+            & ((token < (15<<ML_BITS)) & ((token & ML_MASK) != 15)) ) {
             size_t const ll = token >> ML_BITS;
             size_t const off = LZ4_readLE16(ip+ll);
             const BYTE* const matchPtr = op + ll - off;  /* pointer underflow risk ? */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1538,8 +1538,9 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
          * NOTE: The loop begins with a read, so we must have one byte left at the end. */
         if (endOnInput
           && ((ip + 14 /*maxLL*/ + 2 /*offset*/ < iend)
-            & (op + 14 /*maxLL*/ + 18 /*maxML*/ <= oend))
-            & ((token < (15<<ML_BITS)) & ((token & ML_MASK) != 15)) ) {
+            & (op + 14 /*maxLL*/ + 18 /*maxML*/ <= oend)
+            & (token < (15<<ML_BITS))
+            & ((token & ML_MASK) != 15) ) ) {
             size_t const ll = token >> ML_BITS;
             size_t const off = LZ4_readLE16(ip+ll);
             const BYTE* const matchPtr = op + ll - off;  /* pointer underflow risk ? */

--- a/programs/util.h
+++ b/programs/util.h
@@ -30,8 +30,9 @@ extern "C" {
 *  Dependencies
 ******************************************/
 #include "platform.h"     /* PLATFORM_POSIX_VERSION */
-#include <stdlib.h>       /* malloc */
 #include <stddef.h>       /* size_t, ptrdiff_t */
+#include <stdlib.h>       /* malloc */
+#include <string.h>       /* strlen, strncpy */
 #include <stdio.h>        /* fprintf */
 #include <sys/types.h>    /* stat, utime */
 #include <sys/stat.h>     /* stat */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -80,7 +80,8 @@ lz4c32:   # create a 32-bits version for 32/64 interop tests
 %.o : $(LZ4DIR)/%.c $(LZ4DIR)/%.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
-fullbench  : lz4.o lz4hc.o lz4frame.o xxhash.o fullbench.c
+fullbench : DEBUGLEVEL=0
+fullbench : lz4.o lz4hc.o lz4frame.o xxhash.o fullbench.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
 $(LZ4DIR)/liblz4.a:


### PR DESCRIPTION
by disabling the shortcut, which it cannot use anyway
(see #506 )