### PR TITLE
Include block checksum in worst case scenario calculation of dstCapacity

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -327,6 +327,7 @@ static size_t LZ4F_compressBound_internal(size_t srcSize,
 {
     LZ4F_preferences_t prefsNull = LZ4F_INIT_PREFERENCES;
     prefsNull.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;   /* worst case */
+    prefsNull.frameInfo.blockChecksumFlag = LZ4F_blockChecksumEnabled;   /* worst case */
     {   const LZ4F_preferences_t* const prefsPtr = (preferencesPtr==NULL) ? &prefsNull : preferencesPtr;
         U32 const flush = prefsPtr->autoFlush | (srcSize==0);
         LZ4F_blockSizeID_t const blockID = prefsPtr->frameInfo.blockSizeID;


### PR DESCRIPTION
This results in a slightly increased dstCapacity when preferencesPtr is null.