### PR TITLE
Making fuzzers use dataProducer api instead of random seed for decisions

### DIFF
--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -13,18 +13,22 @@
 #include "lz4.h"
 #include "lz4frame.h"
 #include "lz4_helpers.h"
+#include "fuzz_data_producer.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    uint32_t seed = FUZZ_seed(&data, &size);
-    LZ4F_preferences_t const prefs = FUZZ_randomPreferences(&seed);
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
+    LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
     size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);
-    size_t const dstCapacity = FUZZ_rand32(&seed, 0, compressBound);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(producer, 0, compressBound);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
+
+    /* Restrict to remaining data from producer */
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     /* If compression succeeds it must round trip correctly. */
     size_t const dstSize =
@@ -37,6 +41,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     free(dst);
     free(rt);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -39,6 +39,31 @@ uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
   return min + result % (range + 1);
 }
 
+LZ4F_frameInfo_t FUZZ_dataProducer_frameInfo(FUZZ_dataProducer_t* producer)
+{
+    LZ4F_frameInfo_t info = LZ4F_INIT_FRAMEINFO;
+    info.blockSizeID = FUZZ_dataProducer_uint32(producer, LZ4F_max64KB - 1, LZ4F_max4MB);
+    if (info.blockSizeID < LZ4F_max64KB) {
+        info.blockSizeID = LZ4F_default;
+    }
+    info.blockMode = FUZZ_dataProducer_uint32(producer, LZ4F_blockLinked, LZ4F_blockIndependent);
+    info.contentChecksumFlag = FUZZ_dataProducer_uint32(producer, LZ4F_noContentChecksum,
+                                           LZ4F_contentChecksumEnabled);
+    info.blockChecksumFlag = FUZZ_dataProducer_uint32(producer, LZ4F_noBlockChecksum,
+                                         LZ4F_blockChecksumEnabled);
+    return info;
+}
+
+LZ4F_preferences_t FUZZ_dataProducer_preferences(FUZZ_dataProducer_t* producer)
+{
+    LZ4F_preferences_t prefs = LZ4F_INIT_PREFERENCES;
+    prefs.frameInfo = FUZZ_dataProducer_frameInfo(producer);
+    prefs.compressionLevel = FUZZ_dataProducer_uint32(producer, 0, LZ4HC_CLEVEL_MAX + 3) - 3;
+    prefs.autoFlush = FUZZ_dataProducer_uint32(producer, 0, 1);
+    prefs.favorDecSpeed = FUZZ_dataProducer_uint32(producer, 0, 1);
+    return prefs;
+}
+
 size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer){
   return producer->size;
 }

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 
 #include "fuzz_helpers.h"
+#include "lz4frame.h"
+#include "lz4hc.h"
 
 /* Struct used for maintaining the state of the data */
 typedef struct FUZZ_dataProducer_s FUZZ_dataProducer_t;
@@ -17,6 +19,12 @@ void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 /* Returns value between [min, max] */
 uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max);
+
+/* Returns lz4 preferences */
+LZ4F_preferences_t FUZZ_dataProducer_preferences(FUZZ_dataProducer_t* producer);
+
+/* Returns lz4 frame info */
+LZ4F_frameInfo_t FUZZ_dataProducer_frameInfo(FUZZ_dataProducer_t* producer);
 
 /* Returns the size of the remaining bytes of data in the producer */
 size_t FUZZ_dataProducer_remainingBytes(FUZZ_dataProducer_t *producer);

--- a/ossfuzz/round_trip_frame_fuzzer.c
+++ b/ossfuzz/round_trip_frame_fuzzer.c
@@ -12,17 +12,21 @@
 #include "lz4.h"
 #include "lz4frame.h"
 #include "lz4_helpers.h"
+#include "fuzz_data_producer.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    uint32_t seed = FUZZ_seed(&data, &size);
-    LZ4F_preferences_t const prefs = FUZZ_randomPreferences(&seed);
+    FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
+    LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
     size_t const dstCapacity = LZ4F_compressFrameBound(size, &prefs);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
+
+    /* Restrict to remaining data from producer */
+    size = FUZZ_dataProducer_remainingBytes(producer);
 
     /* Compression must succeed and round trip correctly. */
     size_t const dstSize =
@@ -34,6 +38,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     free(dst);
     free(rt);
+    FUZZ_dataProducer_free(producer);
 
     return 0;
 }


### PR DESCRIPTION
Had planned on moving the remaining fuzzers over to consuming bytes from the end of data for decisions. Doing so now. Previous PR: https://github.com/lz4/lz4/pull/779. 

I've added a new dataProducer method (FUZZ_dataProducer_preferences) to get fuzzed preferences using bytes from the end of the stream instead of rand32().

Still have yet to move round_trip_steam_fuzzer.c. Will do that one separately because it's more complex. 