### PR TITLE
FAST_DEC_LOOP: performance improvements on X86/X64

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1825,9 +1825,10 @@ LZ4_decompress_generic(
                         continue;
                     }
 #endif
-            }   }
+                }
+                if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
+            }
 
-            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) { goto _output_error; } /* Error : offset outside buffers */
             /* match starting within external dictionary */
             if ((dict==usingExtDict) && (match < lowPrefix)) {
                 if (unlikely(op+length > oend-LASTLITERALS)) {


### PR DESCRIPTION
Hi @Cyan4973:

This pull request include 2 commits.
1. FAST_DEC_LOOP:Handle all offset condition.
2. FAST_DEC_LOOP: skip needless offset check if length == ML_MASK

Here is the benchmark result.

File name | lz4 | Patched#747 | Patched#747+skip offset check
-- | -- | -- | --
dickens | 3231 | 3342 | 3351
mozilla | 3231 | 3272 | 3284
mr | 3719 | 3810 | 3830
nci | 4592 | 4738 | 4700
ooffice | 3265 | 3293 | 3321
osdb | 3325 | 3533 | 3567
reymont | 2833 | 2882 | 2894
samba | 3663 | 3798 | 3804
sao | 4433 | 4431 | 4492
webster | 3143 | 3296 | 3306
xml | 3908 | 4049 | 4054
X-ray | 7500 | 7614 | 7569



Chenxi