### PR TITLE
[fuzz] Add streaming round trip fuzzer

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1429,7 +1429,7 @@ void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dict
      */
     LZ4_resetStream_fast(workingStream);
 
-    if (dictionaryStream != NULL) {
+    if (dictionaryStream != NULL && dictionaryStream->internal_donotuse.dictSize > 0) {
         /* If the current offset is zero, we will never look in the
          * external dictionary context, since there is no value a table
          * entry can take that indicate a miss. In that case, we need

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -998,6 +998,11 @@ static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBl
     if (ctxPtr->end >= ctxPtr->base + ctxPtr->dictLimit + 4)
         LZ4HC_Insert (ctxPtr, ctxPtr->end-3);   /* Referencing remaining dictionary content */
 
+    /* cannot reference an extDict and a dictCtx at the same time */
+    if (ctxPtr->dictCtx != NULL) {
+        ctxPtr->dictCtx = NULL;
+    }
+
     /* Only one memory segment for extDict, so any previous extDict is lost at this stage */
     ctxPtr->lowLimit  = ctxPtr->dictLimit;
     ctxPtr->dictLimit = (U32)(ctxPtr->end - ctxPtr->base);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -998,11 +998,6 @@ static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBl
     if (ctxPtr->end >= ctxPtr->base + ctxPtr->dictLimit + 4)
         LZ4HC_Insert (ctxPtr, ctxPtr->end-3);   /* Referencing remaining dictionary content */
 
-    /* cannot reference an extDict and a dictCtx at the same time */
-    if (ctxPtr->dictCtx != NULL) {
-        ctxPtr->dictCtx = NULL;
-    }
-
     /* Only one memory segment for extDict, so any previous extDict is lost at this stage */
     ctxPtr->lowLimit  = ctxPtr->dictLimit;
     ctxPtr->dictLimit = (U32)(ctxPtr->end - ctxPtr->base);
@@ -1010,6 +1005,9 @@ static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBl
     ctxPtr->base = newBlock - ctxPtr->dictLimit;
     ctxPtr->end  = newBlock;
     ctxPtr->nextToUpdate = ctxPtr->dictLimit;   /* match referencing will resume from there */
+
+    /* cannot reference an extDict and a dictCtx at the same time */
+    ctxPtr->dictCtx = NULL;
 }
 
 static int LZ4_compressHC_continue_generic (LZ4_streamHC_t* LZ4_streamHCPtr,

--- a/ossfuzz/Makefile
+++ b/ossfuzz/Makefile
@@ -35,6 +35,14 @@ LZ4_CFLAGS  = $(CFLAGS) $(DEBUGFLAGS) $(MOREFLAGS)
 LZ4_CXXFLAGS = $(CXXFLAGS) $(DEBUGFLAGS) $(MOREFLAGS)
 LZ4_CPPFLAGS = $(CPPFLAGS) -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_
 
+FUZZERS := \
+	compress_fuzzer \
+	decompress_fuzzer \
+	round_trip_fuzzer \
+	round_trip_stream_fuzzer
+
+all: $(FUZZERS)
+
 # Include a rule to build the static library if calling this target
 # directly.
 $(LZ4DIR)/liblz4.a:

--- a/ossfuzz/Makefile
+++ b/ossfuzz/Makefile
@@ -39,7 +39,9 @@ FUZZERS := \
 	compress_fuzzer \
 	decompress_fuzzer \
 	round_trip_fuzzer \
-	round_trip_stream_fuzzer
+	round_trip_stream_fuzzer \
+	compress_hc_fuzzer \
+	round_trip_hc_fuzzer
 
 all: $(FUZZERS)
 

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -1,0 +1,57 @@
+/**
+ * This fuzz target attempts to compress the fuzzed data with the simple
+ * compression function with an output buffer that may be too small to
+ * ensure that the compressor never crashes.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fuzz_helpers.h"
+#include "lz4.h"
+#include "lz4hc.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    uint32_t seed = FUZZ_seed(&data, &size);
+    size_t const dstCapacity = FUZZ_rand32(&seed, 0, LZ4_compressBound(size));
+    char* const dst = (char*)malloc(dstCapacity);
+    char* const rt = (char*)malloc(size);
+    int const level = FUZZ_rand32(&seed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
+    FUZZ_ASSERT(dst);
+    FUZZ_ASSERT(rt);
+
+    /* If compression succeeds it must round trip correctly. */
+    {
+        int const dstSize = LZ4_compress_HC((const char*)data, dst, size,
+                                            dstCapacity, level);
+        if (dstSize > 0) {
+            int const rtSize = LZ4_decompress_safe(dst, rt, dstSize, size);
+            FUZZ_ASSERT_MSG(rtSize == size, "Incorrect regenerated size");
+            FUZZ_ASSERT_MSG(!memcmp(data, rt, size), "Corruption!");
+        }
+    }
+
+    if (dstCapacity > 0) {
+        /* Compression succeeds and must round trip correctly. */
+        void* state = malloc(LZ4_sizeofStateHC());
+        FUZZ_ASSERT(state);
+        int compressedSize = size;
+        int const dstSize = LZ4_compress_HC_destSize(state, (const char*)data,
+                                                     dst, &compressedSize,
+                                                     dstCapacity, level);
+        FUZZ_ASSERT(dstSize > 0);
+        int const rtSize = LZ4_decompress_safe(dst, rt, dstSize, size);
+        FUZZ_ASSERT_MSG(rtSize == compressedSize, "Incorrect regenerated size");
+        FUZZ_ASSERT_MSG(!memcmp(data, rt, compressedSize), "Corruption!");
+        free(state);
+    }
+
+    free(dst);
+    free(rt);
+
+    return 0;
+}

--- a/ossfuzz/fuzz_helpers.h
+++ b/ossfuzz/fuzz_helpers.h
@@ -24,8 +24,13 @@
 extern "C" {
 #endif
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define LZ4_COMMONDEFS_ONLY
+#ifndef LZ4_SRC_INCLUDED
+#include "lz4.c"   /* LZ4_count, constants, mem */
+#endif
+
+#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#define MAX(a,b)   ( (a) > (b) ? (a) : (b) )
 
 #define FUZZ_QUOTE_IMPL(str) #str
 #define FUZZ_QUOTE(str) FUZZ_QUOTE_IMPL(str)

--- a/ossfuzz/ossfuzz.sh
+++ b/ossfuzz/ossfuzz.sh
@@ -16,8 +16,8 @@ echo "OUT: $OUT"
 export MAKEFLAGS+="-j$(nproc)"
 
 pushd ossfuzz
-make V=1 compress_fuzzer decompress_fuzzer
+make V=1 all
 popd
 
 # Copy the fuzzers to the target directory.
-cp -v ossfuzz/compress_fuzzer ossfuzz/decompress_fuzzer $OUT/
+cp -v ossfuzz/*_fuzzer $OUT/

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -1,0 +1,39 @@
+/**
+ * This fuzz target performs a lz4 round-trip test (compress & decompress),
+ * compares the result with the original, and calls abort() on corruption.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fuzz_helpers.h"
+#include "lz4.h"
+#include "lz4hc.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    uint32_t seed = FUZZ_seed(&data, &size);
+    size_t const dstCapacity = LZ4_compressBound(size);
+    char* const dst = (char*)malloc(dstCapacity);
+    char* const rt = (char*)malloc(size);
+    int const level = FUZZ_rand32(&seed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
+    FUZZ_ASSERT(dst);
+    FUZZ_ASSERT(rt);
+
+    /* Compression must succeed and round trip correctly. */
+    int const dstSize = LZ4_compress_HC((const char*)data, dst, size,
+                                        dstCapacity, level);
+    FUZZ_ASSERT(dstSize > 0);
+
+    int const rtSize = LZ4_decompress_safe(dst, rt, dstSize, size);
+    FUZZ_ASSERT_MSG(rtSize == size, "Incorrect size");
+    FUZZ_ASSERT_MSG(!memcmp(data, rt, size), "Corruption!");
+
+    free(dst);
+    free(rt);
+
+    return 0;
+}

--- a/ossfuzz/round_trip_stream_fuzzer.c
+++ b/ossfuzz/round_trip_stream_fuzzer.c
@@ -1,0 +1,217 @@
+/**
+ * This fuzz target performs a lz4 streaming round-trip test
+ * (compress & decompress), compares the result with the original, and calls
+ * abort() on corruption.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fuzz_helpers.h"
+#define LZ4_STATIC_LINKING_ONLY
+#include "lz4.h"
+
+typedef struct {
+  char const* buf;
+  size_t size;
+  size_t pos;
+} const_cursor_t;
+
+typedef struct {
+  char* buf;
+  size_t size;
+  size_t pos;
+} cursor_t;
+
+typedef struct {
+  LZ4_stream_t* cstream;
+  LZ4_streamDecode_t* dstream;
+  const_cursor_t data;
+  cursor_t compressed;
+  cursor_t roundTrip;
+  uint32_t seed;
+} state_t;
+
+cursor_t cursor_create(size_t size)
+{
+  cursor_t cursor;
+  cursor.buf = (char*)malloc(size);
+  cursor.size = size;
+  cursor.pos = 0;
+  FUZZ_ASSERT(cursor.buf);
+  return cursor;
+}
+
+void cursor_free(cursor_t cursor)
+{
+    free(cursor.buf);
+}
+
+state_t state_create(char const* data, size_t size, uint32_t seed)
+{
+    state_t state;
+
+    state.seed = seed;
+
+    state.data.buf = (char const*)data;
+    state.data.size = size;
+    state.data.pos = 0;
+
+    /* Extra margin because we are streaming. */
+    state.compressed = cursor_create(1024 + 2 * LZ4_compressBound(size));
+    state.roundTrip = cursor_create(size);
+
+    state.cstream = LZ4_createStream();
+    FUZZ_ASSERT(state.cstream);
+    state.dstream = LZ4_createStreamDecode();
+    FUZZ_ASSERT(state.dstream);
+
+    return state;
+}
+
+void state_free(state_t state)
+{
+    cursor_free(state.compressed);
+    cursor_free(state.roundTrip);
+    LZ4_freeStream(state.cstream);
+    LZ4_freeStreamDecode(state.dstream);
+}
+
+static void state_reset(state_t* state, uint32_t seed)
+{
+    LZ4_resetStream_fast(state->cstream);
+    LZ4_setStreamDecode(state->dstream, NULL, 0);
+    state->data.pos = 0;
+    state->compressed.pos = 0;
+    state->roundTrip.pos = 0;
+    state->seed = seed;
+}
+
+static void state_decompress(state_t* state, char const* src, int srcSize)
+{
+    char* dst = state->roundTrip.buf + state->roundTrip.pos;
+    int const dstCapacity = state->roundTrip.size - state->roundTrip.pos;
+    int const dSize = LZ4_decompress_safe_continue(state->dstream, src, dst,
+                                                   srcSize, dstCapacity);
+    FUZZ_ASSERT(dSize >= 0);
+    state->roundTrip.pos += dSize;
+}
+
+static void state_checkRoundTrip(state_t const* state)
+{
+    char const* data = state->data.buf;
+    size_t const size = state->data.size;
+    FUZZ_ASSERT_MSG(size == state->roundTrip.pos, "Incorrect size!");
+    FUZZ_ASSERT_MSG(!memcmp(data, state->roundTrip.buf, size), "Corruption!");
+}
+
+/**
+ * Picks a dictionary size and trims the dictionary off of the data.
+ */
+static size_t state_trimDict(state_t* state)
+{
+    /* 64 KB is the max dict size, allow slightly beyond that to test trim. */
+    uint32_t maxDictSize = MIN(70 * 1024, state->data.size);
+    size_t const dictSize = FUZZ_rand32(&state->seed, 0, maxDictSize);
+    FUZZ_ASSERT(state->compressed.pos == 0);
+    state->compressed.pos += dictSize;
+    return dictSize;
+}
+
+static void state_prefixRoundTrip(state_t* state)
+{
+    while (state->data.pos != state->data.size) {
+        char const* src = state->data.buf + state->data.pos;
+        char* dst = state->compressed.buf + state->compressed.pos;
+        int const srcRemaining = state->data.size - state->data.pos;
+        int const srcSize = FUZZ_rand32(&state->seed, 0, srcRemaining);
+        int const dstCapacity = state->compressed.size - state->compressed.pos;
+        int const cSize = LZ4_compress_fast_continue(state->cstream, src, dst,
+                                                     srcSize, dstCapacity, 0);
+        FUZZ_ASSERT(cSize > 0);
+        state->data.pos += srcSize;
+        state->compressed.pos += cSize;
+        state_decompress(state, dst, cSize);
+    }
+}
+
+static void state_extDictRoundTrip(state_t* state)
+{
+    int i = 0;
+    cursor_t data2 = cursor_create(state->data.size);
+    memcpy(data2.buf, state->data.buf, state->data.size);
+    while (state->data.pos != state->data.size) {
+        char const* data = (i++ & 1) ? state->data.buf : data2.buf;
+        char const* src = data + state->data.pos;
+        char* dst = state->compressed.buf + state->compressed.pos;
+        int const srcRemaining = state->data.size - state->data.pos;
+        int const srcSize = FUZZ_rand32(&state->seed, 0, srcRemaining);
+        int const dstCapacity = state->compressed.size - state->compressed.pos;
+        int const cSize = LZ4_compress_fast_continue(state->cstream, src, dst,
+                                                     srcSize, dstCapacity, 0);
+        FUZZ_ASSERT(cSize > 0);
+        state->data.pos += srcSize;
+        state->compressed.pos += cSize;
+        state_decompress(state, dst, cSize);
+    }
+    cursor_free(data2);
+}
+
+static void state_randomRoundTrip(state_t* state)
+{
+    if (FUZZ_rand32(&state->seed, 0, 1)) {
+      state_prefixRoundTrip(state);
+    } else {
+      state_extDictRoundTrip(state);
+    }
+}
+
+static void state_loadDictRoundTrip(state_t* state)
+{
+    char const* dict = state->compressed.buf;
+    size_t const dictSize = state_trimDict(state);
+    LZ4_loadDict(state->cstream, dict, dictSize);
+    LZ4_setStreamDecode(state->dstream, dict, dictSize);
+    state_randomRoundTrip(state);
+}
+
+static void state_attachDictRoundTrip(state_t* state)
+{
+    char const* dict = state->compressed.buf;
+    size_t const dictSize = state_trimDict(state);
+    LZ4_stream_t* dictStream = LZ4_createStream();
+    LZ4_loadDict(dictStream, dict, dictSize);
+    LZ4_attach_dictionary(state->cstream, dictStream);
+    LZ4_setStreamDecode(state->dstream, dict, dictSize);
+    state_randomRoundTrip(state);
+    LZ4_freeStream(dictStream);
+}
+
+typedef void (*round_trip_t)(state_t* state);
+
+round_trip_t roundTrips[] = {
+  &state_prefixRoundTrip,
+  &state_extDictRoundTrip,
+  &state_loadDictRoundTrip,
+  &state_attachDictRoundTrip,
+};
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    uint32_t seed = FUZZ_seed(&data, &size);
+    state_t state = state_create((char const*)data, size, seed);
+    const int n = sizeof(roundTrips) / sizeof(round_trip_t);
+    int i;
+
+    for (i = 0; i < n; ++i) {
+        roundTrips[i](&state);
+        state_checkRoundTrip(&state);
+        state_reset(&state, seed);
+    }
+
+    state_free(state);
+
+    return 0;
+}

--- a/ossfuzz/round_trip_stream_fuzzer.c
+++ b/ossfuzz/round_trip_stream_fuzzer.c
@@ -12,6 +12,8 @@
 #include "fuzz_helpers.h"
 #define LZ4_STATIC_LINKING_ONLY
 #include "lz4.h"
+#define LZ4_HC_STATIC_LINKING_ONLY
+#include "lz4hc.h"
 
 typedef struct {
   char const* buf;
@@ -27,11 +29,13 @@ typedef struct {
 
 typedef struct {
   LZ4_stream_t* cstream;
+  LZ4_streamHC_t* cstreamHC;
   LZ4_streamDecode_t* dstream;
   const_cursor_t data;
   cursor_t compressed;
   cursor_t roundTrip;
   uint32_t seed;
+  int level;
 } state_t;
 
 cursor_t cursor_create(size_t size)
@@ -43,6 +47,8 @@ cursor_t cursor_create(size_t size)
   FUZZ_ASSERT(cursor.buf);
   return cursor;
 }
+
+typedef void (*round_trip_t)(state_t* state);
 
 void cursor_free(cursor_t cursor)
 {
@@ -65,6 +71,8 @@ state_t state_create(char const* data, size_t size, uint32_t seed)
 
     state.cstream = LZ4_createStream();
     FUZZ_ASSERT(state.cstream);
+    state.cstreamHC = LZ4_createStreamHC();
+    FUZZ_ASSERT(state.cstream);
     state.dstream = LZ4_createStreamDecode();
     FUZZ_ASSERT(state.dstream);
 
@@ -76,12 +84,15 @@ void state_free(state_t state)
     cursor_free(state.compressed);
     cursor_free(state.roundTrip);
     LZ4_freeStream(state.cstream);
+    LZ4_freeStreamHC(state.cstreamHC);
     LZ4_freeStreamDecode(state.dstream);
 }
 
 static void state_reset(state_t* state, uint32_t seed)
 {
+    state->level = FUZZ_rand32(&seed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
     LZ4_resetStream_fast(state->cstream);
+    LZ4_resetStreamHC_fast(state->cstreamHC, state->level);
     LZ4_setStreamDecode(state->dstream, NULL, 0);
     state->data.pos = 0;
     state->compressed.pos = 0;
@@ -109,14 +120,19 @@ static void state_checkRoundTrip(state_t const* state)
 
 /**
  * Picks a dictionary size and trims the dictionary off of the data.
+ * We copy the dictionary to the roundTrip so our validation passes.
  */
 static size_t state_trimDict(state_t* state)
 {
     /* 64 KB is the max dict size, allow slightly beyond that to test trim. */
     uint32_t maxDictSize = MIN(70 * 1024, state->data.size);
     size_t const dictSize = FUZZ_rand32(&state->seed, 0, maxDictSize);
-    FUZZ_ASSERT(state->compressed.pos == 0);
-    state->compressed.pos += dictSize;
+    DEBUGLOG(2, "dictSize = %zu", dictSize);
+    FUZZ_ASSERT(state->data.pos == 0);
+    FUZZ_ASSERT(state->roundTrip.pos == 0);
+    memcpy(state->roundTrip.buf, state->data.buf, dictSize);
+    state->data.pos += dictSize;
+    state->roundTrip.pos += dictSize;
     return dictSize;
 }
 
@@ -159,43 +175,111 @@ static void state_extDictRoundTrip(state_t* state)
     cursor_free(data2);
 }
 
-static void state_randomRoundTrip(state_t* state)
+static void state_randomRoundTrip(state_t* state, round_trip_t rt0,
+                                  round_trip_t rt1)
 {
     if (FUZZ_rand32(&state->seed, 0, 1)) {
-      state_prefixRoundTrip(state);
+      rt0(state);
     } else {
-      state_extDictRoundTrip(state);
+      rt1(state);
     }
 }
 
 static void state_loadDictRoundTrip(state_t* state)
 {
-    char const* dict = state->compressed.buf;
+    char const* dict = state->data.buf;
     size_t const dictSize = state_trimDict(state);
     LZ4_loadDict(state->cstream, dict, dictSize);
     LZ4_setStreamDecode(state->dstream, dict, dictSize);
-    state_randomRoundTrip(state);
+    state_randomRoundTrip(state, state_prefixRoundTrip, state_extDictRoundTrip);
 }
 
 static void state_attachDictRoundTrip(state_t* state)
 {
-    char const* dict = state->compressed.buf;
+    char const* dict = state->data.buf;
     size_t const dictSize = state_trimDict(state);
     LZ4_stream_t* dictStream = LZ4_createStream();
     LZ4_loadDict(dictStream, dict, dictSize);
     LZ4_attach_dictionary(state->cstream, dictStream);
     LZ4_setStreamDecode(state->dstream, dict, dictSize);
-    state_randomRoundTrip(state);
+    state_randomRoundTrip(state, state_prefixRoundTrip, state_extDictRoundTrip);
     LZ4_freeStream(dictStream);
 }
 
-typedef void (*round_trip_t)(state_t* state);
+static void state_prefixHCRoundTrip(state_t* state)
+{
+    while (state->data.pos != state->data.size) {
+        char const* src = state->data.buf + state->data.pos;
+        char* dst = state->compressed.buf + state->compressed.pos;
+        int const srcRemaining = state->data.size - state->data.pos;
+        int const srcSize = FUZZ_rand32(&state->seed, 0, srcRemaining);
+        int const dstCapacity = state->compressed.size - state->compressed.pos;
+        int const cSize = LZ4_compress_HC_continue(state->cstreamHC, src, dst,
+                                                   srcSize, dstCapacity);
+        FUZZ_ASSERT(cSize > 0);
+        state->data.pos += srcSize;
+        state->compressed.pos += cSize;
+        state_decompress(state, dst, cSize);
+    }
+}
+
+static void state_extDictHCRoundTrip(state_t* state)
+{
+    int i = 0;
+    cursor_t data2 = cursor_create(state->data.size);
+    DEBUGLOG(2, "extDictHC");
+    memcpy(data2.buf, state->data.buf, state->data.size);
+    while (state->data.pos != state->data.size) {
+        char const* data = (i++ & 1) ? state->data.buf : data2.buf;
+        char const* src = data + state->data.pos;
+        char* dst = state->compressed.buf + state->compressed.pos;
+        int const srcRemaining = state->data.size - state->data.pos;
+        int const srcSize = FUZZ_rand32(&state->seed, 0, srcRemaining);
+        int const dstCapacity = state->compressed.size - state->compressed.pos;
+        int const cSize = LZ4_compress_HC_continue(state->cstreamHC, src, dst,
+                                                   srcSize, dstCapacity);
+        FUZZ_ASSERT(cSize > 0);
+        DEBUGLOG(2, "srcSize = %d", srcSize);
+        state->data.pos += srcSize;
+        state->compressed.pos += cSize;
+        state_decompress(state, dst, cSize);
+    }
+    cursor_free(data2);
+}
+
+static void state_loadDictHCRoundTrip(state_t* state)
+{
+    char const* dict = state->data.buf;
+    size_t const dictSize = state_trimDict(state);
+    LZ4_loadDictHC(state->cstreamHC, dict, dictSize);
+    LZ4_setStreamDecode(state->dstream, dict, dictSize);
+    state_randomRoundTrip(state, state_prefixHCRoundTrip,
+                          state_extDictHCRoundTrip);
+}
+
+static void state_attachDictHCRoundTrip(state_t* state)
+{
+    char const* dict = state->data.buf;
+    size_t const dictSize = state_trimDict(state);
+    LZ4_streamHC_t* dictStream = LZ4_createStreamHC();
+    LZ4_setCompressionLevel(dictStream, state->level);
+    LZ4_loadDictHC(dictStream, dict, dictSize);
+    LZ4_attach_HC_dictionary(state->cstreamHC, dictStream);
+    LZ4_setStreamDecode(state->dstream, dict, dictSize);
+    state_randomRoundTrip(state, state_prefixHCRoundTrip,
+                          state_extDictHCRoundTrip);
+    LZ4_freeStreamHC(dictStream);
+}
 
 round_trip_t roundTrips[] = {
   &state_prefixRoundTrip,
   &state_extDictRoundTrip,
   &state_loadDictRoundTrip,
   &state_attachDictRoundTrip,
+  &state_prefixHCRoundTrip,
+  &state_extDictHCRoundTrip,
+  &state_loadDictHCRoundTrip,
+  &state_attachDictHCRoundTrip,
 };
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
@@ -206,9 +290,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     int i;
 
     for (i = 0; i < n; ++i) {
+        DEBUGLOG(2, "Round trip %d", i);
+        state_reset(&state, seed);
         roundTrips[i](&state);
         state_checkRoundTrip(&state);
-        state_reset(&state, seed);
     }
 
     state_free(state);

--- a/ossfuzz/travisoss.sh
+++ b/ossfuzz/travisoss.sh
@@ -8,10 +8,7 @@ git clone https://github.com/google/oss-fuzz.git /tmp/ossfuzz
 if [[ ! -d /tmp/ossfuzz/projects/lz4 ]]
 then
     echo "Could not find the lz4 project in ossfuzz"
-
-    # Exit with a success code while the lz4 project is not expected to exist
-    # on oss-fuzz.
-    exit 0
+    exit 1
 fi
 
 # Modify the oss-fuzz Dockerfile so that we're checking out the current branch on travis.


### PR DESCRIPTION
Fuzzers
* Streaming compression with prefix
* Streaming compression with extDict
* Streaming compression with loaded dictionary
* Streaming compression with attached dictionary
* Streaming compression with all of the above in HC mode
* LZ4HC round trip fuzzer
* LZ4HC compress fuzzer

Fixes:
* Fixed `LZ4_attach_dictionary()` with an empty dictionary. It would find matches **beyond** the end of the dictionary causing asserts to fail. CC @felixhandte.