### PR TITLE
Add lastError field into LZ4_stream_t_internal

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -477,6 +477,8 @@ LZ4LIB_API int LZ4_compress_fast_extState_fastReset (void* state, const char* sr
  */
 LZ4LIB_API void LZ4_attach_dictionary(LZ4_stream_t *working_stream, const LZ4_stream_t *dictionary_stream);
 
+LZ4LIB_API const char *LZ4_stream_error_desc(const LZ4_stream_t *stream);
+
 #endif
 
 /*-************************************
@@ -490,6 +492,16 @@ LZ4LIB_API void LZ4_attach_dictionary(LZ4_stream_t *working_stream, const LZ4_st
 #define LZ4_HASHTABLESIZE (1 << LZ4_MEMORY_USAGE)
 #define LZ4_HASH_SIZE_U32 (1 << LZ4_HASHLOG)       /* required as macro for static allocation */
 
+typedef enum {
+    stream_no_error = 0,
+    stream_not_initialized = 1,
+    stream_unable_to_store = 2,
+    stream_unsupported_input_size = 3,
+    stream_size_too_large = 4,
+    stream_buffer_overflow = 5,
+    stream_unknown_error = 128
+} stream_error_t;
+
 #if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
 #include <stdint.h>
 
@@ -502,6 +514,7 @@ struct LZ4_stream_t_internal {
     const uint8_t* dictionary;
     const LZ4_stream_t_internal* dictCtx;
     uint32_t dictSize;
+    stream_error_t lastError;
 };
 
 typedef struct {
@@ -522,6 +535,7 @@ struct LZ4_stream_t_internal {
     const unsigned char* dictionary;
     const LZ4_stream_t_internal* dictCtx;
     unsigned int dictSize;
+    stream_error_t lastError;
 };
 
 typedef struct {

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -676,6 +676,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         LZ4_loadDict(&LZ4dict, dict, dictSize);
         ret = LZ4_compress_fast_continue(&LZ4dict, block, compressedBuffer, blockSize, blockContinueCompressedSize-1, 1);
         FUZ_CHECKTEST(ret>0, "LZ4_compress_fast_continue using ExtDict should fail : one missing byte for output buffer : %i written, %i buffer", ret, blockContinueCompressedSize);
+        FUZ_CHECKTEST(LZ4dict.internal_donotuse.lastError!=stream_buffer_overflow, "Should be buffer overflow");
 
         FUZ_DISPLAYTEST("test LZ4_compress_fast_continue() with dictionary loaded with LZ4_loadDict()");
         DISPLAYLEVEL(5, " compress %i bytes from buffer(%p) into dst(%p) using dict(%p) of size %i \n", blockSize, block, decodedBuffer, dict, dictSize);
@@ -990,6 +991,7 @@ static void FUZ_unitTests(int compressionLevel)
         LZ4_resetStream(&streamingState);
         result = LZ4_compress_fast_continue(&streamingState, testInput, testCompressed, testCompressedSize, testCompressedSize-1, 1);
         FUZ_CHECKTEST(result==0, "LZ4_compress_fast_continue() compression failed!");
+        FUZ_CHECKTEST(streamingState.internal_donotuse.lastError!=stream_no_error, "LZ4_compress_fast_continue() compression failed!");
 
         result = LZ4_decompress_safe(testCompressed, testVerify, result, testCompressedSize);
         FUZ_CHECKTEST(result!=(int)testCompressedSize, "LZ4_decompress_safe() decompression failed");


### PR DESCRIPTION
This change adds a new field called `lastError` into `LZ4_stream_t_internal` structure indicating last error that happened during stream compression.

The field can be used by API users (indirectly via auxiliary functions) to get more information about cause of compression failure.

The field can also be used by `_fastReset_` family of functions to check if full reset is necessary.