### PR TITLE
 lz4hc: truncate long sequences at block end

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -464,7 +464,7 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
     if (limit) {
         if (*op + (1 + LASTLITERALS) > oend) return 1;    /* Check output limit */
         maxLength = (oend - *op - LASTLITERALS) * 255;
-        if (length > maxLength) { length = maxLength; matchLength = (size_t)(length + MINMATCH); }
+        if (length > maxLength) { length = maxLength; matchLength = (int)(length + MINMATCH); }
     }
     if (length >= ML_MASK) {
         *token += ML_MASK;

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -460,7 +460,11 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
     /* Encode MatchLength */
     assert(matchLength >= MINMATCH);
     length = (size_t)(matchLength - MINMATCH);
-    if ((limit) && (*op + (length / 255) + (1 + LASTLITERALS) > oend)) return 1;   /* Check output limit */
+    if (limit) {
+        if (*op + (1 + LASTLITERALS) > oend) return 1;    /* Check output limit */
+        size_t maxLength = (oend - *op - LASTLITERALS) * 255;
+        if (length > maxLength) { length = maxLength; matchLength = length + MINMATCH; }
+    }
     if (length >= ML_MASK) {
         *token += ML_MASK;
         length -= ML_MASK;

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -419,6 +419,7 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 {
     size_t length;
     BYTE* const token = (*op)++;
+    size_t maxLength;
 
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 6)
     static const BYTE* start = NULL;
@@ -462,8 +463,8 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
     length = (size_t)(matchLength - MINMATCH);
     if (limit) {
         if (*op + (1 + LASTLITERALS) > oend) return 1;    /* Check output limit */
-        size_t maxLength = (oend - *op - LASTLITERALS) * 255;
-        if (length > maxLength) { length = maxLength; matchLength = length + MINMATCH; }
+        maxLength = (oend - *op - LASTLITERALS) * 255;
+        if (length > maxLength) { length = maxLength; matchLength = (size_t)(length + MINMATCH); }
     }
     if (length >= ML_MASK) {
         *token += ML_MASK;


### PR DESCRIPTION
If a sequence is too long to be compressed into the remaining space in a limited output buffer, we can truncate it and compress the longest possible sub-sequence.  This optimization is especially useful for long sequences that cannot be compressed into a single block (> ~255 * blocksize).