### PR TITLE
LZ4_resetStream*_fast()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 default: lib-release lz4-release
 
 .PHONY: all
-all: allmost examples manuals
+all: allmost examples manuals build_tests
 
 .PHONY: allmost
 allmost: lib lz4
@@ -74,6 +74,10 @@ examples: liblz4.a
 .PHONY: manuals
 manuals:
 	@$(MAKE) -C contrib/gen_manual $@
+
+.PHONY: build_tests
+build_tests:
+	@$(MAKE) -C $(TESTDIR) all
 
 .PHONY: clean
 clean:

--- a/doc/lz4_manual.html
+++ b/doc/lz4_manual.html
@@ -155,9 +155,23 @@ int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int src
 
 <a name="Chapter6"></a><h2>Streaming Compression Functions</h2><pre></pre>
 
-<pre><b>void LZ4_resetStream (LZ4_stream_t* streamPtr);
-</b><p>  An LZ4_stream_t structure can be allocated once and re-used multiple times.
-  Use this function to start compressing a new stream.
+<pre><b>void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
+</b><p>  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
+  (e.g., LZ4_compress_fast_continue()).
+
+  An LZ4_stream_t must be initialized once.
+  This is automatically done when created by LZ4_createStream().
+  However, should the LZ4_stream_t be simply declared on stack (for example),
+  it's necessary to initialize first using LZ4_initStream().
+
+  After that, start any new stream with LZ4_resetStream_fast().
+  A same LZ4_stream_t can be re-used multiple times consecutively
+  and compress multiple streams,
+  provided that it starts each new stream with LZ4_resetStream_fast().
+
+  LZ4_resetStream_fast() is much faster than LZ4_initStream(),
+  but is not compatible with memory regions containing garbage data.
+  For this reason, LZ4_stream_t must be initialized at least once,
  
 </p></pre><BR>
 
@@ -290,43 +304,6 @@ int                 LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream);
  define LZ4_PUBLISH_STATIC_FUNCTIONS when building the LZ4 library.
 <BR></pre>
 
-<pre><b>LZ4LIB_STATIC_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
-</b><p>  Use this to prepare a context for a new chain of calls to a streaming API
-  (e.g., LZ4_compress_fast_continue()).
-
-  Note:
-  To stay on the safe side, when LZ4_stream_t is used for the first time,
-  it should be either created using LZ4_createStream() or
-  initialized using LZ4_resetStream().
-
-  Note:
-  Using this in advance of a non-streaming-compression function is redundant,
-  since they all perform their own custom reset internally.
-
-  Differences from LZ4_resetStream():
-  When an LZ4_stream_t is known to be in an internally coherent state,
-  it will be prepared for a new compression with almost no work.
-  Otherwise, it will fall back to the full, expensive reset.
-
-  LZ4_streams are guaranteed to be in a valid state when:
-  - returned from LZ4_createStream()
-  - reset by LZ4_resetStream()
-  - memset(stream, 0, sizeof(LZ4_stream_t)), though this is discouraged
-  - the stream was in a valid state and was reset by LZ4_resetStream_fast()
-  - the stream was in a valid state and was then used in any compression call
-    that returned success
-  - the stream was in an indeterminate state and was used in a compression
-    call that fully reset the state (e.g., LZ4_compress_fast_extState()) and
-    that returned success
-
-  Note:
-  A stream that was used in a compression call that did not return success
-  (e.g., LZ4_compress_fast_continue()), can still be passed to this function,
-  however, it's history is not preserved because of previous compression
-  failure.
- 
-</p></pre><BR>
-
 <pre><b>LZ4LIB_STATIC_API int LZ4_compress_fast_extState_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
 </b><p>  A variant of LZ4_compress_fast_extState().
 
@@ -394,10 +371,24 @@ union LZ4_stream_u {
     LZ4_stream_t_internal internal_donotuse;
 } ;  </b>/* previously typedef'd to LZ4_stream_t */<b>
 </b><p>  information structure to track an LZ4 stream.
-  init this structure with LZ4_resetStream() before first use.
-  note : only use in association with static linking !
-         this definition is not API/ABI safe,
-         it may change in a future version !
+  LZ4_stream_t can also be created using LZ4_createStream(), which is recommended.
+  The structure definition can be convenient for static allocation
+  (on stack, or as part of larger structure).
+  Init this structure with LZ4_initStream() before first use.
+  note : only use this definition in association with static linking !
+    this definition is not API/ABI safe, and may change in a future version.
+ 
+</p></pre><BR>
+
+<pre><b>LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
+</b><p>  An LZ4_stream_t structure must be initialized at least once.
+  While this is automatically done when invoking LZ4_createStream(),
+  it's not when the structure is simply declared on stack (for example).
+  Use this function to properly initialize a newly declared LZ4_stream_t.
+  It can also accept any arbitrary buffer of sufficient size as input,
+  and will return a pointer of proper type upon initialization.
+  Note : initialization can fail if size < sizeof(LZ4_stream_t).
+  In which case, the function will @return NULL.
  
 </p></pre><BR>
 
@@ -474,6 +465,14 @@ int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize,
          These issues never happen if input data is correct.
          But they may happen if input data is invalid (error or intentional tampering).
          As a consequence, use these functions in trusted environments with trusted data **only**.
+ 
+</p></pre><BR>
+
+<pre><b>//LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
+</b><p>  An LZ4_stream_t structure must be initialized at least once.
+  This is done with LZ4_initStream(), or LZ4_resetStream().
+  Consider switching to LZ4_initStream(),
+  invoking LZ4_resetStream() will trigger deprecation warnings in the future.
  
 </p></pre><BR>
 

--- a/doc/lz4_manual.html
+++ b/doc/lz4_manual.html
@@ -159,19 +159,23 @@ int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int src
 </b><p>  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
   (e.g., LZ4_compress_fast_continue()).
 
-  An LZ4_stream_t must be initialized once.
+  An LZ4_stream_t must be initialized once before usage.
   This is automatically done when created by LZ4_createStream().
   However, should the LZ4_stream_t be simply declared on stack (for example),
-  it's necessary to initialize first using LZ4_initStream().
+  it's necessary to initialize it first, using LZ4_initStream().
 
-  After that, start any new stream with LZ4_resetStream_fast().
+  After init, start any new stream with LZ4_resetStream_fast().
   A same LZ4_stream_t can be re-used multiple times consecutively
   and compress multiple streams,
   provided that it starts each new stream with LZ4_resetStream_fast().
 
   LZ4_resetStream_fast() is much faster than LZ4_initStream(),
   but is not compatible with memory regions containing garbage data.
-  For this reason, LZ4_stream_t must be initialized at least once,
+
+  Note: it's only useful to call LZ4_resetStream_fast()
+        in the context of streaming compression.
+        The *extState* functions perform their own resets.
+        Invoking LZ4_resetStream_fast() before is redundant, and even counterproductive.
  
 </p></pre><BR>
 
@@ -382,13 +386,16 @@ union LZ4_stream_u {
 
 <pre><b>LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
 </b><p>  An LZ4_stream_t structure must be initialized at least once.
-  While this is automatically done when invoking LZ4_createStream(),
-  it's not when the structure is simply declared on stack (for example).
-  Use this function to properly initialize a newly declared LZ4_stream_t.
-  It can also accept any arbitrary buffer of sufficient size as input,
-  and will return a pointer of proper type upon initialization.
-  Note : initialization can fail if size < sizeof(LZ4_stream_t).
-  In which case, the function will @return NULL.
+  This is automatically done when invoking LZ4_createStream(),
+  but it's not when the structure is simply declared on stack (for example).
+
+  Use LZ4_initStream() to properly initialize a newly declared LZ4_stream_t.
+  It can also initialize any arbitrary buffer of sufficient size,
+  and will @return a pointer of proper type upon initialization.
+
+  Note : initialization fails if size and alignment conditions are not respected.
+         In which case, the function will @return NULL.
+  Note2: An LZ4_stream_t structure guarantees correct alignment and size.
  
 </p></pre><BR>
 
@@ -468,7 +475,7 @@ int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize,
  
 </p></pre><BR>
 
-<pre><b>//LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
+<pre><b>void LZ4_resetStream (LZ4_stream_t* streamPtr);
 </b><p>  An LZ4_stream_t structure must be initialized at least once.
   This is done with LZ4_initStream(), or LZ4_resetStream().
   Consider switching to LZ4_initStream(),

--- a/examples/blockStreaming_doubleBuffer.c
+++ b/examples/blockStreaming_doubleBuffer.c
@@ -44,7 +44,7 @@ void test_compress(FILE* outFp, FILE* inpFp)
     char inpBuf[2][BLOCK_BYTES];
     int  inpBufIndex = 0;
 
-    LZ4_resetStream(lz4Stream);
+    LZ4_initStream(lz4Stream, sizeof (*lz4Stream));
 
     for(;;) {
         char* const inpPtr = inpBuf[inpBufIndex];

--- a/examples/dictionaryRandomAccess.c
+++ b/examples/dictionaryRandomAccess.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MIN(x, y) (x) < (y) ? (x) : (y)
+#define MIN(x, y)  ((x) < (y) ? (x) : (y))
 
 enum {
     BLOCK_BYTES = 1024,  /* 1 KiB of uncompressed data in a block */
@@ -63,7 +63,7 @@ void test_compress(FILE* outFp, FILE* inpFp, void *dict, int dictSize)
     int *offsetsEnd = offsets;
 
 
-    LZ4_resetStream(lz4Stream);
+    LZ4_initStream(lz4Stream, sizeof(*lz4Stream));
 
     /* Write header magic */
     write_bin(outFp, kTestMagic, sizeof(kTestMagic));

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1126,6 +1126,7 @@ _failure:
 int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int acceleration)
 {
     LZ4_stream_t_internal* const ctx = & LZ4_initStream(state, sizeof(LZ4_stream_t)) -> internal_donotuse;
+    assert(ctx != NULL);
     if (acceleration < 1) acceleration = ACCELERATION_DEFAULT;
     if (maxOutputSize >= LZ4_compressBound(inputSize)) {
         if (inputSize < LZ4_64Klimit) {
@@ -1236,7 +1237,8 @@ int LZ4_compress_fast_force(const char* src, char* dst, int srcSize, int dstCapa
  * _continue() call without resetting it. */
 static int LZ4_compress_destSize_extState (LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize)
 {
-    LZ4_initStream(state, sizeof (*state));
+    void* const s = LZ4_initStream(state, sizeof (*state));
+    assert(s != NULL); (void)s;
 
     if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
         return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, 1);
@@ -1307,6 +1309,8 @@ LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
     return (LZ4_stream_t*)buffer;
 }
 
+/* resetStream is now deprecated,
+ * prefer initStream() which is more general */
 void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
 {
     DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", LZ4_stream);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1284,10 +1284,17 @@ LZ4_stream_t* LZ4_createStream(void)
     return lz4s;
 }
 
+static size_t LZ4_stream_t_alignment(void)
+{
+    struct { char c; LZ4_stream_t t; } t_a;
+    return sizeof(t_a) - sizeof(t_a.t);
+}
+
 LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
 {
     DEBUGLOG(5, "LZ4_initStream");
     if (size < sizeof(LZ4_stream_t)) return NULL;
+    if (((size_t)buffer) & (LZ4_stream_t_alignment() - 1)) return NULL;  /* alignment check */
     MEM_INIT(buffer, 0, sizeof(LZ4_stream_t));
     return (LZ4_stream_t*)buffer;
 }

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1299,6 +1299,7 @@ static size_t LZ4_stream_t_alignment(void)
 LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
 {
     DEBUGLOG(5, "LZ4_initStream");
+    if (buffer == NULL) return NULL;
     if (size < sizeof(LZ4_stream_t)) return NULL;
 #ifndef _MSC_VER  /* for some reason, Visual fails the aligment test on 32-bit x86 :
                      it reports an aligment of 8-bytes,

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1284,17 +1284,25 @@ LZ4_stream_t* LZ4_createStream(void)
     return lz4s;
 }
 
+#ifndef _MSC_VER  /* for some reason, Visual fails the aligment test on 32-bit x86 :
+                     it reports an aligment of 8-bytes,
+                     while actually aligning LZ4_stream_t on 4 bytes. */
 static size_t LZ4_stream_t_alignment(void)
 {
     struct { char c; LZ4_stream_t t; } t_a;
     return sizeof(t_a) - sizeof(t_a.t);
 }
+#endif
 
 LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
 {
     DEBUGLOG(5, "LZ4_initStream");
     if (size < sizeof(LZ4_stream_t)) return NULL;
+#ifndef _MSC_VER  /* for some reason, Visual fails the aligment test on 32-bit x86 :
+                     it reports an aligment of 8-bytes,
+                     while actually aligning LZ4_stream_t on 4 bytes. */
     if (((size_t)buffer) & (LZ4_stream_t_alignment() - 1)) return NULL;  /* alignment check */
+#endif
     MEM_INIT(buffer, 0, sizeof(LZ4_stream_t));
     return (LZ4_stream_t*)buffer;
 }

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -528,13 +528,16 @@ union LZ4_stream_u {
 
 /*! LZ4_initStream() :
  *  An LZ4_stream_t structure must be initialized at least once.
- *  While this is automatically done when invoking LZ4_createStream(),
- *  it's not when the structure is simply declared on stack (for example).
- *  Use this function to properly initialize a newly declared LZ4_stream_t.
- *  It can also accept any arbitrary buffer of sufficient size as input,
- *  and will return a pointer of proper type upon initialization.
- *  Note : initialization can fail if size < sizeof(LZ4_stream_t).
- *  In which case, the function will @return NULL.
+ *  This is automatically done when invoking LZ4_createStream(),
+ *  but it's not when the structure is simply declared on stack (for example).
+ *
+ *  Use LZ4_initStream() to properly initialize a newly declared LZ4_stream_t.
+ *  It can also initialize any arbitrary buffer of sufficient size,
+ *  and will @return a pointer of proper type upon initialization.
+ *
+ *  Note : initialization fails if size and alignment conditions are not respected.
+ *         In which case, the function will @return NULL.
+ *  Note2: An LZ4_stream_t structure guarantees correct alignment and size.
  */
 LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -242,19 +242,23 @@ LZ4LIB_API int           LZ4_freeStream (LZ4_stream_t* streamPtr);
  *  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
  *  (e.g., LZ4_compress_fast_continue()).
  *
- *  An LZ4_stream_t must be initialized once.
+ *  An LZ4_stream_t must be initialized once before usage.
  *  This is automatically done when created by LZ4_createStream().
  *  However, should the LZ4_stream_t be simply declared on stack (for example),
- *  it's necessary to initialize first using LZ4_initStream().
+ *  it's necessary to initialize it first, using LZ4_initStream().
  *
- *  After that, start any new stream with LZ4_resetStream_fast().
+ *  After init, start any new stream with LZ4_resetStream_fast().
  *  A same LZ4_stream_t can be re-used multiple times consecutively
  *  and compress multiple streams,
  *  provided that it starts each new stream with LZ4_resetStream_fast().
  *
  *  LZ4_resetStream_fast() is much faster than LZ4_initStream(),
  *  but is not compatible with memory regions containing garbage data.
- *  For this reason, LZ4_stream_t must be initialized at least once,
+ *
+ *  Note: it's only useful to call LZ4_resetStream_fast()
+ *        in the context of streaming compression.
+ *        The *extState* functions perform their own resets.
+ *        Invoking LZ4_resetStream_fast() before is redundant, and even counterproductive.
  */
 LZ4LIB_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -238,11 +238,25 @@ typedef union LZ4_stream_u LZ4_stream_t;  /* incomplete type (defined later) */
 LZ4LIB_API LZ4_stream_t* LZ4_createStream(void);
 LZ4LIB_API int           LZ4_freeStream (LZ4_stream_t* streamPtr);
 
-/*! LZ4_resetStream() :
- *  An LZ4_stream_t structure can be allocated once and re-used multiple times.
- *  Use this function to start compressing a new stream.
+/*! LZ4_resetStream_fast() : v1.9.0+
+ *  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
+ *  (e.g., LZ4_compress_fast_continue()).
+ *
+ *  An LZ4_stream_t must be initialized once.
+ *  This is automatically done when created by LZ4_createStream().
+ *  However, should the LZ4_stream_t be simply declared on stack (for example),
+ *  it's necessary to initialize first using LZ4_initStream().
+ *
+ *  After that, start any new stream with LZ4_resetStream_fast().
+ *  A same LZ4_stream_t can be re-used multiple times consecutively
+ *  and compress multiple streams,
+ *  provided that it starts each new stream with LZ4_resetStream_fast().
+ *
+ *  LZ4_resetStream_fast() is much faster than LZ4_initStream(),
+ *  but is not compatible with memory regions containing garbage data.
+ *  For this reason, LZ4_stream_t must be initialized at least once,
  */
-LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
+LZ4LIB_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
 
 /*! LZ4_loadDict() :
  *  Use this function to load a static dictionary into LZ4_stream_t.
@@ -394,42 +408,6 @@ LZ4LIB_API int LZ4_decompress_safe_usingDict (const char* src, char* dst, int sr
 
 #ifdef LZ4_STATIC_LINKING_ONLY
 
-/*! LZ4_resetStream_fast() :
- *  Use this to prepare a context for a new chain of calls to a streaming API
- *  (e.g., LZ4_compress_fast_continue()).
- *
- *  Note:
- *  To stay on the safe side, when LZ4_stream_t is used for the first time,
- *  it should be either created using LZ4_createStream() or
- *  initialized using LZ4_resetStream().
- *
- *  Note:
- *  Using this in advance of a non-streaming-compression function is redundant,
- *  since they all perform their own custom reset internally.
- *
- *  Differences from LZ4_resetStream():
- *  When an LZ4_stream_t is known to be in an internally coherent state,
- *  it will be prepared for a new compression with almost no work.
- *  Otherwise, it will fall back to the full, expensive reset.
- *
- *  LZ4_streams are guaranteed to be in a valid state when:
- *  - returned from LZ4_createStream()
- *  - reset by LZ4_resetStream()
- *  - memset(stream, 0, sizeof(LZ4_stream_t)), though this is discouraged
- *  - the stream was in a valid state and was reset by LZ4_resetStream_fast()
- *  - the stream was in a valid state and was then used in any compression call
- *    that returned success
- *  - the stream was in an indeterminate state and was used in a compression
- *    call that fully reset the state (e.g., LZ4_compress_fast_extState()) and
- *    that returned success
- *
- *  Note:
- *  A stream that was used in a compression call that did not return success
- *  (e.g., LZ4_compress_fast_continue()), can still be passed to this function,
- *  however, it's history is not preserved because of previous compression
- *  failure.
- */
-LZ4LIB_STATIC_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
 
 /*! LZ4_compress_fast_extState_fastReset() :
  *  A variant of LZ4_compress_fast_extState().
@@ -530,10 +508,12 @@ typedef struct {
 
 /*! LZ4_stream_t :
  *  information structure to track an LZ4 stream.
- *  init this structure with LZ4_resetStream() before first use.
- *  note : only use in association with static linking !
- *         this definition is not API/ABI safe,
- *         it may change in a future version !
+ *  LZ4_stream_t can also be created using LZ4_createStream(), which is recommended.
+ *  The structure definition can be convenient for static allocation
+ *  (on stack, or as part of larger structure).
+ *  Init this structure with LZ4_initStream() before first use.
+ *  note : only use this definition in association with static linking !
+ *    this definition is not API/ABI safe, and may change in a future version.
  */
 #define LZ4_STREAMSIZE_U64 ((1 << (LZ4_MEMORY_USAGE-3)) + 4 + ((sizeof(void*)==16) ? 4 : 0) /*AS-400*/ )
 #define LZ4_STREAMSIZE     (LZ4_STREAMSIZE_U64 * sizeof(unsigned long long))
@@ -541,6 +521,18 @@ union LZ4_stream_u {
     unsigned long long table[LZ4_STREAMSIZE_U64];
     LZ4_stream_t_internal internal_donotuse;
 } ;  /* previously typedef'd to LZ4_stream_t */
+
+/*! LZ4_initStream() :
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  While this is automatically done when invoking LZ4_createStream(),
+ *  it's not when the structure is simply declared on stack (for example).
+ *  Use this function to properly initialize a newly declared LZ4_stream_t.
+ *  It can also accept any arbitrary buffer of sufficient size as input,
+ *  and will return a pointer of proper type upon initialization.
+ *  Note : initialization can fail if size < sizeof(LZ4_stream_t).
+ *  In which case, the function will @return NULL.
+ */
+LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
 
 
 /*! LZ4_streamDecode_t :
@@ -651,6 +643,14 @@ LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decom
 int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
 LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_usingDict() instead") LZ4LIB_API
 int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
+
+/*! LZ4_resetStream() :
+ *  An LZ4_stream_t structure must be initialized at least once.
+ *  This is done with LZ4_initStream(), or LZ4_resetStream().
+ *  Consider switching to LZ4_initStream(),
+ *  invoking LZ4_resetStream() will trigger deprecation warnings in the future.
+ */
+LZ4LIB_API void LZ4_resetStream (LZ4_stream_t* streamPtr);
 
 
 #endif /* LZ4_H_2983827168210 */

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -630,7 +630,8 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
             if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
                 LZ4_initStream((LZ4_stream_t *) cctxPtr->lz4CtxPtr, sizeof (LZ4_stream_t));
             } else {
-                LZ4_initStreamHC((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel);
+                LZ4_initStreamHC((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, sizeof(LZ4_streamHC_t));
+                LZ4_setCompressionLevel((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel);
             }
             cctxPtr->lz4CtxState = ctxTypeID;
         }

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1,41 +1,44 @@
 /*
-LZ4 auto-framing library
-Copyright (C) 2011-2016, Yann Collet.
-
-BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-You can contact the author at :
-- LZ4 homepage : http://www.lz4.org
-- LZ4 source repository : https://github.com/lz4/lz4
-*/
+ * LZ4 auto-framing library
+ * Copyright (C) 2011-2016, Yann Collet.
+ *
+ * BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following disclaimer
+ *   in the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * You can contact the author at :
+ * - LZ4 homepage : http://www.lz4.org
+ * - LZ4 source repository : https://github.com/lz4/lz4
+ */
 
 /* LZ4F is a stand-alone API to create LZ4-compressed Frames
-*  in full conformance with specification v1.6.1 .
-*  This library rely upon memory management capabilities.
-* */
+ * in full conformance with specification v1.6.1 .
+ * This library rely upon memory management capabilities (malloc, free)
+ * provided either by <stdlib.h>,
+ * or redirected towards another library of user's choice
+ * (see Memory Routines below).
+ */
 
 
 /*-************************************
@@ -62,20 +65,27 @@ You can contact the author at :
 /*-************************************
 *  Memory routines
 **************************************/
+/*
+ * User may redirect invocations of
+ * malloc(), calloc() and free()
+ * towards another library or solution of their choice
+ * by modifying below section.
+ */
 #include <stdlib.h>   /* malloc, calloc, free */
 #define ALLOC(s)       malloc(s)
-#ifndef LZ4_SRC_INCLUDED
-#define ALLOC_AND_ZERO(s)  calloc(1,(s))
+#ifndef LZ4_SRC_INCLUDED   /* avoid redefinition when sources are coalesced */
+#  define ALLOC_AND_ZERO(s)  calloc(1,(s))
 #endif
 #define FREEMEM(p)     free(p)
+
 #include <string.h>   /* memset, memcpy, memmove */
-#ifndef LZ4_SRC_INCLUDED
-#define MEM_INIT       memset
+#ifndef LZ4_SRC_INCLUDED  /* avoid redefinition when sources are coalesced */
+#  define MEM_INIT       memset
 #endif
 
 
 /*-************************************
-*  Includes
+*  Library declarations
 **************************************/
 #define LZ4F_STATIC_LINKING_ONLY
 #include "lz4frame.h"
@@ -606,11 +616,12 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
         if (cctxPtr->lz4CtxAlloc < ctxTypeID) {
             FREEMEM(cctxPtr->lz4CtxPtr);
             if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
-                cctxPtr->lz4CtxPtr = (void*)LZ4_createStream();
+                cctxPtr->lz4CtxPtr = LZ4_createStream();
             } else {
-                cctxPtr->lz4CtxPtr = (void*)LZ4_createStreamHC();
+                cctxPtr->lz4CtxPtr = LZ4_createStreamHC();
             }
-            if (cctxPtr->lz4CtxPtr == NULL) return err0r(LZ4F_ERROR_allocation_failed);
+            if (cctxPtr->lz4CtxPtr == NULL)
+                return err0r(LZ4F_ERROR_allocation_failed);
             cctxPtr->lz4CtxAlloc = ctxTypeID;
             cctxPtr->lz4CtxState = ctxTypeID;
         } else if (cctxPtr->lz4CtxState != ctxTypeID) {
@@ -619,7 +630,7 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
             if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
                 LZ4_resetStream((LZ4_stream_t *) cctxPtr->lz4CtxPtr);
             } else {
-                LZ4_resetStreamHC((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel);
+                LZ4_initStreamHC((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel);
             }
             cctxPtr->lz4CtxState = ctxTypeID;
         }
@@ -1268,9 +1279,10 @@ static void LZ4F_updateDict(LZ4F_dctx* dctx,
         return;
     }
 
-    if (dstPtr - dstBufferStart + dstSize >= 64 KB) {  /* history in dstBuffer becomes large enough to become dictionary */
+    assert(dstPtr >= dstBufferStart);
+    if ((size_t)(dstPtr - dstBufferStart) + dstSize >= 64 KB) {  /* history in dstBuffer becomes large enough to become dictionary */
         dctx->dict = (const BYTE*)dstBufferStart;
-        dctx->dictSize = dstPtr - dstBufferStart + dstSize;
+        dctx->dictSize = (size_t)(dstPtr - dstBufferStart) + dstSize;
         return;
     }
 
@@ -1286,7 +1298,7 @@ static void LZ4F_updateDict(LZ4F_dctx* dctx,
     }
 
     if (withinTmp) { /* copy relevant dict portion in front of tmpOut within tmpOutBuffer */
-        size_t const preserveSize = dctx->tmpOut - dctx->tmpOutBuffer;
+        size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
         size_t copySize = 64 KB - dctx->tmpOutSize;
         const BYTE* const oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
         if (dctx->tmpOutSize > 64 KB) copySize = 0;
@@ -1371,7 +1383,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
 
         case dstage_getFrameHeader:
             if ((size_t)(srcEnd-srcPtr) >= maxFHSize) {  /* enough to decode - shortcut */
-                size_t const hSize = LZ4F_decodeHeader(dctx, srcPtr, srcEnd-srcPtr);  /* will update dStage appropriately */
+                size_t const hSize = LZ4F_decodeHeader(dctx, srcPtr, (size_t)(srcEnd-srcPtr));  /* will update dStage appropriately */
                 if (LZ4F_isError(hSize)) return hSize;
                 srcPtr += hSize;
                 break;
@@ -1593,13 +1605,13 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                         dict, (int)dictSize);
                 if (decodedSize < 0) return err0r(LZ4F_ERROR_GENERIC);   /* decompression failed */
                 if (dctx->frameInfo.contentChecksumFlag)
-                    XXH32_update(&(dctx->xxh), dstPtr, decodedSize);
+                    XXH32_update(&(dctx->xxh), dstPtr, (size_t)decodedSize);
                 if (dctx->frameInfo.contentSize)
-                    dctx->frameRemainingSize -= decodedSize;
+                    dctx->frameRemainingSize -= (size_t)decodedSize;
 
                 /* dictionary management */
                 if (dctx->frameInfo.blockMode==LZ4F_blockLinked)
-                    LZ4F_updateDict(dctx, dstPtr, decodedSize, dstStart, 0);
+                    LZ4F_updateDict(dctx, dstPtr, (size_t)decodedSize, dstStart, 0);
 
                 dstPtr += decodedSize;
                 dctx->dStage = dstage_getBlockHeader;
@@ -1636,10 +1648,10 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 if (decodedSize < 0)  /* decompression failed */
                     return err0r(LZ4F_ERROR_decompressionFailed);
                 if (dctx->frameInfo.contentChecksumFlag)
-                    XXH32_update(&(dctx->xxh), dctx->tmpOut, decodedSize);
+                    XXH32_update(&(dctx->xxh), dctx->tmpOut, (size_t)decodedSize);
                 if (dctx->frameInfo.contentSize)
-                    dctx->frameRemainingSize -= decodedSize;
-                dctx->tmpOutSize = decodedSize;
+                    dctx->frameRemainingSize -= (size_t)decodedSize;
+                dctx->tmpOutSize = (size_t)decodedSize;
                 dctx->tmpOutStart = 0;
                 dctx->dStage = dstage_flushOut;
             }
@@ -1767,7 +1779,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
       && ((unsigned)(dctx->dStage)-2 < (unsigned)(dstage_getSuffix)-2) )  /* valid stages : [init ... getSuffix[ */
     {
         if (dctx->dStage == dstage_flushOut) {
-            size_t const preserveSize = dctx->tmpOut - dctx->tmpOutBuffer;
+            size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
             size_t copySize = 64 KB - dctx->tmpOutSize;
             const BYTE* oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
             if (dctx->tmpOutSize > 64 KB) copySize = 0;
@@ -1791,8 +1803,8 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
         }
     }
 
-    *srcSizePtr = (srcPtr - srcStart);
-    *dstSizePtr = (dstPtr - dstStart);
+    *srcSizePtr = (size_t)(srcPtr - srcStart);
+    *dstSizePtr = (size_t)(dstPtr - dstStart);
     return nextSrcSizeHint;
 }
 

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -446,7 +446,7 @@ size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
     if (preferencesPtr == NULL ||
         preferencesPtr->compressionLevel < LZ4HC_CLEVEL_MIN)
     {
-        LZ4_resetStream(&lz4ctx);
+        LZ4_initStream(&lz4ctx, sizeof(lz4ctx));
         cctxPtr->lz4CtxPtr = &lz4ctx;
         cctxPtr->lz4CtxAlloc = 1;
         cctxPtr->lz4CtxState = 1;
@@ -628,7 +628,7 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
             /* otherwise, a sufficient buffer is allocated, but we need to
              * reset it to the correct context type */
             if (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) {
-                LZ4_resetStream((LZ4_stream_t *) cctxPtr->lz4CtxPtr);
+                LZ4_initStream((LZ4_stream_t *) cctxPtr->lz4CtxPtr, sizeof (LZ4_stream_t));
             } else {
                 LZ4_initStreamHC((LZ4_streamHC_t *) cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel);
             }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -911,7 +911,7 @@ void LZ4_initStreamHC (void* state, int compressionLevel)
 /* just a stub */
 void LZ4_resetStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
-    return LZ4_initStreamHC(LZ4_streamHCPtr, compressionLevel);
+    LZ4_initStreamHC(LZ4_streamHCPtr, compressionLevel);
 }
 
 void LZ4_resetStreamHC_fast (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -265,7 +265,7 @@ union LZ4_streamHC_u {
  * Static allocation shall only be used in combination with static linking.
  */
 
-LZ4LIB_API void LZ4_initStreamHC (void* streamHCPtr, int compressionLevel);  /* v1.9.0+ */
+LZ4LIB_API LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size);
 
 
 /*-************************************
@@ -299,7 +299,7 @@ LZ4_DEPRECATED("use LZ4_freeStreamHC() instead") LZ4LIB_API   int   LZ4_freeHC (
 LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC2_continue               (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int compressionLevel);
 LZ4_DEPRECATED("use LZ4_compress_HC_continue() instead") LZ4LIB_API int LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* source, char* dest, int inputSize, int maxOutputSize, int compressionLevel);
 LZ4_DEPRECATED("use LZ4_createStreamHC() instead") LZ4LIB_API int   LZ4_sizeofStreamStateHC(void);
-LZ4_DEPRECATED("use LZ4_resetStreamHC() instead") LZ4LIB_API  int   LZ4_resetStreamStateHC(void* state, char* inputBuffer);
+LZ4_DEPRECATED("use LZ4_initStreamHC() instead") LZ4LIB_API  int   LZ4_resetStreamStateHC(void* state, char* inputBuffer);
 
 
 /* LZ4_resetStreamHC() is now replaced by LZ4_initStreamHC().
@@ -310,7 +310,7 @@ LZ4_DEPRECATED("use LZ4_resetStreamHC() instead") LZ4LIB_API  int   LZ4_resetStr
  * It is recommended to switch to LZ4_initStreamHC().
  * LZ4_resetStreamHC() will generate deprecation warnings in a future version.
  */
-LZ4LIB_API void LZ4_resetStreamHC (LZ4_streamHC_t* streamHCPtr, int compressionLevel);
+//LZ4LIB_API void LZ4_resetStreamHC (LZ4_streamHC_t* streamHCPtr, int compressionLevel);
 
 
 #if defined (__cplusplus)

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -310,7 +310,7 @@ LZ4_DEPRECATED("use LZ4_initStreamHC() instead") LZ4LIB_API  int   LZ4_resetStre
  * It is recommended to switch to LZ4_initStreamHC().
  * LZ4_resetStreamHC() will generate deprecation warnings in a future version.
  */
-//LZ4LIB_API void LZ4_resetStreamHC (LZ4_streamHC_t* streamHCPtr, int compressionLevel);
+LZ4LIB_API void LZ4_resetStreamHC (LZ4_streamHC_t* streamHCPtr, int compressionLevel);
 
 
 #if defined (__cplusplus)

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -152,7 +152,7 @@ LZ4LIB_API int             LZ4_freeStreamHC (LZ4_streamHC_t* streamHCPtr);
   just by resetting it, using LZ4_resetStreamHC_fast().
 */
 
-LZ4LIB_API void LZ4_resetStreamHC_fast(LZ4_streamHC_t* streamHCPtr, int compressionLevel);
+LZ4LIB_API void LZ4_resetStreamHC_fast(LZ4_streamHC_t* streamHCPtr, int compressionLevel);   /* v1.9.0+ */
 LZ4LIB_API int  LZ4_loadDictHC (LZ4_streamHC_t* streamHCPtr, const char* dictionary, int dictSize);
 
 LZ4LIB_API int LZ4_compress_HC_continue (LZ4_streamHC_t* streamHCPtr,
@@ -265,7 +265,7 @@ union LZ4_streamHC_u {
  * Static allocation shall only be used in combination with static linking.
  */
 
-LZ4LIB_API void LZ4_initStreamHC (void* streamHCPtr, int compressionLevel);
+LZ4LIB_API void LZ4_initStreamHC (void* streamHCPtr, int compressionLevel);  /* v1.9.0+ */
 
 
 /*-************************************

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -115,15 +115,15 @@ checkFrame : lz4frame.o lz4.o lz4hc.o xxhash.o checkFrame.c
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
-	@$(RM) core *.o *.test tmp* \
+	@$(RM) -rf core *.o *.test tmp* \
         fullbench-dll$(EXT) fullbench-lib$(EXT) \
         fullbench$(EXT) fullbench32$(EXT) \
         fuzzer$(EXT) fuzzer32$(EXT) \
         frametest$(EXT) frametest32$(EXT) \
         fasttest$(EXT) roundTripTest$(EXT) \
         datagen$(EXT) checkTag$(EXT) \
-				frameTest$(EXT)
-	@rm -fR $(TESTDIR)
+        frameTest$(EXT)
+	@$(RM) -rf $(TESTDIR)
 	@echo Cleaning completed
 
 .PHONY: versionsTest

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -151,12 +151,18 @@ endif
 
 DD:=dd
 
+.PHONY: list
+list:
+	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
 
+.PHONY: test
 test: test-lz4 test-lz4c test-frametest test-fullbench test-fuzzer test-install test-amalgamation
 
+.PHONY: test32
 test32: CFLAGS+=-m32
 test32: test
 
+.PHONY: test-amalgamation
 test-amalgamation: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c
 	cat $(LZ4DIR)/lz4.c > lz4_all.c
 	cat $(LZ4DIR)/lz4hc.c >> lz4_all.c

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -327,7 +327,7 @@ test-lz4-dict: lz4 datagen
 test-lz4-hugefile: lz4 datagen
 	@echo "\n ---- test huge files compression/decompression ----"
 	./datagen -g6GB   | $(LZ4) -vB5D  | $(LZ4) -qt
-	./datagen -g6GB   | $(LZ4) -v5BD  | $(LZ4) -qt
+	./datagen -g5GB   | $(LZ4) -v4BD  | $(LZ4) -qt
 	# test large file size [2-4] GB
 	@./datagen -g3G -P100 | $(LZ4) -vv | $(LZ4) --decompress --force --sparse - tmphf1
 	@ls -ls tmphf1

--- a/tests/checkFrame.c
+++ b/tests/checkFrame.c
@@ -1,6 +1,6 @@
   /*
       checkFrame - verify frame headers
-      Copyright (C) Yann Collet 2014-2016
+      Copyright (C) Yann Collet 2014-present
 
       GPL v2 License
 
@@ -159,8 +159,12 @@ int frameCheck(cRess_t ress, FILE* const srcFile, unsigned bsid, size_t blockSiz
                 curblocksize = 0;
                 remaining = readSize - pos;
                 nextToLoad = LZ4F_getFrameInfo(ress.ctx, &frameInfo, (char*)(ress.srcBuffer)+pos, &remaining);
-                if (LZ4F_isError(nextToLoad)) EXM_THROW(22, "Error getting frame info: %s", LZ4F_getErrorName(nextToLoad)); /* XXX */
-                if (frameInfo.blockSizeID != bsid) EXM_THROW(23, "Block size ID %u != expected %u", frameInfo.blockSizeID, bsid);
+                if (LZ4F_isError(nextToLoad))
+                    EXM_THROW(22, "Error getting frame info: %s",
+                                LZ4F_getErrorName(nextToLoad));
+                if (frameInfo.blockSizeID != bsid)
+                    EXM_THROW(23, "Block size ID %u != expected %u",
+                                frameInfo.blockSizeID, bsid);
                 pos += remaining;
                 /* nextToLoad should be block header size */
                 remaining = nextToLoad;
@@ -189,7 +193,8 @@ int frameCheck(cRess_t ress, FILE* const srcFile, unsigned bsid, size_t blockSiz
                 /* detect small block due to end of frame; the final 4-byte frame checksum could be left in the buffer */
                 if ((curblocksize != 0) && (nextToLoad > 4)) {
                     if (curblocksize != blockSize)
-                        EXM_THROW(25, "Block size %zu != expected %zu, pos %zu\n", curblocksize, blockSize, pos);
+                        EXM_THROW(25, "Block size %u != expected %u, pos %u\n",
+                                    (unsigned)curblocksize, (unsigned)blockSize, (unsigned)pos);
                 }
                 curblocksize = 0;
             }
@@ -220,7 +225,7 @@ int FUZ_usage(const char* programName)
 int main(int argc, const char** argv)
 {
     int argNb;
-    int bsid=0;
+    unsigned bsid=0;
     size_t blockSize=0;
     const char* const programName = argv[0];
 
@@ -262,7 +267,7 @@ int main(int argc, const char** argv)
                     bsid=0;
                     while ((*argument>='0') && (*argument<='9')) {
                         bsid *= 10;
-                        bsid += *argument - '0';
+                        bsid += (unsigned)(*argument - '0');
                         argument++;
                     }
                     break;
@@ -272,7 +277,7 @@ int main(int argc, const char** argv)
                     blockSize=0;
                     while ((*argument>='0') && (*argument<='9')) {
                         blockSize *= 10;
-                        blockSize += *argument - '0';
+                        blockSize += (size_t)(*argument - '0');
                         argument++;
                     }
                     break;

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -270,7 +270,7 @@ int basicTests(U32 seed, double compressibility)
             if (decResult != 0) goto _output_error;   /* should finish now */
             op += oSize;
             if (op>oend) { DISPLAY("decompression write overflow \n"); goto _output_error; }
-            {   U64 const crcDest = XXH64(decodedBuffer, op-ostart, 1);
+            {   U64 const crcDest = XXH64(decodedBuffer, (size_t)(op-ostart), 1);
                 if (crcDest != crcOrig) goto _output_error;
         }   }
 
@@ -309,7 +309,6 @@ int basicTests(U32 seed, double compressibility)
             iSize = 15 - iSize;
             CHECK( LZ4F_getFrameInfo(dCtx, &fi, ip, &iSize) );
             DISPLAYLEVEL(3, " correctly decoded \n");
-            ip += iSize;
         }
 
         DISPLAYLEVEL(3, "Decode a buggy input : ");
@@ -337,7 +336,7 @@ int basicTests(U32 seed, double compressibility)
             const BYTE* ip = (const BYTE*) compressedBuffer;
             const BYTE* const iend = ip + cSize;
             while (ip < iend) {
-                size_t oSize = oend-op;
+                size_t oSize = (size_t)(oend-op);
                 size_t iSize = 1;
                 CHECK( LZ4F_decompress(dCtx, op, &oSize, ip, &iSize, NULL) );
                 op += oSize;
@@ -380,8 +379,8 @@ int basicTests(U32 seed, double compressibility)
         while (ip < iend) {
             unsigned const nbBits = FUZ_rand(&randState) % maxBits;
             size_t iSize = (FUZ_rand(&randState) & ((1<<nbBits)-1)) + 1;
-            size_t oSize = oend-op;
-            if (iSize > (size_t)(iend-ip)) iSize = iend-ip;
+            size_t oSize = (size_t)(oend-op);
+            if (iSize > (size_t)(iend-ip)) iSize = (size_t)(iend-ip);
             CHECK( LZ4F_decompress(dCtx, op, &oSize, ip, &iSize, NULL) );
             op += oSize;
             ip += iSize;

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -161,12 +161,12 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 static LZ4_stream_t LZ4_stream;
 static void local_LZ4_resetDictT(void)
 {
-    LZ4_resetStream(&LZ4_stream);
+    LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
 }
 
 static void local_LZ4_createStream(void)
 {
-    LZ4_resetStream(&LZ4_stream);
+    LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
 }
 
 static int local_LZ4_saveDict(const char* in, char* out, int inSize)

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -161,12 +161,14 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 static LZ4_stream_t LZ4_stream;
 static void local_LZ4_resetDictT(void)
 {
-    LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
+    void* const r = LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
+    assert(r != NULL);
 }
 
 static void local_LZ4_createStream(void)
 {
-    LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
+    void* const r = LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
+    assert(r != NULL);
 }
 
 static int local_LZ4_saveDict(const char* in, char* out, int inSize)

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -243,7 +243,7 @@ static int local_LZ4_compress_forceDict(const char* in, char* out, int inSize)
 LZ4_streamHC_t LZ4_streamHC;
 static void local_LZ4_resetStreamHC(void)
 {
-    LZ4_resetStreamHC(&LZ4_streamHC, 0);
+    LZ4_initStreamHC(&LZ4_streamHC, 0);
 }
 
 static int local_LZ4_saveDictHC(const char* in, char* out, int inSize)
@@ -327,16 +327,19 @@ static int local_LZ4_decompress_safe_partial(const char* in, char* out, int inSi
 /* frame functions */
 static int local_LZ4F_compressFrame(const char* in, char* out, int inSize)
 {
-    return (int)LZ4F_compressFrame(out, LZ4F_compressFrameBound(inSize, NULL), in, inSize, NULL);
+    assert(inSize >= 0);
+    return (int)LZ4F_compressFrame(out, LZ4F_compressFrameBound((size_t)inSize, NULL), in, (size_t)inSize, NULL);
 }
 
 static LZ4F_decompressionContext_t g_dCtx;
 
 static int local_LZ4F_decompress(const char* in, char* out, int inSize, int outSize)
 {
-    size_t srcSize = inSize;
-    size_t dstSize = outSize;
+    size_t srcSize = (size_t)inSize;
+    size_t dstSize = (size_t)outSize;
     size_t result;
+    assert(inSize >= 0);
+    assert(outSize >= 0);
     result = LZ4F_decompress(g_dCtx, out, &dstSize, in, &srcSize, NULL);
     if (result!=0) { DISPLAY("Error decompressing frame : unfinished frame\n"); exit(8); }
     if (srcSize != (size_t)inSize) { DISPLAY("Error decompressing frame : read size incorrect\n"); exit(9); }
@@ -439,7 +442,7 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
                 char* out = compressed_buff;
                 nbChunks = (int) (((int)benchedSize + (g_chunkSize-1))/ g_chunkSize);
                 for (i=0; i<nbChunks; i++) {
-                    chunkP[i].id = i;
+                    chunkP[i].id = (U32)i;
                     chunkP[i].origBuffer = in; in += g_chunkSize;
                     if ((int)remaining > g_chunkSize) { chunkP[i].origSize = g_chunkSize; remaining -= g_chunkSize; } else { chunkP[i].origSize = (int)remaining; remaining = 0; }
                     chunkP[i].compressedBuffer = out; out += maxCompressedChunkSize;
@@ -611,7 +614,7 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
                 PROGRESS("%2i-%-34.34s :%10i -> %7.1f MB/s\r", loopNb, dName, (int)benchedSize, (double)benchedSize / bestTime / 1000000);
 
                 /* CRC Checking */
-                crcDecoded = XXH32(orig_buff, (int)benchedSize, 0);
+                crcDecoded = XXH32(orig_buff, benchedSize, 0);
                 if (checkResult && (crcOriginal!=crcDecoded)) {
                     DISPLAY("\n!!! WARNING !!! %14s : Invalid Checksum : %x != %x\n",
                             inFileName, (unsigned)crcOriginal, (unsigned)crcDecoded);

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -245,7 +245,7 @@ static int local_LZ4_compress_forceDict(const char* in, char* out, int inSize)
 LZ4_streamHC_t LZ4_streamHC;
 static void local_LZ4_resetStreamHC(void)
 {
-    LZ4_initStreamHC(&LZ4_streamHC, 0);
+    LZ4_initStreamHC(&LZ4_streamHC, sizeof(LZ4_streamHC));
 }
 
 static int local_LZ4_saveDictHC(const char* in, char* out, int inSize)

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -37,6 +37,7 @@
 *  Dependencies
 **************************************/
 #if defined(__unix__) && !defined(_AIX)   /* must be included before platform.h for MAP_ANONYMOUS */
+#  define _GNU_SOURCE     /* MAP_ANONYMOUS even in -std=c99 mode */
 #  include <sys/mman.h>   /* mmap */
 #endif
 #include "platform.h"   /* _CRT_SECURE_NO_WARNINGS */
@@ -47,9 +48,6 @@
 #include <time.h>       /* clock_t, clock, CLOCKS_PER_SEC */
 #include <assert.h>
 #include <limits.h>     /* INT_MAX */
-#if defined(__unix__) && defined(_AIX)
-#  include <sys/mman.h>   /* mmap */
-#endif
 
 #define LZ4_DISABLE_DEPRECATE_WARNINGS   /* LZ4_decompress_fast */
 #define LZ4_STATIC_LINKING_ONLY

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -836,16 +836,16 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         FUZ_CHECKTEST(blockContinueCompressedSize==0, "LZ4_compress_HC_continue failed");
         FUZ_CHECKTEST(LZ4dictHC.internal_donotuse.dirty, "Context should be clean");
 
-        FUZ_DISPLAYTEST();
+        FUZ_DISPLAYTEST("LZ4_compress_HC_continue with same external dictionary, but output buffer 1 byte too short");
         LZ4_loadDictHC(&LZ4dictHC, dict, dictSize);
         ret = LZ4_compress_HC_continue(&LZ4dictHC, block, compressedBuffer, blockSize, blockContinueCompressedSize-1);
-        FUZ_CHECKTEST(ret>0, "LZ4_compress_HC_continue using ExtDict should fail : one missing byte for output buffer (%i != %i)", ret, blockContinueCompressedSize);
+        FUZ_CHECKTEST(ret>0, "LZ4_compress_HC_continue using ExtDict should fail : one missing byte for output buffer (expected %i, but result=%i)", blockContinueCompressedSize, ret);
         FUZ_CHECKTEST(!LZ4dictHC.internal_donotuse.dirty, "Context should be dirty");
 
-        FUZ_DISPLAYTEST();
+        FUZ_DISPLAYTEST("LZ4_compress_HC_continue with same external dictionary, and output buffer exactly the right size");
         LZ4_loadDictHC(&LZ4dictHC, dict, dictSize);
         ret = LZ4_compress_HC_continue(&LZ4dictHC, block, compressedBuffer, blockSize, blockContinueCompressedSize);
-        FUZ_CHECKTEST(ret!=blockContinueCompressedSize, "LZ4_compress_HC_continue size is different (%i != %i)", ret, blockContinueCompressedSize);
+        FUZ_CHECKTEST(ret!=blockContinueCompressedSize, "LZ4_compress_HC_continue size is different : ret(%i) != expected(%i)", ret, blockContinueCompressedSize);
         FUZ_CHECKTEST(ret<=0, "LZ4_compress_HC_continue should work : enough size available within output buffer");
         FUZ_CHECKTEST(LZ4dictHC.internal_donotuse.dirty, "Context should be clean");
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -37,6 +37,7 @@
 *  Dependencies
 **************************************/
 #if defined(__unix__) && !defined(_AIX)   /* must be included before platform.h for MAP_ANONYMOUS */
+#  undef  _GNU_SOURCE     /* in case it's already defined */
 #  define _GNU_SOURCE     /* MAP_ANONYMOUS even in -std=c99 mode */
 #  include <sys/mman.h>   /* mmap */
 #endif

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -641,7 +641,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         /* Compress using dictionary */
         FUZ_DISPLAYTEST("test LZ4_compress_fast_continue() with dictionary of size %i", dictSize);
         {   LZ4_stream_t LZ4_stream;
-            LZ4_resetStream(&LZ4_stream);
+            LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
             LZ4_compress_fast_continue (&LZ4_stream, dict, compressedBuffer, dictSize, (int)compressedBufferSize, 1);   /* Just to fill hash tables */
             blockContinueCompressedSize = LZ4_compress_fast_continue (&LZ4_stream, block, compressedBuffer, blockSize, (int)compressedBufferSize, 1);
             FUZ_CHECKTEST(blockContinueCompressedSize==0, "LZ4_compress_fast_continue failed");
@@ -742,7 +742,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
 
             FUZ_DISPLAYTEST("LZ4_compress_fast_continue() after LZ4_attach_dictionary()");
             LZ4_loadDict(&LZ4dict, dict, dictSize);
-            LZ4_resetStream(&LZ4_stream);
+            LZ4_initStream(&LZ4_stream, sizeof(LZ4_stream));
             LZ4_attach_dictionary(&LZ4_stream, &LZ4dict);
             blockContinueCompressedSize = LZ4_compress_fast_continue(&LZ4_stream, block, compressedBuffer, blockSize, (int)compressedBufferSize, 1);
             FUZ_CHECKTEST(blockContinueCompressedSize==0, "LZ4_compress_fast_continue using extDictCtx failed");
@@ -1000,7 +1000,7 @@ static void FUZ_unitTests(int compressionLevel)
 
         /* simple compression test */
         crcOrig = XXH64(testInput, testCompressedSize, 0);
-        LZ4_resetStream(&streamingState);
+        LZ4_initStream(&streamingState, sizeof(streamingState));
         result = LZ4_compress_fast_continue(&streamingState, testInput, testCompressed, testCompressedSize, testCompressedSize-1, 1);
         FUZ_CHECKTEST(result==0, "LZ4_compress_fast_continue() compression failed!");
         FUZ_CHECKTEST(streamingState.internal_donotuse.dirty, "context should be clean")


### PR DESCRIPTION
Following discussion on LZ4 v1.9.0 API evolution,
here is a proposal pushing `LZ4_resetStream*fast()` into "stable" category.

As a consequence, it triggers a number of additional decisions related to API consistency.
- `LZ4_resetStream*_fast()` is now the recommended method to start a new stream of blocks, since it's faster.
- But it cannot completely replace `LZ4_resetStream*()` for uninitialized objects
- Since it's hard to explain the difference between `reset` and `reset_fast` in term of "one is an initializer, the other is the recommended reset", I created `LZ4_initStream*()` for the sole purpose of initializing `LZ4_stream*_t` objects allocated by the user (typically on stack) and which may contain arbitrary garbage values.

The main issue in this patch is : what is the exact scope of `LZ4_initStream*()` ?
See the quip document on LZ4 API evolution for details.

I have 2 different logics implemented in this patch, depending on fast of HC variant.

choice 1 (implemented in HC) : `LZ4_initStreamHC()` is the exact copy of `LZ4_resetStreamHC`, just a name change. As it does essentially the same thing, transition is easier. But it mixes initialization and reset role, by requesting a compression level too. Also, it accepts any `void*` pointer as argument, as an attempt to be a more general initializer, but does not control buffer size.

choice 2 (implemented in fast) : `LZ4_initStream()` is a pure universal initializer, able to accept any kind of buffer, allocated in any way by the user. As a consequence, prototype is slightly different : it controls the size, it returns a pointer of target type (`LZ4_stream_t`), and it may fail (return `NULL`), specifically if size condition is not respected (note : it should also control alignment - tbd).

This situation will have to be updated before merge, by selecting a single logic for API consistency.

The purpose of this PR is to collect feedback on the target API design.