### PR TITLE
Don't Attach Very Small Dictionaries

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1271,7 +1271,9 @@ void LZ4_attach_dictionary(LZ4_stream_t *working_stream, const LZ4_stream_t *dic
      */
     LZ4_resetStream_fast(working_stream);
 
-    if (dictionary_stream != NULL) {
+    if (dictionary_stream != NULL
+     && dictionary_stream->internal_donotuse.dictSize - 1 >= 4
+        /* intentional underflow */) {
         /* If the current offset is zero, we will never look in the
          * external dictionary context, since there is no value a table
          * entry can take that indicate a miss. In that case, we need


### PR DESCRIPTION
Fixes a mismatch in behavior between loading into the context (via `LZ4_loadDict()`) a very small (<= 4 bytes) non-contiguous dictionary, versus attaching it with `LZ4_attach_dictionary()`.

Before this patch, this divergence could be reproduced by running

```
make -C tests fuzzer MOREFLAGS="-m32"
tests/fuzzer -v -s1239 -t3146
```

Making sure these two paths behave exactly identically is an easy way to test the correctness of the attach path, so it's desirable that this remain an unpolluted, high signal test.

This condition mirrors the condition in `LZ4_compress_fast_continue()`. It's implemented here instead to avoid performing the check on every `_continue()` call.