### PR TITLE
CircleCI : reduced test duration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,10 @@ version: 2
 jobs:
   build:
     working_directory: ~/lz4/lz4
-    parallelism: 2
+    # Parallelism is broken in this file : it just plays the same tests twice.
+    # The script will have to be modified to support parallelism properly
+    # In the meantime, set it to 1.
+    parallelism: 1
     shell: /bin/bash --login
     # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
     # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
@@ -42,25 +45,20 @@ jobs:
     # This is based on your 1.0 configuration file or project settings
     - run: CFLAGS= make clangtest && make clean
     - run: g++ -v; make gpptest     && make clean
-    - run: gcc -v; make c_standards && make clean
     - run: gcc -v; g++ -v; make ctocpptest && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -Werror" make check && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
-    - run: gcc-6 -v; CC=gcc-6 make c_standards && make clean
     - run: gcc-6 -v; CC=gcc-6 MOREFLAGS="-O2 -Werror" make check  && make clean
     - run: make cmake               && make clean
     - run: make -C tests test-lz4
     - run: make -C tests test-lz4c
     - run: make -C tests test-frametest
-    - run: make -C tests test-fullbench
     - run: make -C tests test-fuzzer && make clean
     - run: make -C lib all          && make clean
     - run: pyenv global 3.4.4; make versionsTest MOREFLAGS=-I/usr/include/x86_64-linux-gnu && make clean
     - run: make travis-install      && make clean
     - run: gcc -v; CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
-    - run: make usan                && make clean
     - run: clang -v; make staticAnalyze && make clean
-    - run: make -C tests test-mem && make clean
     - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static                  && make clean
     - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static MOREFLAGS=-m64 && make clean
     - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static                  && make clean


### PR DESCRIPTION
Ideally, we want to make CircleCI a "fast" test environment, with short feedback loop (~5mn).
We are still far from this goal.

This patch starts this process by removing "long" tasks which are non-essential and redundant with travisCI. It reduces tests duration from ~45mn to ~19mn.

It also acknowledges that parallelism is broken.
The script will have to be more heavily updated to support parallelism.