### PR TITLE
meson: Fix deprecated warnings on build options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,18 +178,24 @@ matrix:
       compiler: clang
       install:
         - sudo apt-get install -qq python3 tree
-        - travis_retry curl -o ~/ninja.zip -L 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip'
-            && unzip ~/ninja.zip -d ~/.local/bin
-        - travis_retry curl -o ~/get-pip.py 'https://bootstrap.pypa.io/get-pip.py'
-            && python3 ~/get-pip.py --user
-            && pip3 install --user meson
+        - |
+          travis_retry curl -o ~/ninja.zip -L 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip' &&
+          unzip ~/ninja.zip -d ~/.local/bin
+        - |
+          travis_retry curl -o ~/get-pip.py 'https://bootstrap.pypa.io/get-pip.py' &&
+          python3 ~/get-pip.py --user &&
+          pip3 install --user meson
       script:
-        - meson setup
-            --buildtype=debug
-            -Db_lundef=false
-            -Dauto_features=enabled
-            -Ddefault_library=both
-            -Dbuild_{programs,contrib,tests,examples}=true
+        - |
+          meson setup \
+            --buildtype=debug \
+            -Db_lundef=false \
+            -Dauto_features=enabled \
+            -Ddefault_library=both \
+            -Dbin_programs=true \
+            -Dbin_contrib=true \
+            -Dbin_tests=true \
+            -Dbin_examples=true \
             contrib/meson build
         - pushd build
         - DESTDIR=./staging ninja install

--- a/contrib/meson/README.md
+++ b/contrib/meson/README.md
@@ -13,7 +13,7 @@ This Meson build system is provided with no guarantee.
 `cd` to this meson directory (`contrib/meson`)
 
 ```sh
-meson setup --buildtype=release -Ddefault_library=shared -Dbuild_programs=true builddir
+meson setup --buildtype=release -Ddefault_library=shared -Dbin_programs=true builddir
 cd builddir
 ninja             # to build
 ninja install     # to install

--- a/contrib/meson/contrib/gen_manual/meson.build
+++ b/contrib/meson/contrib/gen_manual/meson.build
@@ -22,6 +22,7 @@ gen_manual = executable('gen_manual',
   join_paths(lz4_root_dir, 'contrib/gen_manual/gen_manual.cpp'),
   cpp_args: gen_manual_cppflags,
   include_directories: gen_manual_includes,
+  native: true,
   install: false)
 
 # Update lz4 manual

--- a/contrib/meson/meson.build
+++ b/contrib/meson/meson.build
@@ -69,17 +69,17 @@ use_debug = get_option('debug')
 debug_level = get_option('debug_level')
 use_backtrace = get_option('backtrace')
 
-build_programs = get_option('build_programs')
-build_contrib = get_option('build_contrib')
-build_tests = get_option('build_tests')
-build_examples = get_option('build_examples')
+bin_programs = get_option('bin_programs')
+bin_contrib = get_option('bin_contrib')
+bin_tests = get_option('bin_tests')
+bin_examples = get_option('bin_examples')
 #feature_multi_thread = get_option('multi_thread')
 
 # =============================================================================
 # Dependencies
 # =============================================================================
 
-#libm_dep = cc.find_library('m', required: build_tests)
+#libm_dep = cc.find_library('m', required: bin_tests)
 #thread_dep = dependency('threads', required: feature_multi_thread)
 #use_multi_thread = thread_dep.found()
 
@@ -108,18 +108,18 @@ endif
 
 subdir('lib')
 
-if build_programs
+if bin_programs
   subdir('programs')
 endif
 
-if build_tests
+if bin_tests
   subdir('tests')
 endif
 
-if build_contrib
+if bin_contrib
   subdir('contrib')
 endif
 
-if build_examples
+if bin_examples
   subdir('examples')
 endif

--- a/contrib/meson/meson_options.txt
+++ b/contrib/meson/meson_options.txt
@@ -14,11 +14,11 @@ option('debug_level', type: 'integer', min: 0, max: 7, value: 1,
 option('backtrace', type: 'boolean', value: false,
   description: 'Display a stack backtrace when execution generates a runtime exception')
 
-option('build_programs', type: 'boolean', value: false,
+option('bin_programs', type: 'boolean', value: false,
   description: 'Enable programs build')
-option('build_tests', type: 'boolean', value: false,
+option('bin_tests', type: 'boolean', value: false,
   description: 'Enable tests build')
-option('build_contrib', type: 'boolean', value: false,
+option('bin_contrib', type: 'boolean', value: false,
   description: 'Enable contrib build')
-option('build_examples', type: 'boolean', value: false,
+option('bin_examples', type: 'boolean', value: false,
   description: 'Enable examples build')


### PR DESCRIPTION
Meson now reserves `build_` prefix options.