### PR TITLE
Add --list option to display compressed file information.

### DIFF
--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -196,10 +196,10 @@ typedef struct {
 typedef struct {
   LZ4F_frameInfo_t frameInfo;
   const char* fileName;
-  unsigned long fileSize;
+  unsigned long long fileSize;
 } LZ4F_compFileInfo_t;
 
-#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, 0UL }
+#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, 0ULL }
 
 /*-*********************************
 *  Simple compression function

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -193,6 +193,13 @@ typedef struct {
 
 #define LZ4F_INIT_PREFERENCES   { LZ4F_INIT_FRAMEINFO, 0, 0u, 0u, { 0u, 0u, 0u } }    /* v1.8.3+ */
 
+typedef struct {
+  LZ4F_frameInfo_t frameInfo;
+  const char* fileName;
+  unsigned long fileSize;
+} LZ4F_compFileInfo_t;
+
+#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, 0UL }
 
 /*-*********************************
 *  Simple compression function

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -114,6 +114,11 @@ only the latest one will be applied.
 * `-b#`:
   Benchmark mode, using `#` compression level.
 
+* `--list`:
+  List mode.
+  Lists information about .lz4 files. 
+  Useful if compressed with --content-size flag.
+
 ### Operation modifiers
 
 * `-#`:
@@ -161,6 +166,7 @@ only the latest one will be applied.
   Multiple input files.
   Compressed file names will be appended a `.lz4` suffix.
   This mode also reduces notification level.
+  Can also be used to list multiple files.
   `lz4 -m` has a behavior equivalent to `gzip -k`
   (it preserves source files by default).
 

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -40,7 +40,6 @@
 #include <stdlib.h>   /* exit, calloc, free */
 #include <string.h>   /* strcmp, strlen */
 #include "bench.h"    /* BMK_benchFile, BMK_SetNbIterations, BMK_SetBlocksize, BMK_SetPause */
-#include "lz4frame.h"
 #include "lz4io.h"    /* LZ4IO_compressFilename, LZ4IO_decompressFilename, LZ4IO_compressMultipleFilenames */
 #include "lz4hc.h"    /* LZ4HC_CLEVEL_MAX */
 #include "lz4.h"      /* LZ4_VERSION_STRING */
@@ -712,7 +711,7 @@ int main(int argc, const char** argv)
         if(!multiple_inputs){
             inFileNames[ifnIdx++] = input_filename;
         }
-        operationResult = LZ4IO_getCompressedFilesInfo(inFileNames, ifnIdx);
+        operationResult = LZ4IO_displayCompressedFilesInfo(inFileNames, ifnIdx);
         inFileNames=NULL;
     } else {
        /* compression is default action */

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -693,7 +693,7 @@ int main(int argc, const char** argv)
         break;
     }
 
-    if (multiple_inputs==0) assert(output_filename);
+    if (multiple_inputs==0 && mode != om_list) assert(output_filename);
     /* when multiple_inputs==1, output_filename may simply be useless,
      * however, output_filename must be !NULL for next strcmp() tests */
     if (!output_filename) output_filename = "*\\dummy^!//";
@@ -721,7 +721,14 @@ int main(int argc, const char** argv)
             operationResult = LZ4IO_decompressMultipleFilenames(prefs, inFileNames, (int)ifnIdx, !strcmp(output_filename,stdoutmark) ? stdoutmark : LZ4_EXTENSION);
         } else {
             operationResult = DEFAULT_DECOMPRESSOR(prefs, input_filename, output_filename);
-
+        }
+    } else if (mode == om_list){
+        if(!multiple_inputs){
+            inFileNames[ifnIdx++] = input_filename;
+        }
+        operationResult = LZ4IO_displayCompressedFilesInfo(inFileNames, ifnIdx);
+        inFileNames=NULL;
+    } else {   /* compression is default action */
         if (legacy_format) {
             DISPLAYLEVEL(3, "! Generating LZ4 Legacy format (deprecated) ! \n");
             LZ4IO_compressFilename_Legacy(prefs, input_filename, output_filename, cLevel);

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -142,7 +142,7 @@ static int usage_advanced(const char* exeName)
     DISPLAY( " -BX    : enable block checksum (default:disabled) \n");
     DISPLAY( "--no-frame-crc : disable stream checksum (default:enabled) \n");
     DISPLAY( "--content-size : compressed frame includes original size (default:not present)\n");
-    DISPLAY( "--list  : list information about .lz4 files. Only useful if compressed with --content-size flag.\n");
+    DISPLAY( "--list  : lists information about .lz4 files. Useful if compressed with --content-size flag.\n");
     DISPLAY( "--[no-]sparse  : sparse mode (default:enabled on file, disabled on stdout)\n");
     DISPLAY( "--favor-decSpeed: compressed files decompress faster, but are less compressed \n");
     DISPLAY( "--fast[=#]: switch to ultra fast compression level (default: %i)\n", 1);
@@ -709,31 +709,11 @@ int main(int argc, const char** argv)
         else
             operationResult = DEFAULT_DECOMPRESSOR(prefs, input_filename, output_filename);
     } else if (mode == om_list){
-        LZ4F_compFileInfo_t cfinfo;
         if(!multiple_inputs){
             inFileNames[ifnIdx++] = input_filename;
         }
-        DISPLAY("%16s\t%-20s\t%-20s\t%-10s\t%s\n","BlockChecksumFlag","Compressed", "Uncompressed", "Ratio", "Filename");
-        for(unsigned int j=0; j<ifnIdx; j++){
-            /* Get file info */
-            if (!LZ4IO_getCompressedFileInfo(inFileNames[j], &cfinfo)){
-                DISPLAYLEVEL(1, "Failed to get frame info.\n");
-                if (!multiple_inputs){
-                    return 1;
-                }
-                continue;
-            }
-            if(cfinfo.frameInfo.contentSize){
-                double ratio = (double)cfinfo.fileSize / cfinfo.frameInfo.contentSize;
-                DISPLAY("%-16d\t%-20llu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
-            }
-            else{
-                DISPLAY("%-16d\t%-20llu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize, "-", "-", cfinfo.fileName);
-            }
-            free(cfinfo.fileName);
-        }
-        free(inFileNames);
-        return 0;
+        operationResult = LZ4IO_getCompressedFilesInfo(inFileNames, ifnIdx);
+        inFileNames=NULL;
     } else {
        /* compression is default action */
         if (legacy_format) {

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -714,9 +714,9 @@ int main(int argc, const char** argv)
             inFileNames[ifnIdx++] = input_filename;
         }
         DISPLAY("%16s\t%-20s\t%-20s\t%-10s\t%s\n","BlockChecksumFlag","Compressed", "Uncompressed", "Ratio", "Filename");
-        for(i=0; i<ifnIdx; i++){
+        for(unsigned int j=0; j<ifnIdx; j++){
             /* Get file info */
-            if (!LZ4IO_getCompressedFileInfo(inFileNames[i], &cfinfo)){
+            if (!LZ4IO_getCompressedFileInfo(inFileNames[j], &cfinfo)){
                 DISPLAYLEVEL(1, "Failed to get frame info.\n");
                 if (!multiple_inputs){
                     return 1;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1222,7 +1222,6 @@ static int LZ4IO_getCompressedFileInfo(const char* input_filename,  LZ4F_compFil
   size_t readSize = LZ4F_HEADER_SIZE_MAX;
   LZ4F_errorCode_t errorCode;
   dRess_t ress;
-  // LZ4F_compFileInfo_t cfinfo = (LZ4F_compFileInfo_t) LZ4F_INIT_FILEINFO;
   /* Open file */
   FILE* const finput = LZ4IO_openSrcFile(input_filename);
   if (finput==NULL) return 1;
@@ -1247,7 +1246,7 @@ static int LZ4IO_getCompressedFileInfo(const char* input_filename,  LZ4F_compFil
   e = strrchr(b, '.');
 
   /* Allocate Memory */
-  t = malloc( (e-b+1) * sizeof(char));
+  t = (char*)malloc( (e-b+1) * sizeof(char));
   ress.srcBuffer = malloc(LZ4IO_dBufferSize);
   if (!t || !ress.srcBuffer)
     EXM_THROW(21, "Allocation error : not enough memory");
@@ -1332,6 +1331,7 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, const size_t ifnI
   DISPLAY("%16s\t%-20s\t%-20s\t%-10s\t%s\n","BlockChecksumFlag","Compressed", "Uncompressed", "Ratio", "Filename");
   for(idx=0; idx<ifnIdx; idx++){
     /* Get file info */
+    cfinfo = (LZ4F_compFileInfo_t) LZ4F_INIT_FILEINFO;
     op_result=LZ4IO_getCompressedFileInfo(inFileNames[idx], &cfinfo);
     if (op_result != 0){
         DISPLAYLEVEL(1, "Failed to get frame info for file %s\n", inFileNames[idx]);

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1340,10 +1340,10 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, const size_t ifnI
     }
     if(cfinfo.frameInfo.contentSize){
         ratio = (double)cfinfo.fileSize / cfinfo.frameInfo.contentSize;
-        DISPLAY("%-16d\t%-20lu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
+        DISPLAY("%-16d\t%-20llu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
     }
     else{
-        DISPLAY("%-16d\t%-20lu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize, "-", "-", cfinfo.fileName);
+        DISPLAY("%-16d\t%-20llu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize, "-", "-", cfinfo.fileName);
     }
   }
   return op_result;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1214,6 +1214,60 @@ static int LZ4IO_decompressDstFile(LZ4IO_prefs_t* const prefs, dRess_t ress, con
 }
 
 
+static int LZ4IO_getCompressedFileInfo(const char* input_filename,  LZ4F_compFileInfo_t* cfinfo){
+  const char *b, 
+             *e;
+  char *t;
+  size_t readSize = LZ4F_HEADER_SIZE_MAX;
+  LZ4F_errorCode_t errorCode;
+  dRess_t ress;
+  // LZ4F_compFileInfo_t cfinfo = (LZ4F_compFileInfo_t) LZ4F_INIT_FILEINFO;
+  /* Open file */
+  FILE* const finput = LZ4IO_openSrcFile(input_filename);
+  if (finput==NULL) return 1;
+  
+  /* Get file size */
+  if (!UTIL_getFileStat(input_filename, &cfinfo->fileStat)){
+    EXM_THROW(60, "Can't stat file : %s", input_filename);
+  }
+
+  /* Get basename without extension */
+  b = strrchr(input_filename, '/');
+  if (!b){
+    b = strrchr(input_filename, '\\');
+  }
+  if (b && b != input_filename){
+    b++;
+  } else{
+    b=input_filename;
+  }
+  e = strrchr(b, '.');
+
+  /* Allocate Memory */
+  t = malloc( (e-b+1) * sizeof(char));
+  ress.srcBuffer = malloc(LZ4IO_dBufferSize);
+  if (!t || !ress.srcBuffer)
+    EXM_THROW(21, "Allocation error : not enough memory");
+  strncpy(t, b, (e-b));
+  t[e-b] = '\0';
+  cfinfo->fileName = t;
+
+  /* init */
+  errorCode = LZ4F_createDecompressionContext(&ress.dCtx, LZ4F_VERSION);
+  if (LZ4F_isError(errorCode)) EXM_THROW(60, "Can't create LZ4F context : %s", LZ4F_getErrorName(errorCode));
+
+  if (!fread(ress.srcBuffer, readSize, 1, finput)){
+    EXM_THROW(30, "Error reading %s ", input_filename);
+  }
+  LZ4F_getFrameInfo(ress.dCtx, &cfinfo->frameInfo, ress.srcBuffer, &readSize);
+
+  /* Close input/free resources */
+  fclose(finput);
+  free(ress.srcBuffer);
+  return 0;
+}
+
+
 int LZ4IO_decompressFilename(LZ4IO_prefs_t* const prefs, const char* input_filename, const char* output_filename)
 {
     dRess_t const ress = LZ4IO_createDResources(prefs);
@@ -1266,86 +1320,28 @@ int LZ4IO_decompressMultipleFilenames(LZ4IO_prefs_t* const prefs, const char** i
     return missingFiles + skippedFiles;
 }
 
-int LZ4IO_getCompressedFilesInfo(const char** inFileNames, const size_t ifnIdx){
+
+int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, const size_t ifnIdx){
   size_t idx;
   int op_result=0;
-  LZ4F_compFileInfo_t cfinfo = (LZ4F_compFileInfo_t) LZ4F_INIT_FILEINFO;
+  double ratio;
+  LZ4F_compFileInfo_t cfinfo;
   DISPLAY("%16s\t%-20s\t%-20s\t%-10s\t%s\n","BlockChecksumFlag","Compressed", "Uncompressed", "Ratio", "Filename");
   for(idx=0; idx<ifnIdx; idx++){
     /* Get file info */
-    op_result&=LZ4IO_getCompressedFileInfo(inFileNames[idx], &cfinfo);
+    op_result=LZ4IO_getCompressedFileInfo(inFileNames[idx], &cfinfo);
     if (op_result != 0){
         DISPLAYLEVEL(1, "Failed to get frame info for file %s\n", inFileNames[idx]);
-        if (ifnIdx < 2){
-            return 1;
-        }
-        continue;
+        /* Don't bother trying to process any other file */
+        break;
     }
     if(cfinfo.frameInfo.contentSize){
-        DISPLAY("%-16d\t%-20llu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize,cfinfo.frameInfo.contentSize, cfinfo.ratio, cfinfo.fileName);
+        ratio = (double)cfinfo.fileStat.st_size / cfinfo.frameInfo.contentSize;
+        DISPLAY("%-16d\t%-20lu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileStat.st_size,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
     }
     else{
-        DISPLAY("%-16d\t%-20llu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize, "-", "-", cfinfo.fileName);
+        DISPLAY("%-16d\t%-20lu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileStat.st_size, "-", "-", cfinfo.fileName);
     }
   }
   return op_result;
-}
-
-int LZ4IO_getCompressedFileInfo(const char* input_filename, LZ4F_compFileInfo_t* cfinfo){
-  const char *b, 
-             *e;
-  char *t;
-  stat_t statbuf;
-  size_t readSize = LZ4F_HEADER_SIZE_MAX;
-  LZ4F_errorCode_t errorCode;
-  dRess_t ress;
-  /* Open file */
-  FILE* const finput = LZ4IO_openSrcFile(input_filename);
-  if (finput==NULL) return 0;
-  *cfinfo = (LZ4F_compFileInfo_t) LZ4F_INIT_FILEINFO;
-  /* Get file size */
-  if (!UTIL_getFileStat(input_filename, &statbuf)){
-    EXM_THROW(60, "Can't stat file : %s", input_filename);
-  }
-  cfinfo->fileSize = statbuf.st_size;
-
-  /* Get basename without extension */
-  b = strrchr(input_filename, '/');
-  if (!b){
-    b = strrchr(input_filename, '\\');
-  }
-  if (b && b != input_filename){
-    b++;
-  } else{
-    b=input_filename;
-  }
-  e = strrchr(b, '.');
-  /* Allocate Memory */
-  t = malloc( (e-b+1) * sizeof(char));
-  ress.srcBuffer = malloc(LZ4IO_dBufferSize);
-  if (!t || !ress.srcBuffer)
-    EXM_THROW(21, "Allocation error : not enough memory");
-  strncpy(t, b, (e-b));
-  t[e-b] = '\0';
-  cfinfo->fileName = t;
-
-  /* init */
-  errorCode = LZ4F_createDecompressionContext(&ress.dCtx, LZ4F_VERSION);
-  if (LZ4F_isError(errorCode)) EXM_THROW(60, "Can't create LZ4F context : %s", LZ4F_getErrorName(errorCode));
-
-  if (!fread(ress.srcBuffer, readSize, 1, finput)){
-    EXM_THROW(30, "Error reading %s ", input_filename);
-  }
-  // cfinfo->frameInfo = (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO;
-  LZ4F_getFrameInfo(ress.dCtx, &cfinfo->frameInfo, ress.srcBuffer, &readSize);
-  if(cfinfo->frameInfo.contentSize){
-    cfinfo->ratio = (double)cfinfo->fileSize / cfinfo->frameInfo.contentSize;
-  } else {
-    cfinfo->ratio = -1;
-  }
-
-  /* Close input/free resources */
-  fclose(finput);
-  free(ress.srcBuffer);
-  return 0;
 }

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1218,6 +1218,7 @@ static int LZ4IO_getCompressedFileInfo(const char* input_filename,  LZ4F_compFil
   const char *b, 
              *e;
   char *t;
+  stat_t statbuf;
   size_t readSize = LZ4F_HEADER_SIZE_MAX;
   LZ4F_errorCode_t errorCode;
   dRess_t ress;
@@ -1227,9 +1228,11 @@ static int LZ4IO_getCompressedFileInfo(const char* input_filename,  LZ4F_compFil
   if (finput==NULL) return 1;
   
   /* Get file size */
-  if (!UTIL_getFileStat(input_filename, &cfinfo->fileStat)){
+  if (!UTIL_getFileStat(input_filename, &statbuf)){
     EXM_THROW(60, "Can't stat file : %s", input_filename);
   }
+
+  cfinfo->fileSize = statbuf.st_size;
 
   /* Get basename without extension */
   b = strrchr(input_filename, '/');
@@ -1336,11 +1339,11 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, const size_t ifnI
         break;
     }
     if(cfinfo.frameInfo.contentSize){
-        ratio = (double)cfinfo.fileStat.st_size / cfinfo.frameInfo.contentSize;
-        DISPLAY("%-16d\t%-20lu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileStat.st_size,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
+        ratio = (double)cfinfo.fileSize / cfinfo.frameInfo.contentSize;
+        DISPLAY("%-16d\t%-20lu\t%-20llu\t%-8.4f\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize,cfinfo.frameInfo.contentSize, ratio, cfinfo.fileName);
     }
     else{
-        DISPLAY("%-16d\t%-20lu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileStat.st_size, "-", "-", cfinfo.fileName);
+        DISPLAY("%-16d\t%-20lu\t%-20s\t%-10s\t%s\n",cfinfo.frameInfo.blockChecksumFlag,cfinfo.fileSize, "-", "-", cfinfo.fileName);
     }
   }
   return op_result;

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -54,6 +54,14 @@ static const char nulmark[] = "/dev/null";
 
 typedef struct LZ4IO_prefs_s LZ4IO_prefs_t;
 
+typedef struct {
+  LZ4F_frameInfo_t frameInfo;
+  char* fileName;
+  unsigned long long fileSize;
+  double compressionRatio;
+} LZ4F_compFileInfo_t;
+
+
 LZ4IO_prefs_t* LZ4IO_defaultPreferences(void);
 void LZ4IO_freePreferences(LZ4IO_prefs_t* const prefs);
 
@@ -115,6 +123,9 @@ int LZ4IO_setSparseFile(LZ4IO_prefs_t* const prefs, int enable);
 
 /* Default setting : 0 == no content size present in frame header */
 int LZ4IO_setContentSize(LZ4IO_prefs_t* const prefs, int enable);
+
+/*  */
+size_t LZ4IO_getCompressedFileInfo(const char* input_filename, LZ4F_compFileInfo_t* cfinfo);
 
 /* Default setting : 0 == src file preserved */
 void LZ4IO_setRemoveSrcFile(LZ4IO_prefs_t* const prefs, unsigned flag);

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -52,14 +52,6 @@ static const char nulmark[] = "/dev/null";
 /* ****************** Type Definitions ************** */
 /* ************************************************** */
 
-typedef struct {
-  LZ4F_frameInfo_t frameInfo;
-  const char* fileName;
-  stat_t fileStat;
-} LZ4F_compFileInfo_t;
-
-#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, stat_t() }
-
 typedef struct LZ4IO_prefs_s LZ4IO_prefs_t;
 
 LZ4IO_prefs_t* LZ4IO_defaultPreferences(void);

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -56,11 +56,12 @@ typedef struct LZ4IO_prefs_s LZ4IO_prefs_t;
 
 typedef struct {
   LZ4F_frameInfo_t frameInfo;
-  char* fileName;
+  const char* fileName;
   unsigned long long fileSize;
-  double compressionRatio;
+  double ratio;
 } LZ4F_compFileInfo_t;
 
+#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, 0ULL, -1.f }
 
 LZ4IO_prefs_t* LZ4IO_defaultPreferences(void);
 void LZ4IO_freePreferences(LZ4IO_prefs_t* const prefs);
@@ -124,8 +125,9 @@ int LZ4IO_setSparseFile(LZ4IO_prefs_t* const prefs, int enable);
 /* Default setting : 0 == no content size present in frame header */
 int LZ4IO_setContentSize(LZ4IO_prefs_t* const prefs, int enable);
 
-/*  */
-size_t LZ4IO_getCompressedFileInfo(const char* input_filename, LZ4F_compFileInfo_t* cfinfo);
+int LZ4IO_getCompressedFilesInfo(const char** inFileNames,const size_t ifnIdx);
+
+int LZ4IO_getCompressedFileInfo(const char* input_filename, LZ4F_compFileInfo_t* cfinfo);
 
 /* Default setting : 0 == src file preserved */
 void LZ4IO_setRemoveSrcFile(LZ4IO_prefs_t* const prefs, unsigned flag);

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -57,11 +57,10 @@ typedef struct LZ4IO_prefs_s LZ4IO_prefs_t;
 typedef struct {
   LZ4F_frameInfo_t frameInfo;
   const char* fileName;
-  unsigned long long fileSize;
-  double ratio;
+  stat_t fileStat;
 } LZ4F_compFileInfo_t;
 
-#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, 0ULL, -1.f }
+#define LZ4F_INIT_FILEINFO   { (LZ4F_frameInfo_t) LZ4F_INIT_FRAMEINFO, NULL, stat_t() }
 
 LZ4IO_prefs_t* LZ4IO_defaultPreferences(void);
 void LZ4IO_freePreferences(LZ4IO_prefs_t* const prefs);
@@ -125,9 +124,7 @@ int LZ4IO_setSparseFile(LZ4IO_prefs_t* const prefs, int enable);
 /* Default setting : 0 == no content size present in frame header */
 int LZ4IO_setContentSize(LZ4IO_prefs_t* const prefs, int enable);
 
-int LZ4IO_getCompressedFilesInfo(const char** inFileNames,const size_t ifnIdx);
-
-int LZ4IO_getCompressedFileInfo(const char* input_filename, LZ4F_compFileInfo_t* cfinfo);
+int LZ4IO_displayCompressedFilesInfo(const char** inFileNames,const size_t ifnIdx);
 
 /* Default setting : 0 == src file preserved */
 void LZ4IO_setRemoveSrcFile(LZ4IO_prefs_t* const prefs, unsigned flag);


### PR DESCRIPTION
This should close #598
Supports both single lz4 file and multiple files with -m
```
+ echo '1234!'
+ ./lz4
+ ./lz4 README.md -BX --content-size
+ echo '1234!'
+ ./lz4
+ ./lz4 README.md -BD --content-size
+ ./lz4 --list test1.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       25                      -                       -               test1
+ ./lz4 --list test2.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
1                       3373                    5534                    0.6095          test2
+ ./lz4 --list -m test1.lz4 test2.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       25                      -                       -               test1
1                       3373                    5534                    0.6095          test2
+ ./lz4 --list /tmp/test1.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       25                      -                       -               test1
+ ./lz4 --list /tmp/test2.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       3369                    5534                    0.6088          test2
+ ./lz4 --list -m /tmp/test1.lz4 /tmp/test2.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       25                      -                       -               test1
0                       3369                    5534                    0.6088          test2
+ ./lz4 --list -m test1.lz4 test2.lz4 /tmp/test1.lz4 /tmp/test2.lz4
BlockChecksumFlag       Compressed              Uncompressed            Ratio           Filename
0                       25                      -                       -               test1
1                       3373                    5534                    0.6095          test2
0                       25                      -                       -               test1
0                       3369                    5534                    0.6088          test2
```