### PR TITLE
avoid final trailing comma for enum lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ endif
 default: lib-release lz4-release
 
 .PHONY: all
-all: allmost manuals
+all: allmost examples manuals
 
 .PHONY: allmost
-allmost: lib lz4 examples
+allmost: lib lz4
 
 .PHONY: lib lib-release liblz4.a
 lib: liblz4.a
@@ -181,10 +181,10 @@ ctocpptest: clean
 	CC=$(TESTCC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" all
 
 c_standards: clean
-	CFLAGS="-std=c90   -Werror" $(MAKE) clean allmost
-	CFLAGS="-std=gnu90 -Werror" $(MAKE) clean allmost
-	CFLAGS="-std=c99   -Werror" $(MAKE) clean allmost
-	CFLAGS="-std=gnu99 -Werror" $(MAKE) clean allmost
-	CFLAGS="-std=c11   -Werror" $(MAKE) clean allmost
+	$(MAKE) clean; CFLAGS="-std=c90   -Werror -pedantic -Wno-long-long -Wno-variadic-macros" $(MAKE) allmost
+	$(MAKE) clean; CFLAGS="-std=gnu90 -Werror -pedantic -Wno-long-long -Wno-variadic-macros" $(MAKE) allmost
+	$(MAKE) clean; CFLAGS="-std=c99   -Werror -pedantic" $(MAKE) all
+	$(MAKE) clean; CFLAGS="-std=gnu99 -Werror -pedantic" $(MAKE) all
+	$(MAKE) clean; CFLAGS="-std=c11   -Werror" $(MAKE) all
 
 endif

--- a/doc/lz4_manual.html
+++ b/doc/lz4_manual.html
@@ -21,7 +21,7 @@
 </ol>
 <hr>
 <a name="Chapter1"></a><h2>Introduction</h2><pre>
-  LZ4 is lossless compression algorithm, providing compression speed at 400 MB/s per core,
+  LZ4 is lossless compression algorithm, providing compression speed at 500 MB/s per core,
   scalable with multi-cores CPU. It features an extremely fast decoder, with speed in
   multiple GB/s per core, typically reaching RAM speed limits on multi-core systems.
 
@@ -37,8 +37,8 @@
 
   An additional format, called LZ4 frame specification (doc/lz4_Frame_format.md),
   take care of encoding standard metadata alongside LZ4-compressed blocks.
-  If your application requires interoperability, it's recommended to use it.
-  A library is provided to take care of it, see lz4frame.h.
+  Frame format is required for interoperability.
+  It is delivered through a companion API, declared in lz4frame.h.
 <BR></pre>
 
 <a name="Chapter2"></a><h2>Version</h2><pre></pre>

--- a/doc/lz4frame_manual.html
+++ b/doc/lz4frame_manual.html
@@ -84,19 +84,21 @@
   LZ4F_blockChecksum_t   blockChecksumFlag;   </b>/* 1: each block followed by a checksum of block's compressed data; 0: disabled (default) */<b>
 } LZ4F_frameInfo_t;
 </b><p>  makes it possible to set or read frame parameters.
-  It's not required to set all fields, as long as the structure was initially memset() to zero.
-  For all fields, 0 sets it to default value 
+  Structure must be first init to 0, using memset() or LZ4F_INIT_FRAMEINFO,
+  setting all parameters to default.
+  It's then possible to update selectively some parameters 
 </p></pre><BR>
 
 <pre><b>typedef struct {
   LZ4F_frameInfo_t frameInfo;
   int      compressionLevel;    </b>/* 0: default (fast mode); values > LZ4HC_CLEVEL_MAX count as LZ4HC_CLEVEL_MAX; values < 0 trigger "fast acceleration" */<b>
-  unsigned autoFlush;           </b>/* 1: always flush, to reduce usage of internal buffers */<b>
-  unsigned favorDecSpeed;       </b>/* 1: parser favors decompression speed vs compression ratio. Only works for high compression modes (>= LZ4LZ4HC_CLEVEL_OPT_MIN) */  /* >= v1.8.2 */<b>
+  unsigned autoFlush;           </b>/* 1: always flush; reduces usage of internal buffers */<b>
+  unsigned favorDecSpeed;       </b>/* 1: parser favors decompression speed vs compression ratio. Only works for high compression modes (>= LZ4HC_CLEVEL_OPT_MIN) */  /* v1.8.2+ */<b>
   unsigned reserved[3];         </b>/* must be zero for forward compatibility */<b>
 } LZ4F_preferences_t;
-</b><p>  makes it possible to supply detailed compression parameters to the stream interface.
-  Structure is presumed initially memset() to zero, representing default settings.
+</b><p>  makes it possible to supply advanced compression instructions to streaming interface.
+  Structure must be first init to 0, using memset() or LZ4F_INIT_PREFERENCES,
+  setting all parameters to default.
   All reserved fields must be set to zero. 
 </p></pre><BR>
 
@@ -295,7 +297,8 @@ LZ4F_errorCode_t LZ4F_freeDecompressionContext(LZ4F_dctx* dctx);
   and start a new one using same context resources. 
 </p></pre><BR>
 
-<pre><b>typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM) } LZ4F_errorCodes;
+<pre><b>typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM)
+              _LZ4F_dummy_error_enum_for_c89_never_used } LZ4F_errorCodes;
 </b></pre><BR>
 <a name="Chapter11"></a><h2>Bulk processing dictionary API</h2><pre></pre>
 

--- a/examples/frameCompress.c
+++ b/examples/frameCompress.c
@@ -184,8 +184,8 @@ decompress_file_internal(FILE* f_in, FILE* f_out,
     while (ret != 0) {
         /* Load more input */
         size_t readSize = firstChunk ? filled : fread(src, 1, srcCapacity, f_in); firstChunk=0;
-        const void* srcPtr = src + alreadyConsumed; alreadyConsumed=0;
-        const void* const srcEnd = srcPtr + readSize;
+        const void* srcPtr = (const char*)src + alreadyConsumed; alreadyConsumed=0;
+        const void* const srcEnd = (const char*)srcPtr + readSize;
         if (readSize == 0 || ferror(f_in)) {
             printf("Decompress: not enough input or error reading file\n");
             return 1;
@@ -198,7 +198,7 @@ decompress_file_internal(FILE* f_in, FILE* f_out,
         while (srcPtr < srcEnd && ret != 0) {
             /* Any data within dst has been flushed at this stage */
             size_t dstSize = dstCapacity;
-            size_t srcSize = srcEnd - srcPtr;
+            size_t srcSize = (const char*)srcEnd - (const char*)srcPtr;
             ret = LZ4F_decompress(dctx, dst, &dstSize, srcPtr, &srcSize, /* LZ4F_decompressOptions_t */ NULL);
             if (LZ4F_isError(ret)) {
                 printf("Decompression error: %s\n", LZ4F_getErrorName(ret));
@@ -207,7 +207,7 @@ decompress_file_internal(FILE* f_in, FILE* f_out,
             /* Flush output */
             if (dstSize != 0) safe_fwrite(dst, 1, dstSize, f_out);
             /* Update input */
-            srcPtr += srcSize;
+            srcPtr = (const char*)srcPtr + srcSize;
         }
 
         assert(srcPtr <= srcEnd);

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -33,8 +33,8 @@ You can contact the author at :
 */
 
 /* LZ4F is a stand-alone API to create LZ4-compressed Frames
-*  in full conformance with specification v1.5.0
-*  All related operations, including memory management, are handled by the library.
+*  in full conformance with specification v1.6.1 .
+*  This library rely upon memory management capabilities.
 * */
 
 
@@ -63,9 +63,9 @@ You can contact the author at :
 *  Memory routines
 **************************************/
 #include <stdlib.h>   /* malloc, calloc, free */
-#define ALLOC(s)   malloc(s)
-#define ALLOC_AND_ZERO(s)   calloc(1,s)
-#define FREEMEM        free
+#define ALLOC(s)       malloc(s)
+#define ALLOC_AND_ZERO(s)  calloc(1,(s))
+#define FREEMEM(p)     free(p)
 #include <string.h>   /* memset, memcpy, memmove */
 #define MEM_INIT       memset
 

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -427,15 +427,15 @@ LZ4FLIB_API void LZ4F_resetDecompressionContext(LZ4F_dctx* dctx);   /* always su
 extern "C" {
 #endif
 
-/* These declarations are not stable and may change in the future. They are
- * therefore only safe to depend on when the caller is statically linked
- * against the library. To access their declarations, define
- * LZ4F_STATIC_LINKING_ONLY.
+/* These declarations are not stable and may change in the future.
+ * They are therefore only safe to depend on
+ * when the caller is statically linked against the library.
+ * To access their declarations, define LZ4F_STATIC_LINKING_ONLY.
  *
- * There is a further protection mechanism where these symbols aren't published
- * into shared/dynamic libraries. You can override this behavior and force
- * them to be published by defining LZ4F_PUBLISH_STATIC_FUNCTIONS. Use at
- * your own risk.
+ * By default, these symbols aren't published into shared/dynamic libraries.
+ * You can override this behavior and force them to be published
+ * by defining LZ4F_PUBLISH_STATIC_FUNCTIONS.
+ * Use at your own risk.
  */
 #ifdef LZ4F_PUBLISH_STATIC_FUNCTIONS
 #define LZ4FLIB_STATIC_API LZ4FLIB_API
@@ -471,10 +471,10 @@ extern "C" {
 #define LZ4F_GENERATE_ENUM(ENUM) LZ4F_##ENUM,
 
 /* enum list is exposed, to handle specific errors */
-typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM) } LZ4F_errorCodes;
+typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM)
+              _LZ4F_dummy_error_enum_for_c89_never_used } LZ4F_errorCodes;
 
 LZ4FLIB_STATIC_API LZ4F_errorCodes LZ4F_getErrorCode(size_t functionResult);
-
 
 
 /**********************************

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -400,7 +400,7 @@ int LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index tabl
 typedef enum {
     noLimit = 0,
     limitedOutput = 1,
-    limitedDestSize = 2,
+    limitedDestSize = 2
 } limitedOutput_directive;
 
 /* LZ4HC_encodeSequence() :


### PR DESCRIPTION
as detected in #485 by @JoachimSchneider.

Refactored the `c_standards` tests
so that these issues get automatically detected in CI tests.