### PR TITLE
Use / instead of \ when accessing files in the dll subdirectory.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -103,8 +103,8 @@ $(LIBLZ4): $(SRCFILES)
 ifeq ($(BUILD_SHARED),yes)  # can be disabled on command line
 	@echo compiling dynamic library $(LIBVER)
 ifneq (,$(filter Windows%,$(OS)))
-	$(Q)$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll\$@.dll
-	dlltool -D dll\liblz4.dll -d dll\liblz4.def -l dll\liblz4.lib
+	$(Q)$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll
+	dlltool -D dll/liblz4.dll -d dll/liblz4.def -l dll/liblz4.lib
 else
 	$(Q)$(CC) $(FLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
 	@echo creating versioned links


### PR DESCRIPTION
This allow cross-compilation for Windows on Linux