### PR TITLE
enable LZ4_FAST_DEC_LOOP build macro on aarch64 by default

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -317,6 +317,11 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #ifndef LZ4_FAST_DEC_LOOP
 #  if defined(__i386__) || defined(__x86_64__)
 #    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && !defined(__clang__)
+     /* On aarch64, we disable this optimization for clang because on certain
+      * mobile chipsets and clang, it reduces performance. For more information
+      * refer to https://github.com/lz4/lz4/pull/707. */
+#    define LZ4_FAST_DEC_LOOP 1
 #  else
 #    define LZ4_FAST_DEC_LOOP 0
 #  endif


### PR DESCRIPTION
Pull request #645 has introduced the build macro LZ4_FAST_DEC_LOOP which by default enables an optimization only for x86/x64.

I propose to enable this optimization for aarch64 as well. Here are the benchmark results for this pull request running on a1.4xlarge AWS EC2 instance. The final percent is how much faster this patchset is vs. the current dev branch.
```
./lzbench -elz4 silesia/*

lz4 1.8.3                 148 MB/s  1335 MB/s     6428742  63.07 silesia/dickens    
lz4 1.8.3                 147 MB/s  1319 MB/s     6428742  63.07 silesia/dickens    -1%

lz4 1.8.3                 229 MB/s  1503 MB/s    26435667  51.61 silesia/mozilla    
lz4 1.8.3                 229 MB/s  1630 MB/s    26435667  51.61 silesia/mozilla    8%

lz4 1.8.3                 216 MB/s  1350 MB/s     5440937  54.57 silesia/mr         
lz4 1.8.3                 216 MB/s  1416 MB/s     5440937  54.57 silesia/mr         5%

lz4 1.8.3                 406 MB/s  1686 MB/s     5533040  16.49 silesia/nci        
lz4 1.8.3                 408 MB/s  1766 MB/s     5533040  16.49 silesia/nci        5%

lz4 1.8.3                 190 MB/s  1314 MB/s     4338918  70.53 silesia/ooffice    
lz4 1.8.3                 193 MB/s  1481 MB/s     4338918  70.53 silesia/ooffice    13%

lz4 1.8.3                 198 MB/s  1238 MB/s     5256666  52.12 silesia/osdb       
lz4 1.8.3                 199 MB/s  1433 MB/s     5256666  52.12 silesia/osdb       16%

lz4 1.8.3                 167 MB/s  1194 MB/s     3181387  48.00 silesia/reymont    
lz4 1.8.3                 168 MB/s  1137 MB/s     3181387  48.00 silesia/reymont    -5%

lz4 1.8.3                 265 MB/s  1493 MB/s     7716839  35.72 silesia/samba      
lz4 1.8.3                 262 MB/s  1565 MB/s     7716839  35.72 silesia/samba      5%

lz4 1.8.3                 191 MB/s  1379 MB/s     6790273  93.63 silesia/sao        
lz4 1.8.3                 205 MB/s  1570 MB/s     6790273  93.63 silesia/sao        14%

lz4 1.8.3                 173 MB/s  1296 MB/s    20139988  48.58 silesia/webster    
lz4 1.8.3                 173 MB/s  1350 MB/s    20139988  48.58 silesia/webster    4%

lz4 1.8.3                 379 MB/s  2524 MB/s     8390195  99.01 silesia/x-ray      
lz4 1.8.3                 392 MB/s  2675 MB/s     8390195  99.01 silesia/x-ray      6%

lz4 1.8.3                 335 MB/s  1412 MB/s     1227495  22.96 silesia/xml        
lz4 1.8.3                 336 MB/s  1511 MB/s     1227495  22.96 silesia/xml        7%
```