### PR TITLE
Optimize decompress generic

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1632,20 +1632,6 @@ LZ4_decompress_generic(
 
             /* partialDecoding : may not respect endBlock parsing restrictions */
             assert(op<=oend);
-            if (partialDecoding && (cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
-                size_t const mlen = MIN(length, (size_t)(oend-op));
-                const BYTE* const matchEnd = match + mlen;
-                BYTE* const copyEnd = op + mlen;
-                if (matchEnd > op) {   /* overlap copy */
-                    while (op < copyEnd) *op++ = *match++;
-                } else {
-                    memcpy(op, match, mlen);
-                }
-                op = copyEnd;
-                if (op==oend) goto decode_done;
-                continue;
-            }
-
             if (unlikely(offset<16)) {
                 if (offset < 8) {
                     op[0] = match[0];
@@ -1858,7 +1844,6 @@ LZ4_decompress_generic(
             }
             op = cpy;   /* wildcopy correction */
         }
-    decode_done:
 
         /* end of decoding */
         if (endOnInput)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1581,11 +1581,6 @@ LZ4_decompress_generic(
             length = token & ML_MASK;
 
             if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) goto _output_error;   /* Error : offset outside buffers */
-            if (!partialDecoding) {
-                assert(oend > op);
-                assert(oend - op >= 4);
-                LZ4_write32(op, 0);   /* silence an msan warning when offset==0; costs <1%; */
-            }   /* note : when partialDecoding, there is no guarantee that at least 4 bytes remain available in output buffer */
 
             if (length == ML_MASK) {
               variable_length_error error = ok;

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1434,6 +1434,35 @@ typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 #undef MIN
 #define MIN(a,b)    ( (a) < (b) ? (a) : (b) )
 
+/* Read the variable-length literal or match length.
+ *
+ * ip - pointer to use as input.
+ * lencheck - end ip.  Return an error if ip advances >= lencheck.
+ * loop_check - check ip >= lencheck in body of loop.  Returns loop_error if so.
+ * initial_check - check ip >= lencheck before start of loop.  Returns initial_error if so.
+ * error (output) - error code.  Should be set to 0 before call.  
+ */
+typedef enum { loop_error = -2, initial_error = -1, ok = 0} variable_length_error;
+LZ4_FORCE_INLINE unsigned read_variable_length(const BYTE**ip, const BYTE* lencheck, int loop_check, int initial_check, variable_length_error* error) {
+  unsigned length = 0;
+  unsigned s;
+  if (initial_check && unlikely((*ip) >= lencheck)) {    /* overflow detection */
+    *error = initial_error;
+    return length;
+  }
+  do {
+    s = **ip;
+    (*ip)++;
+    length += s;
+    if (loop_check && unlikely((*ip) >= lencheck)) {    /* overflow detection */
+      *error = loop_error;
+      return length;
+    }
+  } while (s==255);
+
+  return length;
+}
+
 /*! LZ4_decompress_generic() :
  *  This generic decompression function covers all use cases.
  *  It shall be instantiated several times, using different sets of directives.
@@ -1536,12 +1565,9 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                unsigned s;
-                if (unlikely(endOnInput ? ip >= iend-RUN_MASK : 0)) goto _output_error;   /* overflow detection */
-                do {
-                    s = *ip++;
-                    length += s;
-                } while ( likely(endOnInput ? ip<iend-RUN_MASK : 1) & (s==255) );
+              variable_length_error error = ok;
+              length += read_variable_length(&ip, iend-RUN_MASK, endOnInput, endOnInput, &error);
+              if (error == initial_error) goto _output_error;
                 if ((safeDecode) && unlikely((uptrval)(op)+length<(uptrval)(op))) goto _output_error;   /* overflow detection */
                 if ((safeDecode) && unlikely((uptrval)(ip)+length<(uptrval)(ip))) goto _output_error;   /* overflow detection */
             }
@@ -1588,12 +1614,9 @@ LZ4_decompress_generic(
             }   /* note : when partialDecoding, there is no guarantee that at least 4 bytes remain available in output buffer */
 
             if (length == ML_MASK) {
-                unsigned s;
-                do {
-                    s = *ip++;
-                    if ((endOnInput) && (ip > iend-LASTLITERALS)) goto _output_error;
-                    length += s;
-                } while (s==255);
+              variable_length_error error = ok;
+              length += read_variable_length(&ip, iend - LASTLITERALS + 1, endOnInput, 0, &error);
+              if (error != ok) goto _output_error;
                 if ((safeDecode) && unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
             }
             length += MINMATCH;


### PR DESCRIPTION
The current decompress_generic code suffers from many blocked loads, originally mentioned in issue #411. This patchset attemps to fix that issue.  Also similar issues mentioned in pull #470 , issue #126, and probably others.

The heart of the issue is that LZ4_wildCopy does a copy by 8 bytes at a time, leading to lots of work happening side-by-side.   The farther away we can move these copies by extending the copy width, the faster things seem to go.  Increasing the copy width to as wide as 32 bytes results in overall decompression speed improvement of around ~10% a xeon, ~20% on a modern AMD.

The primary code challenge then is that we have only 8 bytes of WILDCOPYLENGTH, when we'd really like far larger.  So we end up duplicating most of the decode loop, to add a fastpath for a larger copy length, and then the last handful of bytes can use the original loop.  

I've split up the code in what I hope are readable small diffs.  Testing has mostly consisted of 'make test', and an attempt at fuzzing with afl.  Has *not* been tested on other arches, but it would be fairly easy to #ifdef the first loop away and be the same as previous if it shows a regression.

Benchmarks on Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz, from lzbench.  The final percent is how much faster this patchset is vs. the current dev branch
```
./lzbench -elz4 silesia/*

lz4 1.8.3                 297 MB/s  2598 MB/s     6428742  63.07 silesia/dickens
lz4 1.8.3                 328 MB/s  2452 MB/s     6428742  63.07 silesia/dickens    -5% 

lz4 1.8.3                 472 MB/s  2374 MB/s    26435667  51.61 silesia/mozilla
lz4 1.8.3                 493 MB/s  2658 MB/s    26435667  51.61 silesia/mozilla        12%

lz4 1.8.3                 454 MB/s  2778 MB/s     5440937  54.57 silesia/mr
lz4 1.8.3                 493 MB/s  3037 MB/s     5440937  54.57 silesia/mr             9%

lz4 1.8.3                 796 MB/s  3240 MB/s     5533040  16.49 silesia/nci
lz4 1.8.3                 877 MB/s  4061 MB/s     5533040  16.49 silesia/nci            25%

lz4 1.8.3                 385 MB/s  2383 MB/s     4338918  70.53 silesia/ooffice
lz4 1.8.3                 426 MB/s  2709 MB/s     4338918  70.53 silesia/ooffice        14%

lz4 1.8.3                 413 MB/s  2463 MB/s     5256666  52.12 silesia/osdb
lz4 1.8.3                 439 MB/s  2950 MB/s     5256666  52.12 silesia/osdb           20%

lz4 1.8.3                 303 MB/s  2181 MB/s     3181387  48.00 silesia/reymont
lz4 1.8.3                 331 MB/s  2182 MB/s     3181387  48.00 silesia/reymont        0%

lz4 1.8.3                 511 MB/s  2806 MB/s     7716839  35.72 silesia/samba
lz4 1.8.3                 552 MB/s  3330 MB/s     7716839  35.72 silesia/samba          19%

lz4 1.8.3                 381 MB/s  2899 MB/s     6790273  93.63 silesia/sao
lz4 1.8.3                 412 MB/s  3586 MB/s     6790273  93.63 silesia/sao            24%

lz4 1.8.3                 448 MB/s  2475 MB/s   100881331  47.60 silesia/silesia.tar
lz4 1.8.3                 474 MB/s  2784 MB/s   100881331  47.60 silesia/silesia.tar    12%

lz4 1.8.3                 344 MB/s  2395 MB/s    20139988  48.58 silesia/webster
lz4 1.8.3                 372 MB/s  2536 MB/s    20139988  48.58 silesia/webster        6%

lz4 1.8.3                1104 MB/s  7769 MB/s     8390195  99.01 silesia/x-ray
lz4 1.8.3                1032 MB/s  9056 MB/s     8390195  99.01 silesia/x-ray          17%

lz4 1.8.3                 715 MB/s  2932 MB/s     1227495  22.96 silesia/xml
lz4 1.8.3                 729 MB/s  3514 MB/s     1227495  22.96 silesia/xml            20%
```

An all-zeroes test is particularly ugly for the current code:

```

dd if=/dev/zero of=zerotest bs=1M count=2
(Currently any match extending in to the last 64 bytes uses the slowpath, TODO)
dd if=/dev/random bs=65 count=1 >> zerotest

lz4 1.8.3               15996 MB/s  4920 MB/s        8296   0.40 silesia/zerotest
lz4 1.8.3               16041 MB/s 10151 MB/s        8296   0.40 silesia/zerotest       106%
```

I also tested on a AMD 2400G:

```
dickens          7%
mozilla          12%
mr               18%
nci              29%
ooffice          23%
osdb             28%
reymont          7%
samba            25%
sao              39%
silesia.tar      20%
webster          17%
xml              32%
x-ray            6%
```

The same issue likely exists in zstd (where it is likely easier to fix, since parsing isn't mixed up with sequence execution).