### PR TITLE
Introduced constants LZ4F_INIT_*

### DIFF
--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -195,7 +195,7 @@ decompress_file_internal(FILE* f_in, FILE* f_out,
          * Continue while there is more input to read (srcPtr != srcEnd)
          * and the frame isn't over (ret != 0)
          */
-        while (srcPtr != srcEnd && ret != 0) {
+        while (srcPtr < srcEnd && ret != 0) {
             /* Any data within dst has been flushed at this stage */
             size_t dstSize = dstCapacity;
             size_t srcSize = srcEnd - srcPtr;
@@ -209,9 +209,20 @@ decompress_file_internal(FILE* f_in, FILE* f_out,
             /* Update input */
             srcPtr += srcSize;
         }
+
+        assert(srcPtr <= srcEnd);
+
+        /* Ensure all input data has been consumed.
+         * It is valid to have multiple frames in the same file,
+         * but this example only supports one frame.
+         */
+        if (srcPtr < srcEnd) {
+            printf("Decompress: Trailing data left in file after frame\n");
+            return 1;
+        }
     }
 
-    /* Check that there isn't trailing input data after the frame.
+    /* Check that there isn't trailing data in the file after the frame.
      * It is valid to have multiple frames in the same file,
      * but this example only supports one frame.
      */

--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -31,12 +31,13 @@ static const LZ4F_preferences_t kPrefs = {
 static void safe_fwrite(void* buf, size_t eltSize, size_t nbElt, FILE* f)
 {
     size_t const writtenSize = fwrite(buf, eltSize, nbElt, f);
-    size_t const expectedSize = eltSize * nbElt;   /* note : should check for overflow */
+    size_t const expectedSize = eltSize * nbElt;
+    assert(expectedSize / nbElt == eltSize);   /* check overflow */
     if (writtenSize < expectedSize) {
         if (ferror(f))  /* note : ferror() must follow fwrite */
-            printf("Write failed\n");
+            fprintf(stderr, "Write failed \n");
         else
-            printf("Short write\n");
+            fprintf(stderr, "Short write \n");
         exit(1);
     }
 }
@@ -54,9 +55,9 @@ typedef struct {
 
 static compressResult_t
 compress_file_internal(FILE* f_in, FILE* f_out,
-                    LZ4F_compressionContext_t ctx,
-                    void* inBuff, size_t inChunkSize,
-                    void* outBuff, size_t outCapacity)
+                       LZ4F_compressionContext_t ctx,
+                       void* inBuff,  size_t inChunkSize,
+                       void* outBuff, size_t outCapacity)
 {
     compressResult_t result = { 1, 0, 0 };  /* result for an error */
     unsigned long long count_in = 0, count_out;
@@ -167,9 +168,9 @@ static size_t get_block_size(const LZ4F_frameInfo_t* info) {
 /* @return : 1==error, 0==success */
 static int
 decompress_file_internal(FILE* f_in, FILE* f_out,
-                        LZ4F_dctx* dctx,
-                        void* src, size_t srcCapacity, size_t filled, size_t alreadyConsumed,
-                        void* dst, size_t dstCapacity)
+                         LZ4F_dctx* dctx,
+                         void* src, size_t srcCapacity, size_t filled, size_t alreadyConsumed,
+                         void* dst, size_t dstCapacity)
 {
     int firstChunk = 1;
     size_t ret = 1;
@@ -278,7 +279,7 @@ static int decompress_file(FILE* f_in, FILE* f_out)
     if (!src) { perror("decompress_file(src)"); return 1; }
 
     LZ4F_dctx* dctx;
-    {   size_t const dctxStatus = LZ4F_createDecompressionContext(&dctx, 100);
+    {   size_t const dctxStatus = LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
         if (LZ4F_isError(dctxStatus)) {
             printf("LZ4F_dctx creation error: %s\n", LZ4F_getErrorName(dctxStatus));
     }   }

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -35,7 +35,8 @@
 /* LZ4F is a stand-alone API to create LZ4-compressed frames
  * conformant with specification v1.6.1.
  * It also offers streaming capabilities.
- * lz4.h is not required when using lz4frame.h.
+ * lz4.h is not required when using lz4frame.h,
+ * except to get constant such as LZ4_VERSION_NUMBER.
  * */
 
 #ifndef LZ4F_H_09782039843
@@ -172,7 +173,7 @@ typedef struct {
   LZ4F_blockChecksum_t   blockChecksumFlag;   /* 1: each block followed by a checksum of block's compressed data; 0: disabled (default) */
 } LZ4F_frameInfo_t;
 
-#define LZ4F_INIT_FRAMEINFO   { 0, 0, 0, 0, 0, 0, 0 }
+#define LZ4F_INIT_FRAMEINFO   { 0, 0, 0, 0, 0, 0, 0 }    /* v1.8.3+ */
 
 /*! LZ4F_preferences_t :
  *  makes it possible to supply advanced compression instructions to streaming interface.
@@ -183,11 +184,11 @@ typedef struct {
   LZ4F_frameInfo_t frameInfo;
   int      compressionLevel;    /* 0: default (fast mode); values > LZ4HC_CLEVEL_MAX count as LZ4HC_CLEVEL_MAX; values < 0 trigger "fast acceleration" */
   unsigned autoFlush;           /* 1: always flush; reduces usage of internal buffers */
-  unsigned favorDecSpeed;       /* 1: parser favors decompression speed vs compression ratio. Only works for high compression modes (>= LZ4HC_CLEVEL_OPT_MIN) */  /* >= v1.8.2 */
+  unsigned favorDecSpeed;       /* 1: parser favors decompression speed vs compression ratio. Only works for high compression modes (>= LZ4HC_CLEVEL_OPT_MIN) */  /* v1.8.2+ */
   unsigned reserved[3];         /* must be zero for forward compatibility */
 } LZ4F_preferences_t;
 
-#define LZ4F_INIT_PREFERENCES   { LZ4F_INIT_FRAMEINFO, 0, 0, 0, { 0, 0, 0 } }
+#define LZ4F_INIT_PREFERENCES   { LZ4F_INIT_FRAMEINFO, 0, 0, 0, { 0, 0, 0 } }    /* v1.8.3+ */
 
 
 /*-*********************************
@@ -229,7 +230,7 @@ typedef struct {
 
 /*---   Resource Management   ---*/
 
-#define LZ4F_VERSION 100       /* API version, signal an API breaking change */
+#define LZ4F_VERSION 100    /* This number can be used to check for an incompatible API breaking change */
 LZ4FLIB_API unsigned LZ4F_getVersion(void);
 
 /*! LZ4F_createCompressionContext() :


### PR DESCRIPTION
to simplify initialization of `lz4frame.h` structures.
Partially in response to #546.