### PR TITLE
Adding fuzz data producer for uint32 and using in decompress_fuzzer

### DIFF
--- a/ossfuzz/Makefile
+++ b/ossfuzz/Makefile
@@ -58,7 +58,7 @@ $(LZ4DIR)/liblz4.a:
 	$(CC) -c $(LZ4_CFLAGS) $(LZ4_CPPFLAGS) $< -o $@
 
 # Generic rule for generating fuzzers
-%_fuzzer: %_fuzzer.o lz4_helpers.o $(LZ4DIR)/liblz4.a
+%_fuzzer: %_fuzzer.o lz4_helpers.o fuzz_data_producer.o $(LZ4DIR)/liblz4.a
 	# Compile the standalone code just in case. The OSS-Fuzz code might
 	# override the LIB_FUZZING_ENGINE value to "-fsanitize=fuzzer"
 	$(CC) -c $(LZ4_CFLAGS) $(LZ4_CPPFLAGS) standaloneengine.c -o standaloneengine.o

--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -10,14 +10,12 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
-#include "fuzz_data_producer.h"
 #include "lz4.h"
 #include "lz4frame.h"
 #include "lz4_helpers.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
     uint32_t seed = FUZZ_seed(&data, &size);
     LZ4F_preferences_t const prefs = FUZZ_randomPreferences(&seed);
     size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);

--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -10,12 +10,14 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
+#include "fuzz_data_producer.h"
 #include "lz4.h"
 #include "lz4frame.h"
 #include "lz4_helpers.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
     uint32_t seed = FUZZ_seed(&data, &size);
     LZ4F_preferences_t const prefs = FUZZ_randomPreferences(&seed);
     size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);

--- a/ossfuzz/compress_fuzzer.c
+++ b/ossfuzz/compress_fuzzer.c
@@ -22,7 +22,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     char* const rt = (char*)malloc(size);
 
     /* Restrict to remaining data from producer */
-    size = producer->size;
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/compress_fuzzer.c
+++ b/ossfuzz/compress_fuzzer.c
@@ -10,14 +10,19 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
+#include "fuzz_data_producer.h"
 #include "lz4.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    uint32_t seed = FUZZ_seed(&data, &size);
-    size_t const dstCapacity = FUZZ_rand32(&seed, 0, LZ4_compressBound(size));
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(
+      producer, 0, LZ4_compressBound(size));
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
+
+    /* Restrict to remaining data from producer */
+    size = producer->size;
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
@@ -46,6 +51,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     free(dst);
     free(rt);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -25,7 +25,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
       producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 
     /* Restrict to remaining data from producer */
-    size = producer->size;
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -10,16 +10,22 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
+#include "fuzz_data_producer.h"
 #include "lz4.h"
 #include "lz4hc.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    uint32_t seed = FUZZ_seed(&data, &size);
-    size_t const dstCapacity = FUZZ_rand32(&seed, 0, LZ4_compressBound(size));
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(
+      producer, 0, LZ4_compressBound(size));
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-    int const level = FUZZ_rand32(&seed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+    int const level = FUZZ_dataProducer_uint32(
+      producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
+    /* Restrict to remaining data from producer */
+    size = producer->size;
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
@@ -52,6 +58,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     free(dst);
     free(rt);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }

--- a/ossfuzz/decompress_frame_fuzzer.c
+++ b/ossfuzz/decompress_frame_fuzzer.c
@@ -43,7 +43,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
 
     /* Restrict to remaining data from producer */
-    size = producer->size;
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dctx);
     FUZZ_ASSERT(dst);

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -15,7 +15,8 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(producer, 0, 4 * size);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(
+      producer, 0, 4 * size);
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -9,13 +9,12 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
+#include "fuzz_data_producer.h"
 #include "lz4.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-
-    uint32_t seed = FUZZ_seed(&data, &size);
-    size_t const dstCapacity = FUZZ_rand32(&seed, 0, 4 * size);
+    size_t const dstCapacity = FUZZ_produceUint32Range(data, size, 0, 4 * size);
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -14,7 +14,8 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    size_t const dstCapacity = FUZZ_produceUint32Range(data, size, 0, 4 * size);
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(producer, 0, 4 * size);
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);
@@ -23,6 +24,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     char* const largeDict = dict;
     char* const dataAfterDict = dict + dictSize;
     char* const smallDict = dataAfterDict - smallDictSize;
+
+    /* Restrict to remaining data from producer */
+    size = producer->size;
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(dict);
@@ -52,6 +56,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
                                 dstCapacity, dstCapacity);
     free(dst);
     free(dict);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -27,7 +27,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     char* const smallDict = dataAfterDict - smallDictSize;
 
     /* Restrict to remaining data from producer */
-    size = producer->size;
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(dict);

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -1,0 +1,32 @@
+#include "fuzz_data_producer.h"
+
+FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) {
+  FUZZ_dataProducer_t *producer = malloc(sizeof(FUZZ_dataProducer_t));
+  producer->data = data;
+  producer->size = size;
+  return producer;
+}
+
+void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer) { free(producer); }
+
+uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
+                                  uint32_t max) {
+  FUZZ_ASSERT(min <= max);
+
+  uint32_t range = max - min;
+  uint32_t rolling = range;
+  uint32_t result = 0;
+
+  while (rolling > 0 && producer->size > 0) {
+    uint8_t next = *(producer->data + producer->size - 1);
+    producer->size -= 1;
+    result = (result << 8) | next;
+    rolling >>= 8;
+  }
+
+  if (range == 0xffffffff) {
+    return result;
+  }
+
+  return min + result % (range + 1);
+}

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -1,7 +1,15 @@
 #include "fuzz_data_producer.h"
 
+struct FUZZ_dataProducer_s{
+  const uint8_t *data;
+  size_t size;
+};
+
 FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) {
   FUZZ_dataProducer_t *producer = malloc(sizeof(FUZZ_dataProducer_t));
+
+  FUZZ_ASSERT(producer != NULL);
+
   producer->data = data;
   producer->size = size;
   return producer;
@@ -29,4 +37,8 @@ uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
   }
 
   return min + result % (range + 1);
+}
+
+size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer){
+  return producer->size;
 }

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -5,14 +5,18 @@
 
 #include "fuzz_helpers.h"
 
-typedef struct {
-  const uint8_t *data;
-  size_t size;
-} FUZZ_dataProducer_t;
+/* Struct used for maintaining the state of the data */
+typedef struct FUZZ_dataProducer_s FUZZ_dataProducer_t;
 
+/* Returns a data producer state struct. Use for producer initialization. */
 FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 
+/* Frees the data producer */
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
+/* Returns value between [min, max] */
 uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max);
+
+/* Returns the size of the remaining bytes of data in the producer */
+size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer);

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -3,40 +3,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "fuzz_helpers.h"
+
 typedef struct {
   const uint8_t *data;
   size_t size;
 } FUZZ_dataProducer_t;
 
-FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) {
-  FUZZ_dataProducer_t *producer = malloc(sizeof(FUZZ_dataProducer_t));
-  producer->data = data;
-  producer->size = size;
-  return producer;
-}
+FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 
-void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer) { free(producer); }
+void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
 uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
-                                  uint32_t max) {
-  if (min > max) {
-    return 0;
-  }
-
-  uint32_t range = max - min;
-  uint32_t rolling = range;
-  uint32_t result = 0;
-
-  while (rolling > 0 && producer->size > 0) {
-    uint8_t next = *(producer->data + producer->size - 1);
-    producer->size -= 1;
-    result = (result << 8) | next;
-    rolling >>= 8;
-  }
-
-  if (range == 0xffffffff) {
-    return result;
-  }
-
-  return min + result % (range + 1);
-}
+                                  uint32_t max);

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -3,8 +3,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-FUZZ_STATIC uint32_t FUZZ_produceUint32Range(uint8_t *data, size_t size,
-                                             uint32_t min, uint32_t max) {
+typedef struct {
+  const uint8_t *data;
+  size_t size;
+} FUZZ_dataProducer_t;
+
+FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) {
+  FUZZ_dataProducer_t *producer = malloc(sizeof(FUZZ_dataProducer_t));
+  producer->data = data;
+  producer->size = size;
+  return producer;
+}
+
+void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer) { free(producer); }
+
+uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
+                                  uint32_t max) {
   if (min > max) {
     return 0;
   }
@@ -13,10 +27,11 @@ FUZZ_STATIC uint32_t FUZZ_produceUint32Range(uint8_t *data, size_t size,
   uint32_t rolling = range;
   uint32_t result = 0;
 
-  while (rolling > 0 && size > 0) {
-    uint8_t next = *(data + size - 1);
-    size -= 1;
+  while (rolling > 0 && producer->size > 0) {
+    uint8_t next = *(producer->data + producer->size - 1);
+    producer->size -= 1;
     result = (result << 8) | next;
+    rolling >>= 8;
   }
 
   if (range == 0xffffffff) {

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -1,0 +1,27 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+FUZZ_STATIC uint32_t FUZZ_produceUint32Range(uint8_t *data, size_t size,
+                                             uint32_t min, uint32_t max) {
+  if (min > max) {
+    return 0;
+  }
+
+  uint32_t range = max - min;
+  uint32_t rolling = range;
+  uint32_t result = 0;
+
+  while (rolling > 0 && size > 0) {
+    uint8_t next = *(data + size - 1);
+    size -= 1;
+    result = (result << 8) | next;
+  }
+
+  if (range == 0xffffffff) {
+    return result;
+  }
+
+  return min + result % (range + 1);
+}

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -9,16 +9,21 @@
 #include <string.h>
 
 #include "fuzz_helpers.h"
+#include "fuzz_data_producer.h"
 #include "lz4.h"
 #include "lz4hc.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    uint32_t seed = FUZZ_seed(&data, &size);
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
     size_t const dstCapacity = LZ4_compressBound(size);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-    int const level = FUZZ_rand32(&seed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+    int const level = FUZZ_dataProducer_uint32(
+      producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
+    /* Restrict to remaining data from producer */
+    size = producer->size;
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
@@ -34,6 +39,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     free(dst);
     free(rt);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -23,7 +23,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
       producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 
     /* Restrict to remaining data from producer */
-    size = producer->size;
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);


### PR DESCRIPTION
Consuming bytes from the end of data instead of from the front to prevent "all-in-one" decisions.