### PR TITLE
Allow installation of lz4 for Windows (MSYS2 or when cross-compiling)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ clean:
 #-----------------------------------------------------------------------------
 # make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD MINGW32_NT-6.1 MINGW64_NT-6.1))
 HOST_OS = POSIX
 
 .PHONY: install uninstall

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -204,9 +204,14 @@ endif
 
 uninstall:
 	$(Q)$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
+ifneq (,$(filter Windows%,$(OS)))
+	$(Q)$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4).dll
+	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.lib
+else
 	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
 	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
 	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_VER)
+endif
 	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.a
 	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4.h
 	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4hc.h

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -184,6 +184,9 @@ ifeq ($(BUILD_STATIC),yes)
 	$(Q)$(INSTALL_DATA) lz4frame_static.h $(DESTDIR)$(includedir)/lz4frame_static.h
 endif
 ifeq ($(BUILD_SHARED),yes)
+# Traditionnally, one installs the DLLs in the bin directory as programs
+# search them first in their directory. This allows to not pollute system
+# directories (like c:/windows/system32), nor modify the PATH variable.
 ifneq (,$(filter Windows%,$(OS)))
 	$(Q)$(INSTALL_PROGRAM) dll/$(LIBLZ4).dll $(DESTDIR)$(bindir)
 	$(Q)$(INSTALL_PROGRAM) dll/liblz4.lib $(DESTDIR)$(libdir)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -73,7 +73,11 @@ else
 	SHARED_EXT_VER = $(SHARED_EXT).$(LIBVER)
 endif
 
+ifneq (,$(filter Windows%,$(OS)))
+LIBLZ4 = liblz4-$(LIBVER_MAJOR)
+else
 LIBLZ4 = liblz4.$(SHARED_EXT_VER)
+endif
 
 .PHONY: default
 default: lib-release
@@ -126,7 +130,7 @@ clean:
 #-----------------------------------------------------------------------------
 # make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD MINGW32_NT-6.1 MINGW64_NT-6.1))
 
 .PHONY: listL120
 listL120:  # extract lines >= 120 characters in *.{c,h}, by Takayuki Matsuoka (note : $$, for Makefile compatibility)
@@ -140,6 +144,8 @@ PREFIX      ?= /usr/local
 prefix      ?= $(PREFIX)
 EXEC_PREFIX ?= $(prefix)
 exec_prefix ?= $(EXEC_PREFIX)
+BINDIR      ?= $(exec_prefix)/bin
+bindir      ?= $(BINDIR)
 LIBDIR      ?= $(exec_prefix)/lib
 libdir      ?= $(LIBDIR)
 INCLUDEDIR  ?= $(prefix)/include
@@ -170,7 +176,7 @@ liblz4.pc: liblz4.pc.in Makefile
           $< >$@
 
 install: lib liblz4.pc
-	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/
+	$(Q)$(INSTALL) -d -m 755 $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
 	$(Q)$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(pkgconfigdir)/
 	@echo Installing libraries
 ifeq ($(BUILD_STATIC),yes)
@@ -178,9 +184,14 @@ ifeq ($(BUILD_STATIC),yes)
 	$(Q)$(INSTALL_DATA) lz4frame_static.h $(DESTDIR)$(includedir)/lz4frame_static.h
 endif
 ifeq ($(BUILD_SHARED),yes)
+ifneq (,$(filter Windows%,$(OS)))
+	$(Q)$(INSTALL_PROGRAM) dll/$(LIBLZ4).dll $(DESTDIR)$(bindir)
+	$(Q)$(INSTALL_PROGRAM) dll/liblz4.lib $(DESTDIR)$(libdir)
+else
 	$(Q)$(INSTALL_PROGRAM) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)
 	$(Q)ln -sf liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
 	$(Q)ln -sf liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
+endif
 endif
 	@echo Installing headers in $(includedir)
 	$(Q)$(INSTALL_DATA) lz4.h $(DESTDIR)$(includedir)/lz4.h

--- a/lib/README.md
+++ b/lib/README.md
@@ -46,6 +46,10 @@ by using build macro `LZ4_PUBLISH_STATIC_FUNCTIONS`.
 
 DLL can be created using MinGW+MSYS with the `make liblz4` command.
 This command creates `dll\liblz4.dll` and the import library `dll\liblz4.lib`.
+To override the `dlltool` command  when cross-compiling on Linux, just set the `DLLTOOL` variable. Example of cross compilation on Linux with mingw-w64 64 bits:
+```
+make BUILD_STATIC=no CC=x86_64-w64-mingw32-gcc DLLTOOL=x86_64-w64-mingw32-dlltool OS=Windows_NT
+```
 The import library is only required with Visual C++.
 The header files `lz4.h`, `lz4hc.h`, `lz4frame.h` and the dynamic library
 `dll\liblz4.dll` are required to compile a project using gcc/MinGW.
@@ -64,7 +68,6 @@ Other files present in the directory are not source code. There are :
 
  - `LICENSE` : contains the BSD license text
  - `Makefile` : `make` script to compile and install lz4 library (static and dynamic)
- - dlltool can be overrided by setting DLLTOOL variable (useful when cross-compiling on Linux for Windows)
  - `liblz4.pc.in` : for `pkg-config` (used in `make install`)
  - `README.md` : this file
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -109,7 +109,7 @@ clean:
 #-----------------------------------------------------------------------------
 # make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
-ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD))
+ifneq (,$(filter $(shell uname),Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD MINGW32_NT-6.1 MINGW64_NT-6.1))
 
 unlz4: lz4
 	ln -s lz4$(EXT) unlz4$(EXT)


### PR DESCRIPTION

- When cross-compiling (64 bits cross compiler) : 

```make install PREFIX=$HOME/lz4_test BUILD_STATIC=no CC=x86_64-w64-mingw32-gcc DLLTOOL=x86_64-w64-mingw32-dlltool OS=Windows_NT```

```find /home/vtorri/lz4_test``` gives : 

/home/vtorri/lz4_test/
/home/vtorri/lz4_test/lib
/home/vtorri/lz4_test/lib/liblz4.lib
/home/vtorri/lz4_test/lib/pkgconfig
/home/vtorri/lz4_test/lib/pkgconfig/liblz4.pc
/home/vtorri/lz4_test/share
/home/vtorri/lz4_test/share/man
/home/vtorri/lz4_test/share/man/man1
/home/vtorri/lz4_test/share/man/man1/lz4c.1
/home/vtorri/lz4_test/share/man/man1/lz4cat.1
/home/vtorri/lz4_test/share/man/man1/lz4.1
/home/vtorri/lz4_test/share/man/man1/unlz4.1
/home/vtorri/lz4_test/bin
/home/vtorri/lz4_test/bin/unlz4.exe
/home/vtorri/lz4_test/bin/liblz4-1.dll
/home/vtorri/lz4_test/bin/lz4.exe
/home/vtorri/lz4_test/bin/lz4c.exe
/home/vtorri/lz4_test/bin/lz4cat.exe
/home/vtorri/lz4_test/include
/home/vtorri/lz4_test/include/lz4.h
/home/vtorri/lz4_test/include/lz4hc.h
/home/vtorri/lz4_test/include/lz4frame.h

- With MSYS2 (here 32 bits cross compiler) : 

```make install PREFIX=$HOME/lz4_test BUILD_STATIC=no CC=x86_64-w64-mingw32-gcc ```

same files are installed