### PR TITLE
FAST_DEC_LOOP: inline more functions.

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -155,7 +155,7 @@
 #  define LZ4_FORCE_O2_INLINE_GCC_PPC64LE __attribute__((optimize("O2"))) LZ4_FORCE_INLINE
 #else
 #  define LZ4_FORCE_O2_GCC_PPC64LE
-#  define LZ4_FORCE_O2_INLINE_GCC_PPC64LE static
+#  define LZ4_FORCE_O2_INLINE_GCC_PPC64LE LZ4_FORCE_INLINE
 #endif
 
 #if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)


### PR DESCRIPTION
LZ4_FORCE_O2_INLINE_GCC_PPC64LE should be define as LZ4_FORCE_INLINE
if PPC64LE is not defined.

It introdue performance a little because LZ4_wildCopy8 &
LZ4_memcpy_using_offset are busy during decompress.