### PR TITLE
added command -BI for "Independent Blocks"

### DIFF
--- a/programs/lz4.1
+++ b/programs/lz4.1
@@ -159,8 +159,12 @@ Block size [4\-7](default : 7)
 \fB\-B4\fR= 64KB ; \fB\-B5\fR= 256KB ; \fB\-B6\fR= 1MB ; \fB\-B7\fR= 4MB
 .
 .TP
+\fB\-BI\fR
+Produce independent blocks (default)
+.
+.TP
 \fB\-BD\fR
-Block Dependency (improves compression ratio on small blocks)
+Blocks depend on predecessors (improves compression ratio, more noticeable on small blocks)
 .
 .TP
 \fB\-\-[no\-]frame\-crc\fR

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -172,8 +172,11 @@ only the latest one will be applied.
   Block size \[4-7\](default : 7)<br/>
   `-B4`= 64KB ; `-B5`= 256KB ; `-B6`= 1MB ; `-B7`= 4MB
 
+* `-BI`:
+  Produce independent blocks (default)
+
 * `-BD`:
-  Block Dependency (improves compression ratio on small blocks)
+  Blocks depend on predecessors (improves compression ratio, more noticeable on small blocks)
 
 * `--[no-]frame-crc`:
   Select frame checksum (default:enabled)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -248,7 +248,7 @@ test-lz4-basic: lz4 datagen unlz4 lz4cat
 	$(DIFF) -q tmp-tlb-dg20k tmp-tlb-dec
 	$(LZ4) --no-frame-crc < tmp-tlb-dg20k | $(LZ4) -d > tmp-tlb-dec
 	$(DIFF) -q tmp-tlb-dg20k tmp-tlb-dec
-	./datagen           | $(LZ4)        | $(LZ4) -t
+	./datagen           | $(LZ4) -BI    | $(LZ4) -t
 	./datagen -g6M -P99 | $(LZ4) -9BD   | $(LZ4) -t
 	./datagen -g17M     | $(LZ4) -9v    | $(LZ4) -qt
 	./datagen -g33M     | $(LZ4) --no-frame-crc | $(LZ4) -t


### PR DESCRIPTION
This is the reverse of `-BD`, and the current default.

This command can be useful to reverse a previous `-BD` command.

It may become more important in the future 
if `lz4` switches to generating dependent blocks by default.