### PR TITLE
Fix src temporary buffer use in lz4frame

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1494,7 +1494,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 /* next block is a compressed block */
                 dctx->tmpInTarget = nextCBlockSize + crcSize;
                 dctx->dStage = dstage_getCBlock;
-                if (dstPtr==dstEnd) {
+                if (dstPtr==dstEnd || srcPtr==srcEnd) {
                     nextSrcSizeHint = BHSize + nextCBlockSize + crcSize;
                     doAnotherStage = 0;
                 }


### PR DESCRIPTION
I noticed a bug, that forces lz4frame decompression to use a temporary source buffer in the case when size hint is respected, but dst buffer is not fully exhausted.

After next block header is read, the `dstage_getCBlock` state expects input based on  dctx->tmpInTarget, but remaining buffer size will always be 0, after reading a header, if src buf had been of a hint size, so it transitions to `dstage_storeCBlock` state. So, when one optimizes their code to always provide the src buffer of the hinted size, all compressed blocks will always hit the temporary buffer, unless they're lucky having destination buffer exhausted.

This has a very notable speed impact on some embedded hardware, where only a limited amount of fast memory is available and you never want to hit tmp buffers.