### PR TITLE
Fix bug in frame decompress example

### DIFF
--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -260,7 +260,7 @@ decompress_file_allocDst(FILE* f_in, FILE* f_out,
     int const decompressionResult = decompress_file_internal(
                         f_in, f_out,
                         dctx,
-                        src, srcCapacity, readSize, consumedSize,
+                        src, srcCapacity, readSize-consumedSize, consumedSize,
                         dst, dstCapacity);
 
     free(dst);


### PR DESCRIPTION
The decompression was failing as the srcEnd pointer in
decompress_file_internal was wrongly computed beyond
the end of the memory block.
We need to account for the fact that the header ("info")
was already read in the calling function ("alreadyConsumed").