### PR TITLE
Fix out-of-bound read in LZ4_decompress_fast()

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -135,9 +135,6 @@
 #  endif  /* _MSC_VER */
 #endif /* LZ4_FORCE_INLINE */
 
-#undef LZ4_FORCE_INLINE
-#define LZ4_FORCE_INLINE static /* disable */
-
 /* LZ4_FORCE_O2_GCC_PPC64LE and LZ4_FORCE_O2_INLINE_GCC_PPC64LE
  * Gcc on ppc64le generates an unrolled SIMDized loop for LZ4_wildCopy,
  * together with a simple 8-byte copy loop as a fall-back path.

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -631,14 +631,15 @@ LZ4_DEPRECATED("use LZ4_decompress_safe_usingDict() instead") LZ4LIB_API int LZ4
 LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4_decompress_fast_withPrefix64k (const char* src, char* dst, int originalSize);
 
 /*! LZ4_decompress_fast() : **unsafe!**
- *  These functions are generally slightly faster than LZ4_decompress_safe(),
- *  though the difference is small (generally ~5%).
- *  However, the real cost is a risk :  LZ4_decompress_safe() is protected vs malformed input, while `LZ4_decompress_fast()` is not, making it a security liability.
+ *  These functions used to be faster than LZ4_decompress_safe(),
+ *  but it has changed, and they are now slower than LZ4_decompress_safe().
+ *  This is because LZ4_decompress_fast() doesn't know the input size,
+ *  and therefore must progress more cautiously in the input buffer to not read beyond the end of block.
+ *  On top of that `LZ4_decompress_fast()` is not protected vs malformed or malicious inputs, making it a security liability.
  *  As a consequence, LZ4_decompress_fast() is strongly discouraged, and deprecated.
- *  These functions will generate a deprecation warning in the future.
  *
- *  Last LZ4_decompress_fast() specificity is that it can decompress a block without knowing its compressed size.
- *  Note that even that functionality could be achieved in a more secure manner if need be,
+ *  Only LZ4_decompress_fast() specificity is that it can decompress a block without knowing its compressed size.
+ *  Even that functionality could be achieved in a more secure manner if need be,
  *  though it would require new prototypes, and adaptation of the implementation to this new use case.
  *
  *  Parameters:
@@ -655,11 +656,11 @@ LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4
  *         As a consequence, use these functions in trusted environments with trusted data **only**.
  */
 
-/* LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe() instead")  */
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe() instead")
 LZ4LIB_API int LZ4_decompress_fast (const char* src, char* dst, int originalSize);
-/* LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_continue() instead") */
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_continue() instead")
 LZ4LIB_API int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
-/* LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_usingDict() instead") */
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_usingDict() instead")
 LZ4LIB_API int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
 
 /*! LZ4_resetStream() :

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -209,7 +209,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                 blockTable[nbBlocks].cPtr = cPtr;
                 blockTable[nbBlocks].resPtr = resPtr;
                 blockTable[nbBlocks].srcSize = thisBlockSize;
-                blockTable[nbBlocks].cRoom = LZ4_compressBound((int)thisBlockSize);
+                blockTable[nbBlocks].cRoom = (size_t)LZ4_compressBound((int)thisBlockSize);
                 srcPtr += thisBlockSize;
                 cPtr += blockTable[nbBlocks].cRoom;
                 resPtr += thisBlockSize;
@@ -257,8 +257,8 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                 for (nbLoops=0; nbLoops < nbCompressionLoops; nbLoops++) {
                     U32 blockNb;
                     for (blockNb=0; blockNb<nbBlocks; blockNb++) {
-                        size_t const rSize = compP.compressionFunction(blockTable[blockNb].srcPtr, blockTable[blockNb].cPtr, (int)blockTable[blockNb].srcSize, (int)blockTable[blockNb].cRoom, cLevel);
-                        if (LZ4_isError(rSize)) EXM_THROW(1, "LZ4_compress() failed");
+                        size_t const rSize = (size_t)compP.compressionFunction(blockTable[blockNb].srcPtr, blockTable[blockNb].cPtr, (int)blockTable[blockNb].srcSize, (int)blockTable[blockNb].cRoom, cLevel);
+                        if (LZ4_isError(rSize)) EXM_THROW(1, "LZ4 compression failed");
                         blockTable[blockNb].cSize = rSize;
                 }   }
                 {   U64 const clockSpan = UTIL_clockSpanNano(clockStart);
@@ -298,12 +298,12 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                 for (nbLoops=0; nbLoops < nbDecodeLoops; nbLoops++) {
                     U32 blockNb;
                     for (blockNb=0; blockNb<nbBlocks; blockNb++) {
-                        size_t const regenSize = LZ4_decompress_safe(blockTable[blockNb].cPtr, blockTable[blockNb].resPtr, (int)blockTable[blockNb].cSize, (int)blockTable[blockNb].srcSize);
-                        if (LZ4_isError(regenSize)) {
+                        int const regenSize = LZ4_decompress_safe(blockTable[blockNb].cPtr, blockTable[blockNb].resPtr, (int)blockTable[blockNb].cSize, (int)blockTable[blockNb].srcSize);
+                        if (regenSize < 0) {
                             DISPLAY("LZ4_decompress_safe() failed on block %u \n", blockNb);
                             break;
                         }
-                        blockTable[blockNb].resSize = regenSize;
+                        blockTable[blockNb].resSize = (size_t)regenSize;
                 }   }
                 {   U64 const clockSpan = UTIL_clockSpanNano(clockStart);
                     if (clockSpan > 0) {

--- a/tests/checkFrame.c
+++ b/tests/checkFrame.c
@@ -105,7 +105,7 @@ typedef struct {
     LZ4F_decompressionContext_t ctx;
 } cRess_t;
 
-static int createCResources(cRess_t *ress)
+static int createCResources(cRess_t* ress)
 {
     ress->srcBufferSize = 4 MB;
     ress->srcBuffer = malloc(ress->srcBufferSize);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -331,7 +331,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         if (cond) {                                            \
             printf("Test %u : ", testNb); printf(__VA_ARGS__); \
             printf(" (seed %u, cycle %u) \n", seed, cycleNb);  \
-            goto _output_error;                                \
+            exit(1);                                           \
         }
 
 #   define FUZ_DISPLAYTEST(...) {                 \
@@ -347,7 +347,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
     /* init */
     if(!CNBuffer || !compressedBuffer || !decodedBuffer) {
         DISPLAY("Not enough memory to start fuzzer tests");
-        goto _output_error;
+        exit(1);
     }
     if ( LZ4_initStream(&LZ4dict, sizeof(LZ4dict)) == NULL) abort();
     if ( LZ4_initStreamHC(&LZ4dictHC, sizeof(LZ4dictHC)) == NULL) abort();
@@ -505,7 +505,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
             decodedBuffer[blockSize-1] = 0;
             ret = LZ4_decompress_fast(cBuffer_exact, decodedBuffer, blockSize-1);
             FUZ_CHECKTEST(ret>=0, "LZ4_decompress_fast should have failed, due to Output Size being too small");
-            FUZ_CHECKTEST(decodedBuffer[blockSize-1], "LZ4_decompress_fast overrun specified output buffer");
+            FUZ_CHECKTEST(decodedBuffer[blockSize-1]!=0, "LZ4_decompress_fast overrun specified output buffer");
 
             /* Test decoding with one byte too much => must fail */
             FUZ_DISPLAYTEST();
@@ -960,20 +960,13 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
     printf("ratio with dict: %0.3f%%\n", (double)ccbytes/bytes*100);
 
     /* release memory */
-    {
-_exit:
-        free(CNBuffer);
-        free(compressedBuffer);
-        free(decodedBuffer);
-        FUZ_freeLowAddr(lowAddrBuffer, labSize);
-        free(stateLZ4);
-        free(stateLZ4HC);
-        return result;
-
-_output_error:
-        result = 1;
-        goto _exit;
-    }
+    free(CNBuffer);
+    free(compressedBuffer);
+    free(decodedBuffer);
+    FUZ_freeLowAddr(lowAddrBuffer, labSize);
+    free(stateLZ4);
+    free(stateLZ4HC);
+    return result;
 }
 
 
@@ -1388,8 +1381,6 @@ static void FUZ_unitTests(int compressionLevel)
 
     printf("All unit tests completed successfully compressionLevel=%d \n", compressionLevel);
     return;
-_output_error:
-    exit(1);
 }
 
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -487,7 +487,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         /* Decompression tests */
 
         /* Test decompress_fast() with input buffer size exactly correct => must not read out of bound */
-        {   char* const cBuffer_exact = malloc((size_t)compressedSize);
+        {   char* const cBuffer_exact = (char*)malloc((size_t)compressedSize);
             assert(cBuffer_exact != NULL);
             memcpy(cBuffer_exact, compressedBuffer, compressedSize);
 


### PR DESCRIPTION
fix #676,

also deprecated `LZ4_decompress_fast()`,
which now generates deprecation warnings by default.

Note also that `LZ4_decompress_fast()` is now slower than `LZ4_decompress_safe()`,
removing any incentive to use it in place of the more secure variant.