### PR TITLE
Adding information about dirty context for _HC_ family of functions

### DIFF
--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -161,7 +161,9 @@ struct LZ4HC_CCtx_internal
     uint32_t   lowLimit;        /* below that point, no more dict */
     uint32_t   nextToUpdate;    /* index from which to continue dictionary update */
     short      compressionLevel;
-    short      favorDecSpeed;
+    int8_t     favorDecSpeed;   /* favor decompression speed if this flag set,
+                                   otherwise, favor compression ratio */
+    int8_t     dirty;           /* stream has to be fully reset if this flag is set */
     const LZ4HC_CCtx_internal* dictCtx;
 };
 
@@ -179,7 +181,9 @@ struct LZ4HC_CCtx_internal
     unsigned int   lowLimit;         /* below that point, no more dict */
     unsigned int   nextToUpdate;     /* index from which to continue dictionary update */
     short          compressionLevel;
-    short          favorDecSpeed;
+    char           favorDecSpeed;    /* favor decompression speed if this flag set,
+                                        otherwise, favor compression ratio */
+    char           dirty;            /* stream has to be fully reset if this flag is set */
     const LZ4HC_CCtx_internal* dictCtx;
 };
 
@@ -314,6 +318,11 @@ void LZ4_favorDecompressionSpeed(LZ4_streamHC_t* LZ4_streamHCPtr, int favor);
  *  - the stream was in an indeterminate state and was used in a compression
  *    call that fully reset the state (LZ4_compress_HC_extStateHC()) and that
  *    returned success
+ *
+ *  Note:
+ *  A stream that was last used in a compression call that returned an error
+ *  may be passed to this function. However, it will be fully reset, which will
+ *  clear any existing history and settings from the context.
  */
 void LZ4_resetStreamHC_fast(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel);
 


### PR DESCRIPTION
With this change an HC compression function in case of failure will update the stream's state to have "dirty context". It is safe now to pass such a stream into `LZ4_resetStreamHC_fast()` function, because it will detect "dirty context" internally and fall back to full reset then.

What was changed:
* renamed `favorDecSpeed` field to `flags`, first 11 bits are not used currently, 12th bit is used to indicate if context is dirty, last 4 bits are reserved for favor kinds;
* updated `LZ4HC_compress_generic_internal()` function to set "dirty context" flag (`lz4hc.c` has complex hierarchy of function calls, therefore refer to the picture);
* updated `LZ4_resetStreamHC_fast()` to detect "dirty context" case;
* updated the tests.

![1102_001](https://user-images.githubusercontent.com/1170768/45900472-c43de400-bd94-11e8-999c-e5e23916c21a.png)
