### PR TITLE
Separating the seed generation and use in FUZZ_dataProducer api 

### DIFF
--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -19,8 +19,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-    size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(producer, 0, compressBound);
+    size_t const compressBound = LZ4F_compressFrameBound(FUZZ_dataProducer_remainingBytes(producer), &prefs);
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, compressBound);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
+        0, FUZZ_dataProducer_remainingBytes(producer));
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 

--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -19,13 +19,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-
+    size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
+
     size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, compressBound);
-
-    size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, size);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, compressBound);
 
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);

--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -19,18 +19,19 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-    size_t const compressBound = LZ4F_compressFrameBound(FUZZ_dataProducer_remainingBytes(producer), &prefs);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, compressBound);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
-        0, FUZZ_dataProducer_remainingBytes(producer));
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const compressBound = LZ4F_compressFrameBound(size, &prefs);
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, compressBound);
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, size);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     /* If compression succeeds it must round trip correctly. */
     size_t const dstSize =

--- a/ossfuzz/compress_fuzzer.c
+++ b/ossfuzz/compress_fuzzer.c
@@ -16,8 +16,9 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(
-      producer, 0, LZ4_compressBound(size));
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, LZ4_compressBound(size));
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
+        0, LZ4_compressBound(FUZZ_dataProducer_remainingBytes(producer)));
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 

--- a/ossfuzz/compress_fuzzer.c
+++ b/ossfuzz/compress_fuzzer.c
@@ -16,10 +16,11 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, LZ4_compressBound(size));
-
+    size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, LZ4_compressBound(size));
+
+    size_t const compressBound = LZ4_compressBound(size);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, compressBound);
 
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);

--- a/ossfuzz/compress_fuzzer.c
+++ b/ossfuzz/compress_fuzzer.c
@@ -16,14 +16,13 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, LZ4_compressBound(size));
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
-        0, LZ4_compressBound(FUZZ_dataProducer_remainingBytes(producer)));
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, LZ4_compressBound(size));
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, LZ4_compressBound(size));
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -17,12 +17,16 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(
-      producer, 0, LZ4_compressBound(size));
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer,
+        0, LZ4_compressBound(size));
+    size_t const levelSeed = FUZZ_dataProducer_uint32_seed(producer,
+        LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
+        0, FUZZ_dataProducer_remainingBytes(producer));
+    int const level = FUZZ_dataProducer_uint32(
+        levelSeed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-    int const level = FUZZ_dataProducer_uint32(
-      producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 
     /* Restrict to remaining data from producer */
     size = FUZZ_dataProducer_remainingBytes(producer);

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -17,12 +17,10 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer,
-        0, LZ4_compressBound(size));
-    size_t const levelSeed = FUZZ_dataProducer_uint32(producer,
-        LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
-
+    size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
+    size_t const levelSeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
+
     size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, size);
     int const level = FUZZ_getRange_from_uint32(levelSeed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 

--- a/ossfuzz/compress_hc_fuzzer.c
+++ b/ossfuzz/compress_hc_fuzzer.c
@@ -17,19 +17,17 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer,
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer,
         0, LZ4_compressBound(size));
-    size_t const levelSeed = FUZZ_dataProducer_uint32_seed(producer,
+    size_t const levelSeed = FUZZ_dataProducer_uint32(producer,
         LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
-        0, FUZZ_dataProducer_remainingBytes(producer));
-    int const level = FUZZ_dataProducer_uint32(
-        levelSeed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, size);
+    int const level = FUZZ_getRange_from_uint32(levelSeed, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/decompress_frame_fuzzer.c
+++ b/ossfuzz/decompress_frame_fuzzer.c
@@ -31,11 +31,15 @@ static void decompress(LZ4F_dctx* dctx, void* dst, size_t dstCapacity,
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(
-      producer, 0, 4 * size);
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer,
+        0, 4 * size);
     size_t const largeDictSize = 64 * 1024;
+    size_t const dictSizeSeed = FUZZ_dataProducer_uint32_seed(producer,
+        0, largeDictSize);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(
+      dstCapacitySeed, 0, 4 * FUZZ_dataProducer_remainingBytes(producer));
     size_t const dictSize = FUZZ_dataProducer_uint32(
-      producer, 0, largeDictSize);
+      dictSizeSeed, 0, largeDictSize);
     char* const dst = (char*)malloc(dstCapacity);
     char* const dict = (char*)malloc(dictSize);
     LZ4F_decompressOptions_t opts;

--- a/ossfuzz/decompress_frame_fuzzer.c
+++ b/ossfuzz/decompress_frame_fuzzer.c
@@ -31,23 +31,23 @@ static void decompress(LZ4F_dctx* dctx, void* dst, size_t dstCapacity,
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer,
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer,
         0, 4 * size);
     size_t const largeDictSize = 64 * 1024;
-    size_t const dictSizeSeed = FUZZ_dataProducer_uint32_seed(producer,
+    size_t const dictSizeSeed = FUZZ_dataProducer_uint32(producer,
         0, largeDictSize);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(
-      dstCapacitySeed, 0, 4 * FUZZ_dataProducer_remainingBytes(producer));
-    size_t const dictSize = FUZZ_dataProducer_uint32(
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(
+      dstCapacitySeed, 0, 4 * size);
+    size_t const dictSize = FUZZ_getRange_from_uint32(
       dictSizeSeed, 0, largeDictSize);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const dict = (char*)malloc(dictSize);
     LZ4F_decompressOptions_t opts;
     LZ4F_dctx* dctx;
     LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dctx);
     FUZZ_ASSERT(dst);

--- a/ossfuzz/decompress_frame_fuzzer.c
+++ b/ossfuzz/decompress_frame_fuzzer.c
@@ -31,15 +31,13 @@ static void decompress(LZ4F_dctx* dctx, void* dst, size_t dstCapacity,
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer,
-        0, 4 * size);
-    size_t const largeDictSize = 64 * 1024;
-    size_t const dictSizeSeed = FUZZ_dataProducer_uint32(producer,
-        0, largeDictSize);
-
+    size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
+    size_t const dictSizeSeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
+
     size_t const dstCapacity = FUZZ_getRange_from_uint32(
       dstCapacitySeed, 0, 4 * size);
+    size_t const largeDictSize = 64 * 1024;
     size_t const dictSize = FUZZ_getRange_from_uint32(
       dictSizeSeed, 0, largeDictSize);
 

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -15,11 +15,10 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, 4 * size);
-
+    size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, 4 * size);
 
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, 4 * size);
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -15,8 +15,9 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(
-      producer, 0, 4 * size);
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, 4 * size);
+    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
+        0, 4 * FUZZ_dataProducer_remainingBytes(producer));
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);

--- a/ossfuzz/decompress_fuzzer.c
+++ b/ossfuzz/decompress_fuzzer.c
@@ -15,9 +15,11 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, 4 * size);
-    size_t const dstCapacity = FUZZ_dataProducer_uint32(dstCapacitySeed,
-        0, 4 * FUZZ_dataProducer_remainingBytes(producer));
+    size_t const dstCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, 4 * size);
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = FUZZ_getRange_from_uint32(dstCapacitySeed, 0, 4 * size);
+
     size_t const smallDictSize = size + 1;
     size_t const largeDictSize = 64 * 1024 - 1;
     size_t const dictSize = MAX(smallDictSize, largeDictSize);
@@ -26,9 +28,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     char* const largeDict = dict;
     char* const dataAfterDict = dict + dictSize;
     char* const smallDict = dataAfterDict - smallDictSize;
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(dict);

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -17,7 +17,7 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) 
 
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer) { free(producer); }
 
-uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
+uint32_t FUZZ_dataProducer_uint32_seed(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max) {
   FUZZ_ASSERT(min <= max);
 
@@ -32,24 +32,36 @@ uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
     rolling >>= 8;
   }
 
-  if (range == 0xffffffff) {
-    return result;
-  }
+  return result;
+}
 
-  return min + result % (range + 1);
+uint32_t FUZZ_dataProducer_uint32(uint32_t seed, uint32_t min, uint32_t max)
+{
+    uint32_t range = max - min;
+    if (range == 0xffffffff) {
+      return seed;
+    }
+    return min + seed % (range + 1);
+}
+
+uint32_t FUZZ_dataProducer_uint32NonAdaptive(FUZZ_dataProducer_t* producer,
+    uint32_t min, uint32_t max)
+{
+    size_t const seed = FUZZ_dataProducer_uint32_seed(producer, min, max);
+    return FUZZ_dataProducer_uint32(seed, min, max);
 }
 
 LZ4F_frameInfo_t FUZZ_dataProducer_frameInfo(FUZZ_dataProducer_t* producer)
 {
     LZ4F_frameInfo_t info = LZ4F_INIT_FRAMEINFO;
-    info.blockSizeID = FUZZ_dataProducer_uint32(producer, LZ4F_max64KB - 1, LZ4F_max4MB);
+    info.blockSizeID = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_max64KB - 1, LZ4F_max4MB);
     if (info.blockSizeID < LZ4F_max64KB) {
         info.blockSizeID = LZ4F_default;
     }
-    info.blockMode = FUZZ_dataProducer_uint32(producer, LZ4F_blockLinked, LZ4F_blockIndependent);
-    info.contentChecksumFlag = FUZZ_dataProducer_uint32(producer, LZ4F_noContentChecksum,
+    info.blockMode = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_blockLinked, LZ4F_blockIndependent);
+    info.contentChecksumFlag = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_noContentChecksum,
                                            LZ4F_contentChecksumEnabled);
-    info.blockChecksumFlag = FUZZ_dataProducer_uint32(producer, LZ4F_noBlockChecksum,
+    info.blockChecksumFlag = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_noBlockChecksum,
                                          LZ4F_blockChecksumEnabled);
     return info;
 }
@@ -58,9 +70,9 @@ LZ4F_preferences_t FUZZ_dataProducer_preferences(FUZZ_dataProducer_t* producer)
 {
     LZ4F_preferences_t prefs = LZ4F_INIT_PREFERENCES;
     prefs.frameInfo = FUZZ_dataProducer_frameInfo(producer);
-    prefs.compressionLevel = FUZZ_dataProducer_uint32(producer, 0, LZ4HC_CLEVEL_MAX + 3) - 3;
-    prefs.autoFlush = FUZZ_dataProducer_uint32(producer, 0, 1);
-    prefs.favorDecSpeed = FUZZ_dataProducer_uint32(producer, 0, 1);
+    prefs.compressionLevel = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, LZ4HC_CLEVEL_MAX + 3) - 3;
+    prefs.autoFlush = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, 1);
+    prefs.favorDecSpeed = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, 1);
     return prefs;
 }
 

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -17,7 +17,7 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size) 
 
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer) { free(producer); }
 
-uint32_t FUZZ_dataProducer_uint32_seed(FUZZ_dataProducer_t *producer, uint32_t min,
+uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max) {
   FUZZ_ASSERT(min <= max);
 
@@ -35,7 +35,7 @@ uint32_t FUZZ_dataProducer_uint32_seed(FUZZ_dataProducer_t *producer, uint32_t m
   return result;
 }
 
-uint32_t FUZZ_dataProducer_uint32(uint32_t seed, uint32_t min, uint32_t max)
+uint32_t FUZZ_getRange_from_uint32(uint32_t seed, uint32_t min, uint32_t max)
 {
     uint32_t range = max - min;
     if (range == 0xffffffff) {
@@ -44,24 +44,24 @@ uint32_t FUZZ_dataProducer_uint32(uint32_t seed, uint32_t min, uint32_t max)
     return min + seed % (range + 1);
 }
 
-uint32_t FUZZ_dataProducer_uint32NonAdaptive(FUZZ_dataProducer_t* producer,
+uint32_t FUZZ_dataProducer_range32(FUZZ_dataProducer_t* producer,
     uint32_t min, uint32_t max)
 {
-    size_t const seed = FUZZ_dataProducer_uint32_seed(producer, min, max);
-    return FUZZ_dataProducer_uint32(seed, min, max);
+    size_t const seed = FUZZ_dataProducer_uint32(producer, min, max);
+    return FUZZ_getRange_from_uint32(seed, min, max);
 }
 
 LZ4F_frameInfo_t FUZZ_dataProducer_frameInfo(FUZZ_dataProducer_t* producer)
 {
     LZ4F_frameInfo_t info = LZ4F_INIT_FRAMEINFO;
-    info.blockSizeID = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_max64KB - 1, LZ4F_max4MB);
+    info.blockSizeID = FUZZ_dataProducer_range32(producer, LZ4F_max64KB - 1, LZ4F_max4MB);
     if (info.blockSizeID < LZ4F_max64KB) {
         info.blockSizeID = LZ4F_default;
     }
-    info.blockMode = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_blockLinked, LZ4F_blockIndependent);
-    info.contentChecksumFlag = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_noContentChecksum,
+    info.blockMode = FUZZ_dataProducer_range32(producer, LZ4F_blockLinked, LZ4F_blockIndependent);
+    info.contentChecksumFlag = FUZZ_dataProducer_range32(producer, LZ4F_noContentChecksum,
                                            LZ4F_contentChecksumEnabled);
-    info.blockChecksumFlag = FUZZ_dataProducer_uint32NonAdaptive(producer, LZ4F_noBlockChecksum,
+    info.blockChecksumFlag = FUZZ_dataProducer_range32(producer, LZ4F_noBlockChecksum,
                                          LZ4F_blockChecksumEnabled);
     return info;
 }
@@ -70,9 +70,9 @@ LZ4F_preferences_t FUZZ_dataProducer_preferences(FUZZ_dataProducer_t* producer)
 {
     LZ4F_preferences_t prefs = LZ4F_INIT_PREFERENCES;
     prefs.frameInfo = FUZZ_dataProducer_frameInfo(producer);
-    prefs.compressionLevel = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, LZ4HC_CLEVEL_MAX + 3) - 3;
-    prefs.autoFlush = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, 1);
-    prefs.favorDecSpeed = FUZZ_dataProducer_uint32NonAdaptive(producer, 0, 1);
+    prefs.compressionLevel = FUZZ_dataProducer_range32(producer, 0, LZ4HC_CLEVEL_MAX + 3) - 3;
+    prefs.autoFlush = FUZZ_dataProducer_range32(producer, 0, 1);
+    prefs.favorDecSpeed = FUZZ_dataProducer_range32(producer, 0, 1);
     return prefs;
 }
 

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -16,8 +16,15 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 /* Frees the data producer */
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
+/* Returns a seed value for the function after this one to consume */
+uint32_t FUZZ_dataProducer_uint32_seed(FUZZ_dataProducer_t *producer, uint32_t min,
+                                  uint32_t max);
+
 /* Returns value between [min, max] */
-uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
+uint32_t FUZZ_dataProducer_uint32(uint32_t seed, uint32_t min, uint32_t max);
+
+/* Combination of above two functions for non adaptive use cases. ie where size is not involved */
+uint32_t FUZZ_dataProducer_uint32NonAdaptive(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max);
 
 /* Returns lz4 preferences */

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -16,9 +16,8 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 /* Frees the data producer */
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
-/* Returns a seed value for the function after this one to consume */
-uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
-                                  uint32_t max);
+/* Returns 32 bits from the end of data */
+uint32_t FUZZ_dataProducer_retrieve32(FUZZ_dataProducer_t *producer);
 
 /* Returns value between [min, max] */
 uint32_t FUZZ_getRange_from_uint32(uint32_t seed, uint32_t min, uint32_t max);

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -17,14 +17,14 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
 /* Returns a seed value for the function after this one to consume */
-uint32_t FUZZ_dataProducer_uint32_seed(FUZZ_dataProducer_t *producer, uint32_t min,
+uint32_t FUZZ_dataProducer_uint32(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max);
 
 /* Returns value between [min, max] */
-uint32_t FUZZ_dataProducer_uint32(uint32_t seed, uint32_t min, uint32_t max);
+uint32_t FUZZ_getRange_from_uint32(uint32_t seed, uint32_t min, uint32_t max);
 
 /* Combination of above two functions for non adaptive use cases. ie where size is not involved */
-uint32_t FUZZ_dataProducer_uint32NonAdaptive(FUZZ_dataProducer_t *producer, uint32_t min,
+uint32_t FUZZ_dataProducer_range32(FUZZ_dataProducer_t *producer, uint32_t min,
                                   uint32_t max);
 
 /* Returns lz4 preferences */

--- a/ossfuzz/round_trip_frame_fuzzer.c
+++ b/ossfuzz/round_trip_frame_fuzzer.c
@@ -16,11 +16,12 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
+    FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, size);
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-    size_t const dstCapacity = LZ4F_compressFrameBound(size, &prefs);
+    size_t const dstCapacity = LZ4F_compressFrameBound(
+        LZ4_compressBound(FUZZ_dataProducer_remainingBytes(producer)), &prefs);
     char* const dst = (char*)malloc(dstCapacity);
-    char* const rt = (char*)malloc(size);
+    char* const rt = (char*)malloc(FUZZ_dataProducer_remainingBytes(producer));
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/round_trip_frame_fuzzer.c
+++ b/ossfuzz/round_trip_frame_fuzzer.c
@@ -18,10 +18,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, size);
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-
     size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const dstCapacity = LZ4F_compressFrameBound(LZ4_compressBound(size), &prefs);
 
+    size_t const dstCapacity = LZ4F_compressFrameBound(LZ4_compressBound(size), &prefs);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(FUZZ_dataProducer_remainingBytes(producer));
 

--- a/ossfuzz/round_trip_frame_fuzzer.c
+++ b/ossfuzz/round_trip_frame_fuzzer.c
@@ -18,16 +18,15 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, size);
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
-    size_t const dstCapacity = LZ4F_compressFrameBound(
-        LZ4_compressBound(FUZZ_dataProducer_remainingBytes(producer)), &prefs);
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = LZ4F_compressFrameBound(LZ4_compressBound(size), &prefs);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(FUZZ_dataProducer_remainingBytes(producer));
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     /* Compression must succeed and round trip correctly. */
     size_t const dstSize =

--- a/ossfuzz/round_trip_fuzzer.c
+++ b/ossfuzz/round_trip_fuzzer.c
@@ -15,11 +15,10 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const partialCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, size);
-
+    size_t const partialCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const partialCapacity = FUZZ_getRange_from_uint32(partialCapacitySeed,
-        0, size);
+
+    size_t const partialCapacity = FUZZ_getRange_from_uint32(partialCapacitySeed, 0, size);
     size_t const dstCapacity = LZ4_compressBound(size);
 
     char* const dst = (char*)malloc(dstCapacity);

--- a/ossfuzz/round_trip_fuzzer.c
+++ b/ossfuzz/round_trip_fuzzer.c
@@ -15,7 +15,9 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const partialCapacity = FUZZ_dataProducer_uint32(producer, 0, size);
+    size_t const partialCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, size);
+    size_t const partialCapacity = FUZZ_dataProducer_uint32(partialCapacitySeed,
+        0, FUZZ_dataProducer_remainingBytes(producer));
     size_t const dstCapacity = LZ4_compressBound(size);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);

--- a/ossfuzz/round_trip_fuzzer.c
+++ b/ossfuzz/round_trip_fuzzer.c
@@ -15,18 +15,18 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const partialCapacitySeed = FUZZ_dataProducer_uint32_seed(producer, 0, size);
-    size_t const partialCapacity = FUZZ_dataProducer_uint32(partialCapacitySeed,
-        0, FUZZ_dataProducer_remainingBytes(producer));
+    size_t const partialCapacitySeed = FUZZ_dataProducer_uint32(producer, 0, size);
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const partialCapacity = FUZZ_getRange_from_uint32(partialCapacitySeed,
+        0, size);
     size_t const dstCapacity = LZ4_compressBound(size);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     /* Compression must succeed and round trip correctly. */
     int const dstSize = LZ4_compress_default((const char*)data, dst,

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -16,15 +16,14 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    int const level = FUZZ_dataProducer_uint32NonAdaptive(producer,
+    int const level = FUZZ_dataProducer_range32(producer,
         LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
-    size_t const dstCapacity = LZ4_compressBound(
-        FUZZ_dataProducer_remainingBytes(producer));
+
+    size = FUZZ_dataProducer_remainingBytes(producer);
+    size_t const dstCapacity = LZ4_compressBound(size);
+
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-
-    /* Restrict to remaining data from producer */
-    size = FUZZ_dataProducer_remainingBytes(producer);
 
     FUZZ_ASSERT(dst);
     FUZZ_ASSERT(rt);

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -16,11 +16,12 @@
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
-    size_t const dstCapacity = LZ4_compressBound(size);
+    int const level = FUZZ_dataProducer_uint32NonAdaptive(producer,
+        LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
+    size_t const dstCapacity = LZ4_compressBound(
+        FUZZ_dataProducer_remainingBytes(producer));
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
-    int const level = FUZZ_dataProducer_uint32(
-      producer, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 
     /* Restrict to remaining data from producer */
     size = FUZZ_dataProducer_remainingBytes(producer);

--- a/ossfuzz/round_trip_hc_fuzzer.c
+++ b/ossfuzz/round_trip_hc_fuzzer.c
@@ -18,10 +18,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
     int const level = FUZZ_dataProducer_range32(producer,
         LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
-
     size = FUZZ_dataProducer_remainingBytes(producer);
-    size_t const dstCapacity = LZ4_compressBound(size);
 
+    size_t const dstCapacity = LZ4_compressBound(size);
     char* const dst = (char*)malloc(dstCapacity);
     char* const rt = (char*)malloc(size);
 


### PR DESCRIPTION
The problem: The data producer was used to generate values for buffer sizes. But the data producer also consumes bytes from the data stream, making it smaller. This isn't an issue when values less than the original size are produced but this isn't always the case. 

Solution: Instead of using the value from the producer directly, use that as a seed and then have a secondary function do the actual data generation within the correct range (for example between 0 and the truncated size).