### PR TITLE
[LZ4_compress_destSize] Fix off-by-one error

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1040,7 +1040,7 @@ _next_match:
                     ip -= matchCode - newMatchCode;
                     assert(newMatchCode < matchCode);
                     matchCode = newMatchCode;
-                    if (unlikely(ip < filledIp)) {
+                    if (unlikely(ip <= filledIp)) {
                         /* We have already filled up to filledIp so if ip ends up less than filledIp
                          * we have positions in the hash table beyond the current position. This is
                          * a problem if we reuse the hash table. So we have to remove these positions


### PR DESCRIPTION
PR#756 fixed the data corruption bug, but didn't clear `ip`. PR#760
fixed that off-by-one error, but missed the case where `ip == filledIp`,
which is harder for the fuzzers to find (it took 20 days not 1 day).

Verified this fixed the issue reported by OSS-Fuzz.

Credit to OSS-Fuzz.