### PR TITLE
Using size instead of LZ4_compressBound(size) <- causes heap overflow

### DIFF
--- a/ossfuzz/compress_frame_fuzzer.c
+++ b/ossfuzz/compress_frame_fuzzer.c
@@ -17,7 +17,7 @@
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
-    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, LZ4_compressBound(size));
+    FUZZ_dataProducer_t *producer = FUZZ_dataProducer_create(data, size);
     LZ4F_preferences_t const prefs = FUZZ_dataProducer_preferences(producer);
     size_t const dstCapacitySeed = FUZZ_dataProducer_retrieve32(producer);
     size = FUZZ_dataProducer_remainingBytes(producer);


### PR DESCRIPTION
Should be the cause of the build failure. Passing LZ4_compressBound(size) makes the data producer try and access things outside the data buffer. 