### PR TITLE
Make Attaching an Empty Dict Behave the Same as Using it Directly

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1429,6 +1429,10 @@ int LZ4_loadDict (LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize)
 }
 
 void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream) {
+    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %d)",
+        workingStream, dictionaryStream, dictionaryStream != NULL ?
+        dictionaryStream->internal_donotuse.dictSize : 0);
+
     /* Calling LZ4_resetStream_fast() here makes sure that changes will not be
      * erased by subsequent calls to LZ4_resetStream_fast() in case stream was
      * marked as having dirty context, e.g. requiring full reset.


### PR DESCRIPTION
When using an empty dictionary, we bail out of loading or attaching it in
ways that leave the working context in potentially slightly different states.
In particular, in some paths, we will cause the currentOffset to be non-zero,
while in others we would allow it to remain 0.

This difference in behavior is perfectly harmless, but in some situations, it
can produce slight differences in the compressed output. For sanity's sake,
we currently try to maintain a strict correspondence between the behavior of
the dict attachment and the dict loading paths. This patch restores them to
behaving identically.

This shouldn't have any negative side-effects, as far as I can tell. When
writing the dict attachment code, I tried to preserve zeroed currentOffsets
when possible, since they benchmarked as very slightly faster. However, the
case of attaching an empty dictionary is probably rare enought that it's
acceptable to minisculely degrade performance in that corner case.

This split in behavior could previously be observed with:

```
make -C tests fuzzer
tests/fuzzer -s240 -t284906 -i284907
tests/fuzzer -s1330 -t3796126 -i3796127
```

These tests now pass.