### PR TITLE
Make LZ4F_getBlockSize public and public in experimental section

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -265,21 +265,20 @@ unsigned LZ4F_getVersion(void) { return LZ4F_VERSION; }
 
 int LZ4F_compressionLevel_max(void) { return LZ4HC_CLEVEL_MAX; }
 
+size_t LZ4F_getBlockSize(unsigned blockSizeID)
+{
+    static const size_t blockSizes[4] = { 64 KB, 256 KB, 1 MB, 4 MB };
+
+    if (blockSizeID == 0) blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
+    if (blockSizeID < 4 || blockSizeID > 7) return err0r(LZ4F_ERROR_maxBlockSize_invalid);
+    blockSizeID -= 4;
+    return blockSizes[blockSizeID];
+}
 
 /*-************************************
 *  Private functions
 **************************************/
 #define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
-
-static size_t LZ4F_getBlockSize(unsigned blockSizeID)
-{
-    static const size_t blockSizes[4] = { 64 KB, 256 KB, 1 MB, 4 MB };
-
-    if (blockSizeID == 0) blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
-    blockSizeID -= 4;
-    if (blockSizeID > 3) return err0r(LZ4F_ERROR_maxBlockSize_invalid);
-    return blockSizes[blockSizeID];
-}
 
 static BYTE LZ4F_headerChecksum (const void* header, size_t length)
 {

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -483,6 +483,7 @@ typedef enum { LZ4F_LIST_ERRORS(LZ4F_GENERATE_ENUM)
 
 LZ4FLIB_STATIC_API LZ4F_errorCodes LZ4F_getErrorCode(size_t functionResult);
 
+LZ4FLIB_STATIC_API size_t LZ4F_getBlockSize(unsigned);
 
 /**********************************
  *  Bulk processing dictionary API

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -658,6 +658,28 @@ int basicTests(U32 seed, double compressibility)
         CHECK( LZ4F_freeCompressionContext(cctx) ); cctx = NULL;
     }
 
+    DISPLAYLEVEL(3, "getBlockSize test: \n");
+    { size_t result;
+      for (unsigned blockSizeID = 4; blockSizeID < 8; ++blockSizeID) {
+        result = LZ4F_getBlockSize(blockSizeID);
+        CHECK(result);
+        DISPLAYLEVEL(3, "Returned block size of %zu bytes for blockID %u \n",
+                         result, blockSizeID);
+      }
+
+      /* Test an invalid input that's too large */
+      result = LZ4F_getBlockSize(8);
+      if(!LZ4F_isError(result) ||
+          LZ4F_getErrorCode(result) != LZ4F_ERROR_maxBlockSize_invalid)
+        goto _output_error;
+
+      /* Test an invalid input that's too small */
+      result = LZ4F_getBlockSize(3);
+      if(!LZ4F_isError(result) ||
+          LZ4F_getErrorCode(result) != LZ4F_ERROR_maxBlockSize_invalid)
+        goto _output_error;
+    }
+
 
     DISPLAYLEVEL(3, "Skippable frame test : \n");
     {   size_t decodedBufferSize = COMPRESSIBLE_NOISE_LENGTH;

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -660,7 +660,8 @@ int basicTests(U32 seed, double compressibility)
 
     DISPLAYLEVEL(3, "getBlockSize test: \n");
     { size_t result;
-      for (unsigned blockSizeID = 4; blockSizeID < 8; ++blockSizeID) {
+      unsigned blockSizeID;
+      for (blockSizeID = 4; blockSizeID < 8; ++blockSizeID) {
         result = LZ4F_getBlockSize(blockSizeID);
         CHECK(result);
         DISPLAYLEVEL(3, "Returned block size of %zu bytes for blockID %u \n",


### PR DESCRIPTION
Publish the `LZ4_getBlockSize` function to the experimental section of the API. 

This resolves #608 