### PR TITLE
[lz4hc] Further improve pattern detection and chain swapping

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -312,20 +312,26 @@ LZ4HC_InsertAndGetWiderMatch (
         if (chainSwap && matchLength==longest) {    /* better match => select a better chain */
             assert(lookBackLength==0);   /* search forward only */
             if (matchIndex + (U32)longest <= ipIndex) {
+                int const kTrigger = 4;
                 U32 distanceToNextMatch = 1;
+                int const end = longest - MINMATCH + 1;
+                int step = 1;
+                int accel = 1 << kTrigger;
                 int pos;
-                for (pos = matchChainPos; pos <= longest - MINMATCH; ++pos) {
+                for (pos = 0; pos < end; pos += step) {
                     U32 const candidateDist = DELTANEXTU16(chainTable, matchIndex + (U32)pos);
+                    step = (accel++ >> kTrigger);
                     if (candidateDist > distanceToNextMatch) {
                         distanceToNextMatch = candidateDist;
                         matchChainPos = (U32)pos;
-                }   }
+                        accel = 1 << kTrigger;
+                    }
+                }
                 if (distanceToNextMatch > 1) {
                     if (distanceToNextMatch > matchIndex) break;   /* avoid overflow */
                     matchIndex -= distanceToNextMatch;
                     continue;
-                }
-        }   }
+        }   }   }
 
         {   U32 const distNextMatch = DELTANEXTU16(chainTable, matchIndex);
             if (patternAnalysis && distNextMatch==1 && matchChainPos==0) {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -314,7 +314,7 @@ LZ4HC_InsertAndGetWiderMatch (
             if (matchIndex + (U32)longest <= ipIndex) {
                 U32 distanceToNextMatch = 1;
                 int pos;
-                for (pos = 0; pos <= longest - MINMATCH; ++pos) {
+                for (pos = matchChainPos; pos <= longest - MINMATCH; ++pos) {
                     U32 const candidateDist = DELTANEXTU16(chainTable, matchIndex + (U32)pos);
                     if (candidateDist > distanceToNextMatch) {
                         distanceToNextMatch = candidateDist;

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -335,7 +335,7 @@ LZ4HC_InsertAndGetWiderMatch (
                         const BYTE* const dictStart = dictBase + hc4->lowLimit;
                         const BYTE* const iLimit = extDict ? dictBase + dictLimit : iHighLimit;
                         size_t forwardPatternLength = LZ4HC_countPattern(matchPtr+sizeof(pattern), iLimit, pattern) + sizeof(pattern);
-                        if (extDict && ip + forwardPatternLength == iLimit) {
+                        if (extDict && matchPtr + forwardPatternLength == iLimit) {
                             U32 const rotatedPattern = LZ4HC_rotatePattern(forwardPatternLength, pattern);
                             forwardPatternLength += LZ4HC_countPattern(lowPrefixPtr, iHighLimit, rotatedPattern);
                         }


### PR DESCRIPTION
* Add an acceleration parameter to chain swapping to speed it up in the case of long unfruitful matches. This is approximately neutral for the common case, but speeds up long matches considerably. This showed up as slow units in my fuzzing (1 MB took 50 seconds with ASAN or 12 seconds in an optimized build).
* Fix a typo bug in the forward extension `s/ip/matchPtr`.
* In the pattern detection code, make sure we never set `matchCandidateIdx` or `matchIndex` to within 3 bytes of the end of the dictionary using `LZ4HC_protectDictEnd()`. This could cause data corruption and/or a read out of bounds.
* Extend the match backwards if it hits `lowPrefixPtr`. This was the OSS-Fuzz slow unit cause. Credit to OSS-Fuzz.

The compression ratio is the same for every file in silesia, calgary, and enwik7.

Fuzz testing overnight with the `round_trip_stream_fuzzer`.

```
12#dickens           :  10192446 ->   4376097 (2.329),  10.6 MB/s ,2943.0 MB/s
12#dickens           :  10192446 ->   4376097 (2.329),  10.6 MB/s ,2940.0 MB/s
12#mozilla           :  51220480 ->  22014250 (2.327),   6.5 MB/s ,3775.5 MB/s
12#mozilla           :  51220480 ->  22014250 (2.327),   6.3 MB/s ,3778.4 MB/s
12#mr                :   9970564 ->   4189363 (2.380),   7.9 MB/s ,3629.1 MB/s
12#mr                :   9970564 ->   4189363 (2.380),   7.8 MB/s ,3626.9 MB/s
12#nci               :  33553445 ->   3617512 (9.275),  15.7 MB/s ,5718.9 MB/s
12#nci               :  33553445 ->   3617512 (9.275),  15.7 MB/s ,5719.4 MB/s
12#ooffice           :   6152192 ->   3535250 (1.740),  14.3 MB/s ,3091.8 MB/s
12#ooffice           :   6152192 ->   3535250 (1.740),  14.1 MB/s ,3095.2 MB/s
12#osdb              :  10085684 ->   3946233 (2.556),  22.6 MB/s ,4229.9 MB/s
12#osdb              :  10085684 ->   3946233 (2.556),  21.9 MB/s ,4227.4 MB/s
12#reymont           :   6627202 ->   2063052 (3.212),   8.0 MB/s ,3568.0 MB/s
12#reymont           :   6627202 ->   2063052 (3.212),   7.9 MB/s ,3570.2 MB/s
12#samba             :  21606400 ->   6095902 (3.544),  10.1 MB/s ,4095.9 MB/s
12#samba             :  21606400 ->   6095902 (3.544),   9.9 MB/s ,4096.8 MB/s
12#sao               :   7251944 ->   5668734 (1.279),  15.1 MB/s ,3270.0 MB/s
12#sao               :   7251944 ->   5668734 (1.279),  15.4 MB/s ,3268.8 MB/s
12#webster           :  41458703 ->  13823143 (2.999),  12.7 MB/s ,3060.9 MB/s
12#webster           :  41458703 ->  13823143 (2.999),  12.6 MB/s ,3060.1 MB/s
12#xml               :   5345280 ->    759893 (7.034),  20.9 MB/s ,5340.6 MB/s
12#xml               :   5345280 ->    759893 (7.034),  21.2 MB/s ,5339.2 MB/s
12#x-ray             :   8474240 ->   7172970 (1.181),  24.5 MB/s ,2685.2 MB/s
12#x-ray             :   8474240 ->   7172970 (1.181),  24.3 MB/s ,2684.1 MB/s
```