### PR TITLE
[LZ4_compress_destSize] Fix off-by-one error in fix

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1042,7 +1042,7 @@ _next_match:
                          */
                         const BYTE* ptr;
                         DEBUGLOG(5, "Clearing %u positions", (U32)(filledIp - ip));
-                        for (ptr = ip + 1; ptr <= filledIp; ++ptr) {
+                        for (ptr = ip; ptr <= filledIp; ++ptr) {
                             U32 const h = LZ4_hashPosition(ptr, tableType);
                             LZ4_clearHash(h, cctx->hashTable, tableType);
                         }


### PR DESCRIPTION
The next match is looking at the current ip, not the next ip,
so it needs to be cleared as well.

Credit to OSS-Fuzz