### PR TITLE
fixed improper hint

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1474,7 +1474,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 }
                 dctx->tmpInTarget -= sizeToCopy;  /* need to copy more */
                 nextSrcSizeHint = dctx->tmpInTarget +
-                                + dctx->frameInfo.contentChecksumFlag * 4  /* block checksum */
+                                + dctx->frameInfo.blockChecksumFlag * 4   /* size for block checksum */
                                 + BHSize /* next header size */;
                 doAnotherStage = 0;
                 break;
@@ -1525,8 +1525,10 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 dctx->tmpInSize += sizeToCopy;
                 srcPtr += sizeToCopy;
                 if (dctx->tmpInSize < dctx->tmpInTarget) { /* need more input */
-                    nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize) + BHSize;
-                    doAnotherStage=0;
+                    nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize)
+                                    + dctx->frameInfo.blockChecksumFlag * 4   /* size for block checksum */
+                                    + BHSize /* next header size */;
+                    doAnotherStage = 0;
                     break;
                 }
                 selectedIn = dctx->tmpIn;


### PR DESCRIPTION
when `LZ4F_decompress()` decodes an uncompressed block,
it may provide an incorrect hint for next block
when frame checksum is enabled and block checksum is not.

Impact is low : the hint is just an hint,
so the decoder still works correctly, whatever the amount of input provided.

But the assumption that each call to `LZ4F_decompress()`
would generate just one complete block when input size hint was respected
end up being false with this error.