### PR TITLE
FAST_DEC_LOOP:Handle all offset condition

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1726,17 +1726,51 @@ LZ4_decompress_generic(
 
                 /* Fastpath check: Avoids a branch in LZ4_wildCopy32 if true */
                 if ((dict == withPrefix64k) || (match >= lowPrefix)) {
-                    if (offset >= 8) {
-                        assert(match >= lowPrefix);
-                        assert(match <= op);
-                        assert(op + 18 <= oend);
-
+                    assert(match >= lowPrefix);
+                    assert(match <= op);
+                    assert(op + 18 <= oend);
+#if defined(__i386__) || defined(__x86_64__)
+/**
+ * Sperate offset to 3 parts for best performance.
+ * Note that there might be negative impact on branch prediction.
+ * Not only offset >=8 but also offset[0,8) will be handled as well.
+ */
+                    if (likely(offset >= 16)) {
+                        memcpy(op, match, 16);
+                        memcpy(op+16, match+16, 2);
+                        op += length;
+                        continue;
+                    } else if (offset >= 8) {
                         memcpy(op, match, 8);
                         memcpy(op+8, match+8, 8);
                         memcpy(op+16, match+16, 2);
                         op += length;
                         continue;
-            }   }   }
+                    } else {
+                        assert(offset < 8);
+                        cpy = op + length;
+                        op[0] = match[0];
+                        op[1] = match[1];
+                        op[2] = match[2];
+                        op[3] = match[3];
+                        match += inc32table[offset];
+                        memcpy(op+4, match, 4);
+                        match -= dec64table[offset];
+                        op += 8;
+                        do { memcpy(op,match,8); op+=8; match+=8; } while (op<cpy);
+                        op = cpy;
+                        continue;
+                    }
+#else /* ARM64 */
+                    if (offset >= 8) {
+                        memcpy(op, match, 8);
+                        memcpy(op+8, match+8, 8);
+                        memcpy(op+16, match+16, 2);
+                        op += length;
+                        continue;
+                    }
+#endif
+            }   }
 
             if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
             /* match starting within external dictionary */


### PR DESCRIPTION
FAST_DEC_LOOP:Handle all offset condition.

During test, the possibility of offset >= 16 is much higher than [8,15]
we could leverage build-in memcpy 16 bytes if offset >= 16.
Meanwhile, add likely to in offset >= 16 for better code generation.
That would be introduce better performance.

After adding offset >= 16 handle routine, most of cases are improved but
few cases downgrade.

Investigation result is branch prediction failing might be introduce
latency if offset < 16.

To migrate the downgrade, hanle offset[0,8) condition to finish a loop
as quickly as possible (Reduce some useless condition checks and API calling).

After above modifications, only one case has little downgrade,
other cases obviously improved.

Here is the result:

X86: Intel(R) Xeon(R) CPU E5-1650 v4 @ 3.60GHz
gcc version 8.1.0 (Ubuntu 8.1.0-5ubuntu1~16.04)
Vanilla-9dc59813:
(Merge pull request #739 from cmeister2/cmeister2/ossfuzz)
lzbench 1.7.3 (64-bit Linux)   Assembled by P.Skibinski
Compressor name         Compress. Decompress. Compr. size  Ratio Filename
memcpy                   9141 MB/s 12134 MB/s    10192446 100.00 dickens
lz4 1.9.x                 382 MB/s  3446 MB/s     6428742  63.07 dickens
lz4 1.9.x                 617 MB/s  3399 MB/s    26435667  51.61 mozilla
lz4 1.9.x                 585 MB/s  3970 MB/s     5440937  54.57 mr
lz4 1.9.x                1031 MB/s  4961 MB/s     5533040  16.49 nci
lz4 1.9.x                 499 MB/s  3409 MB/s     4338918  70.53 ooffice
lz4 1.9.x                 531 MB/s  3597 MB/s     5256666  52.12 osdb
lz4 1.9.x                 382 MB/s  3062 MB/s     3181387  48.00 reymont
lz4 1.9.x                 651 MB/s  3952 MB/s     7716839  35.72 samba
lz4 1.9.x                 499 MB/s  4505 MB/s     6790273  93.63 sao
lz4 1.9.x                 576 MB/s  3711 MB/s   100880015  47.60 silesia
lz4 1.9.x                 437 MB/s  3446 MB/s    20139988  48.58 webster
lz4 1.9.x                 817 MB/s  4256 MB/s     1227495  22.96 xml
lz4 1.9.x                1351 MB/s  7751 MB/s     8390195  99.01 x-ray
done... (cIters=1 dIters=1 cTime=1.0 dTime=100.0 chunkSize=1706MB cSpeed=0MB)

Patched:
lzbench 1.7.3 (64-bit Linux)   Assembled by P.Skibinski
Compressor name         Compress. Decompress. Compr. size  Ratio Filename
memcpy                  10263 MB/s 13220 MB/s    10192446 100.00 dickens
lz4 1.9.x                 377 MB/s  3625 MB/s     6428742  63.07 dickens
lz4 1.9.x                 603 MB/s  3330 MB/s    26435667  51.61 mozilla
lz4 1.9.x                 584 MB/s  4084 MB/s     5440937  54.57 mr
lz4 1.9.x                1020 MB/s  5100 MB/s     5533040  16.49 nci
lz4 1.9.x                 500 MB/s  3449 MB/s     4338918  70.53 ooffice
lz4 1.9.x                 532 MB/s  3718 MB/s     5256666  52.12 osdb
lz4 1.9.x                 382 MB/s  3120 MB/s     3181387  48.00 reymont
lz4 1.9.x                 645 MB/s  4033 MB/s     7716839  35.72 samba
lz4 1.9.x                 508 MB/s  4644 MB/s     6790273  93.63 sao
lz4 1.9.x                 572 MB/s  3756 MB/s   100880015  47.60 silesia
lz4 1.9.x                 437 MB/s  3536 MB/s    20139988  48.58 webster
lz4 1.9.x                 832 MB/s  4354 MB/s     1227495  22.96 xml
lz4 1.9.x                1355 MB/s  7832 MB/s     8390195  99.01 x-ray

For ARM64, keep original implementation.
Based on test result, this change only affect on X86 and X64 platform