### PR TITLE
silence msan warning when offset==0

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -15,6 +15,7 @@ checkFrame
 # test artefacts
 tmp*
 versionsTest
+lz4_all.c
 
 # local tests
 afl


### PR DESCRIPTION
Ensure target buffer get overwritten with 0 when `offset==0` is specified in the compressed block.

This fix seems, on average, slightly performance detrimental, in the vicinity of <1% loss. Note that I can't access my benchmark platform at the moment, so I'm using my laptop, and performance variations between measurements is high on this platform, so measured differences could be noise.

| name | `dev` | `offset0` |
| --- | --- | --- |
| silesia | 4263 MB/s | 4250 MB/s |
| calgary | 4369 MB/s | 4358 MB/s |
| enwik8 | 3939 MB/s | 3946 MB/s | 

