### PR TITLE
Faster decoding speed

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1431,7 +1431,7 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
             /* strictly "less than" on input, to re-enter the loop with at least one byte */
             likely((endOnInput ? ip < shortiend : 1) & (op <= shortoend)))
         {
-            /* Copy the literals. */
+            /* Copy the literals */
             memcpy(op, ip, endOnInput ? 16 : 8);
             op += length; ip += length;
 
@@ -1688,12 +1688,11 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
     return 0;
 }
 
-/*!
- * LZ4_setStreamDecode() :
- * Use this function to instruct where to find the dictionary.
- * This function is not necessary if previous data is still available where it was decoded.
- * Loading a size of 0 is allowed (same effect as no dictionary).
- * Return : 1 if OK, 0 if error
+/*! LZ4_setStreamDecode() :
+ *  Use this function to instruct where to find the dictionary.
+ *  This function is not necessary if previous data is still available where it was decoded.
+ *  Loading a size of 0 is allowed (same effect as no dictionary).
+ * @return : 1 if OK, 0 if error
  */
 int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
 {
@@ -1703,6 +1702,26 @@ int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dicti
     lz4sd->externalDict = NULL;
     lz4sd->extDictSize  = 0;
     return 1;
+}
+
+/*! LZ4_decoderRingBufferSize() :
+ *  when setting a ring buffer for streaming decompression (optional scenario),
+ *  provides the minimum size of this ring buffer
+ *  to be compatible with any source respecting maxBlockSize condition.
+ *  Note : in a ring buffer scenario,
+ *  blocks are presumed decompressed next to each other
+ *  up to the moment there is not enough remaining space for next block (remainingSize < maxBlockSize),
+ *  at which stage it resumes from beginning of ring buffer.
+ * @return : minimum ring buffer size,
+ *           or 0 if there is an error (invalid maxBlockSize).
+ */
+
+int LZ4_decoderRingBufferSize(int maxBlockSize)
+{
+    if (maxBlockSize < 0) return 0;
+    if (maxBlockSize > LZ4_MAX_INPUT_SIZE) return 0;
+    if (maxBlockSize < 16) maxBlockSize = 16;
+    return LZ4_DECODER_RING_BUFFER_SIZE(maxBlockSize);
 }
 
 /*

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1427,10 +1427,9 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
          * those 18 bytes earlier, upon entering the shortcut (in other words,
          * there is a combined check for both stages).
          */
-        if ((endOnInput ? length != RUN_MASK : length <= 8) &&
+        if ( (endOnInput ? length != RUN_MASK : length <= 8)
             /* strictly "less than" on input, to re-enter the loop with at least one byte */
-            likely((endOnInput ? ip < shortiend : 1) & (op <= shortoend)))
-        {
+          && likely((endOnInput ? ip < shortiend : 1) & (op <= shortoend)) ) {
             /* Copy the literals */
             memcpy(op, ip, endOnInput ? 16 : 8);
             op += length; ip += length;
@@ -1442,9 +1441,9 @@ LZ4_FORCE_INLINE int LZ4_decompress_generic(
             match = op - offset;
 
             /* Do not deal with overlapping matches. */
-            if ((length != 15) && (offset >= 8) &&
-                (dict==withPrefix64k || match >= lowPrefix))
-            {
+            if ( (length != ML_MASK)
+              && (offset >= 8)
+              && (dict==withPrefix64k || match >= lowPrefix) ) {
                 /* Copy the match. */
                 memcpy(op + 0, match + 0, 8);
                 memcpy(op + 8, match + 8, 8);
@@ -1709,13 +1708,12 @@ int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dicti
  *  provides the minimum size of this ring buffer
  *  to be compatible with any source respecting maxBlockSize condition.
  *  Note : in a ring buffer scenario,
- *  blocks are presumed decompressed next to each other
- *  up to the moment there is not enough remaining space for next block (remainingSize < maxBlockSize),
- *  at which stage it resumes from beginning of ring buffer.
+ *  blocks are presumed decompressed next to each other.
+ *  When not enough space remains for next block (remainingSize < maxBlockSize),
+ *  decoding resumes from beginning of ring buffer.
  * @return : minimum ring buffer size,
  *           or 0 if there is an error (invalid maxBlockSize).
  */
-
 int LZ4_decoderRingBufferSize(int maxBlockSize)
 {
     if (maxBlockSize < 0) return 0;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1232,7 +1232,6 @@ static void FUZ_unitTests(int compressionLevel)
 
             /* first block */
             messageSize = BSIZE1;   /* note : we cheat a bit here, in theory no message should be > maxMessageSize. We just want to fill the decoding ring buffer once. */
-            assert(messageSize < dBufferSize);
             XXH64_update(&xxhOrig, testInput + iNext, messageSize);
             crcOrig = XXH64_digest(&xxhOrig);
 
@@ -1276,7 +1275,7 @@ static void FUZ_unitTests(int compressionLevel)
                 assert(dBufferSize - dNext >= maxMessageSize);
                 result = LZ4_decompress_safe_continue(&decodeStateSafe,
                                                       testCompressed, ringBufferSafe + dNext,
-                                                      compressedSize, dBufferSize - dNext);   /* works without knowing messageSize, but under assumption that messageSize < maxMessageSize */
+                                                      compressedSize, dBufferSize - dNext);   /* works without knowing messageSize, under assumption that messageSize <= maxMessageSize */
                 FUZ_CHECKTEST(result!=messageSize, "D.ringBuffer : LZ4_decompress_safe_continue() test failed");
                 XXH64_update(&xxhNewSafe, ringBufferSafe + dNext, messageSize);
                 {   U64 const crcNew = XXH64_digest(&xxhNewSafe);


### PR DESCRIPTION
This patch introduces the 2-stage shortcut, proposed by @svpv,
which improves decoding speed by about +10%.

While reviewing this patch, it became clear that 
clarifying ring buffer scenarios was a necessity.
To this end, documentation is updated,
and a new function is proposed : `LZ4_decoderRingBufferSize(maxBlockSize)`.
This is the minimum size above which LZ4 decompression is guaranteed to work 
(provided source is an LZ4 format compliant block of size `<= maxBlockSize`).
Ring buffer tests cases are also updated to use the new function.