### PR TITLE
Aix 32bit fuzzer

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -38,7 +38,7 @@
 /*-************************************
 *  Dependencies
 **************************************/
-#ifdef __unix__   /* must be included before platform.h for MAP_ANONYMOUS */
+#if defined(__unix__) && !defined(_AIX)   /* must be included before platform.h for MAP_ANONYMOUS */
 #  include <sys/mman.h>   /* mmap */
 #endif
 #include "platform.h"   /* _CRT_SECURE_NO_WARNINGS */
@@ -48,6 +48,10 @@
 #include <string.h>     /* strcmp */
 #include <time.h>       /* clock_t, clock, CLOCKS_PER_SEC */
 #include <assert.h>
+#if defined(__unix__) && defined(_AIX)
+#  include <sys/mman.h>   /* mmap */
+#endif
+
 #define LZ4_STATIC_LINKING_ONLY
 #define LZ4_HC_STATIC_LINKING_ONLY
 #include "lz4hc.h"


### PR DESCRIPTION
Fix compile error of fuzzer.c on AIX 32 bit builds.  On AIX 32 bit, sys/mman.h must be included after platform.h else we get errors shown in the attachment, likely caused by bugs in AIX header files.
AIX 64 bit builds also run clean with this change.

[lz4_aix_32bit.txt](https://github.com/lz4/lz4/files/2063868/lz4_aix_32bit.txt)


