### PR TITLE
bugfix: correctly control the offset < LZ4_DISTANCE_MAX,when change t…

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -228,7 +228,7 @@ LZ4HC_InsertAndGetWiderMatch (
     const U32 dictLimit = hc4->dictLimit;
     const BYTE* const lowPrefixPtr = base + dictLimit;
     const U32 ipIndex = (U32)(ip - base);
-    const U32 lowestMatchIndex = (hc4->lowLimit + 64 KB > ipIndex) ? hc4->lowLimit : ipIndex - LZ4_DISTANCE_MAX;
+    const U32 lowestMatchIndex = (hc4->lowLimit + (LZ4_DISTANCE_MAX + 1) > ipIndex) ? hc4->lowLimit : ipIndex - LZ4_DISTANCE_MAX;
     const BYTE* const dictBase = hc4->dictBase;
     int const lookBackLength = (int)(ip-iLowLimit);
     int nbAttempts = maxNbAttempts;


### PR DESCRIPTION
when change the value of  LZ4_DISTANCE_MAX macro，and set -DLZ4_DEBUG=1 during compile lz4；use the compression parameter  -  [lz4hc,9],it will trigger an assert ，because it can not correctly contrl offset smaller than the value of LZ4_DISTANCE_MAX.   this bug can be fixed by set lowestMatchIndex according to LZ4_DISTANCE_MAX ,but not fixed 64K.