### PR TITLE
Removing size modification after data producer call 

### DIFF
--- a/ossfuzz/round_trip_fuzzer.c
+++ b/ossfuzz/round_trip_fuzzer.c
@@ -23,9 +23,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
 
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
-
     /* Compression must succeed and round trip correctly. */
     int const dstSize = LZ4_compress_default((const char*)data, dst,
                                              size, dstCapacity);


### PR DESCRIPTION
The assert below was failing because the data producer generates partialCapacity between (0, n)  inclusive but then we shrink the size of the data to be n-1 right after so when the data producer selects n as the partialCapacity, the assert fails. 

Of course, the current solution means that we're reusing the data we used to make the decision for the fuzzer. Maybe this is okay? Maybe not? thoughts? 

This means we need to do this for all the other fuzzers that I moved too. I'll do that once I get some feedback on the above decision. 