### PR TITLE
FAST_DEC_LOOP: decompress speed improvements on ARM64/X86

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1725,14 +1725,13 @@ LZ4_decompress_generic(
                 }
 
                 /* Fastpath check: Avoids a branch in LZ4_wildCopy32 if true */
-                if (!(dict == usingExtDict) || (match >= lowPrefix)) {
-                    if (offset >= 8) {
+                if ((offset >= 8) && (!(dict == usingExtDict) || (match >= lowPrefix))) {
                         memcpy(op, match, 8);
                         memcpy(op+8, match+8, 8);
                         memcpy(op+16, match+16, 2);
                         op += length;
                         continue;
-            }   }   }
+            }   }
 
             if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
             /* match starting within external dictionary */


### PR DESCRIPTION
@Cyan4973 :
FAST_DEC_LOOP: improve condition check to avoid branch miss 
This patch is to avoid branch miss if offest smaller than 8.
I found if check offset >=8 first, the decompress speed can be improved on ARM64.
Normal DEC check offset first as well.
https://github.com/lz4/lz4/blob/dev/lib/lz4.c#L1815
So this patch don't have function change but improve the performance.