### PR TITLE
FAST_DEC_LOOP: better decompress performance on ARM64/X86

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1664,7 +1664,7 @@ LZ4_decompress_generic(
             assert(!endOnInput || ip <= iend); /* ip < iend before the increment */
 
             /* decode literal length */
-            if (length == RUN_MASK) {
+            if (unlikely(length == RUN_MASK)) {
                 variable_length_error error = ok;
                 length += read_variable_length(&ip, iend-RUN_MASK, endOnInput, endOnInput, &error);
                 if (error == initial_error) { goto _output_error; }
@@ -1688,7 +1688,7 @@ LZ4_decompress_generic(
                 if (endOnInput) {  /* LZ4_decompress_safe() */
                     DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                     /* We don't need to check oend, since we check it once for each loop below */
-                    if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) { goto safe_literal_copy; }
+                    if (unlikely(ip > iend-(16 + 1/*max lit + offset + nextToken*/))) { goto safe_literal_copy; }
                     /* Literals can only be 14, but hope compilers optimize if we copy by a register size */
                     memcpy(op, ip, 16);
                 } else {  /* LZ4_decompress_fast() */
@@ -1707,7 +1707,7 @@ LZ4_decompress_generic(
             /* get matchlength */
             length = token & ML_MASK;
 
-            if (length == ML_MASK) {
+            if (unlikely(length == ML_MASK)) {
               variable_length_error error = ok;
               if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
               length += read_variable_length(&ip, iend - LASTLITERALS + 1, endOnInput, 0, &error);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1717,6 +1717,7 @@ LZ4_decompress_generic(
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
+                goto skip_dup_check;
             } else {
                 length += MINMATCH;
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
@@ -1743,6 +1744,7 @@ LZ4_decompress_generic(
             }   }   }
 
             if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
+skip_dup_check:
             /* match starting within external dictionary */
             if ((dict==usingExtDict) && (match < lowPrefix)) {
                 if (unlikely(op+length > oend-LASTLITERALS)) {

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1725,7 +1725,16 @@ LZ4_decompress_generic(
 
                 /* Fastpath check: Avoids a branch in LZ4_wildCopy32 if true */
                 if (!(dict == usingExtDict) || (match >= lowPrefix)) {
+#if defined(__aarch64__) && defined(__GNUC__) && !defined(__clang__)
+                    if (offset >= 16) {
+                        memcpy(op, match, 16);
+                        memcpy(op+16, match+16, 2);
+                        op += length;
+                        continue;
+                     } else if (offset >= 8) {
+#else
                     if (offset >= 8) {
+#endif
                         memcpy(op, match, 8);
                         memcpy(op+8, match+8, 8);
                         memcpy(op+16, match+16, 2);


### PR DESCRIPTION
Here are 3 commits to improve decompress performance on ARM64/X86.
1. FAST_DEC_LOOP: prefer to lerverage 16 bytes copy if offset >= 16 
This patch is only affect ARM64 which has better 16 bytes copy performance compare with 8 bytes.
After this change, the 16 bytes copy invovled if offest >= 16.
2. FAST_DEC_LOOP: Add hints for better code generation. 
This could be generate better instructions for hot path.
3. FAST_DEC_LOOP: skip duplicate offset check if length == ML_MASK 
Reduce duplicate offset check number by 40% to improve the decompress speed.

Test via lzbench (GCC7.4 on ARM64(cortex-a53))
dev branch with 3 patches.
lz4 1.9.x                 127 MB/s   **586** MB/s   302640041  47.60 /sdcard/silesia
vanilla:
lz4 1.8.3                 128 MB/s   569 MB/s   302640041  47.60 /sdcard/silesia
v1.9.x-348e10(restored FORCE_INLINE)
lz4 1.9.x                 128 MB/s   577 MB/s   302640041  47.60 /sdcard/silesia
