### PR TITLE
Fix pass-through mode

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -340,6 +340,7 @@ int main(int argc, const char** argv)
     if (exeNameMatch(exeName, LZ4CAT)) {
         mode = om_decompress;
         LZ4IO_setOverwrite(1);
+        LZ4IO_setPassThrough(1);
         LZ4IO_setRemoveSrcFile(0);
         forceStdout=1;
         output_filename=stdoutmark;
@@ -468,7 +469,11 @@ int main(int argc, const char** argv)
                 case 'd': mode = om_decompress; break;
 
                     /* Force stdout, even if stdout==console */
-                case 'c': forceStdout=1; output_filename=stdoutmark; break;
+                case 'c':
+                  forceStdout=1;
+                  output_filename=stdoutmark;
+                  LZ4IO_setPassThrough(1);
+                  break;
 
                     /* Test integrity */
                 case 't': mode = om_test; break;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -107,6 +107,7 @@ static clock_t g_time = 0;
 /**************************************
 *  Local Parameters
 **************************************/
+static int g_passThrough = 0;
 static int g_overwrite = 1;
 static int g_testMode = 0;
 static int g_blockSizeId = LZ4IO_BLOCKSIZEID_DEFAULT;
@@ -156,6 +157,14 @@ int LZ4IO_setDictionaryFilename(const char* dictionaryFilename) {
     g_useDictionary = dictionaryFilename != NULL;
     return g_useDictionary;
 }
+
+/* Default setting : passThrough = 0; return : passThrough mode (0/1) */
+int LZ4IO_setPassThrough(int yes)
+{
+   g_passThrough = (yes!=0);
+   return g_passThrough;
+}
+
 
 /* Default setting : overwrite = 1; return : overwrite mode (0/1) */
 int LZ4IO_setOverwrite(int yes)
@@ -1070,7 +1079,7 @@ static unsigned long long selectDecoder(dRess_t ress, FILE* finput, FILE* foutpu
     default:
         if (nbFrames == 1) {  /* just started */
             /* Wrong magic number at the beginning of 1st stream */
-            if (!g_testMode && g_overwrite) {
+            if (!g_testMode && g_overwrite && g_passThrough) {
                 nbFrames = 0;
                 return LZ4IO_passThrough(finput, foutput, MNstore);
             }

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -66,6 +66,10 @@ int LZ4IO_decompressMultipleFilenames(const char** inFileNamesTable, int ifntSiz
 
 int LZ4IO_setDictionaryFilename(const char* dictionaryFilename);
 
+/* Default setting : passThrough = 0;
+   return : passThrough mode (0/1) */
+int LZ4IO_setPassThrough(int yes);
+
 /* Default setting : overwrite = 1;
    return : overwrite mode (0/1) */
 int LZ4IO_setOverwrite(int yes);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -337,8 +337,11 @@ test-lz4-testmode: lz4 datagen
 	! ./datagen | $(LZ4) -t
 	! ./datagen | $(LZ4) -tf
 	@echo "\n ---- pass-through mode ----"
-	! ./datagen | $(LZ4) -d  > $(VOID)
-	./datagen | $(LZ4) -df > $(VOID)
+	@echo "Why hello there " > tmp-tlt2.lz4
+	! $(LZ4) -f tmp-tlt2.lz4 > $(VOID)
+	! ./datagen | $(LZ4) -dc  > $(VOID)
+	! ./datagen | $(LZ4) -df > $(VOID)
+	./datagen | $(LZ4) -dcf > $(VOID)
 	@echo "Hello World !" > tmp-tlt1
 	$(LZ4) -dcf tmp-tlt1
 	@echo "from underground..." > tmp-tlt2
@@ -347,7 +350,7 @@ test-lz4-testmode: lz4 datagen
 	! $(LZ4)     file-does-not-exist
 	! $(LZ4) -f  file-does-not-exist
 	! $(LZ4) -fm file1-dne file2-dne
-	@$(RM) tmp-tlt
+	@$(RM) tmp-tlt tmp-tlt1 tmp-tlt2 tmp-tlt2.lz4
 
 test-lz4-opt-parser: lz4 datagen
 	@echo "\n ---- test opt-parser ----"


### PR DESCRIPTION
This PR resolves issues surrounding pass-through mode with lz4. It does so by adding an additional flag to to signify pass-through mode in `LZ4IO`, we then use this when selecting the decoder.

Resolves #601 