### PR TITLE
Replace obsolete postgres extension on github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@ They are not interoperable with LZ4 command line utility.
 <li><a href="https://olegdb.org/"				><img src="images/logo50/olegdb.png"	/><span> OlegDB</span></a></li>
 <li><a href="https://gemtalksystems.com/products/gs64/"		><img src="images/logo50/gemstone.png"	/><span> GemStone</span></a></li>
 <li><a href="https://www.percona.com/blog/2016/08/11/percona-server-mongodb-3-2-8-2-0-now-available/"> <img src="images/logo50/percona.png"	/><span> Percona</span></a></li>
-<li><a href="https://github.com/zilder/pg_lz4"		><img src="images/logo50/postgresql.png" /><span> PostgreSQL</span></a></li>
+<li><a href="https://github.com/adjust/pg_cryogen"		><img src="images/logo50/postgresql.png" /><span> PostgreSQL</span></a></li>
   </ul>
 </div>
 


### PR DESCRIPTION
Hi,

Sorry if this isn't the right place to bring this up. I've noticed that you mentioned one of my postgres extensions on your github pages, [pg_lz4](https://github.com/zilder/pg_lz4). I just wanted to say that this extension was implemented as a demo for the postgres patch that my colleague @ildus was working on and which unfortunately didn't make it into the postgres core. Therefore this extension is not useable with vanilla postgres. I see people keep coming from your page and then get confused because they can't build it.

As an alternative i can suggest you another extension i'm currently working on and which can actually be used with the latest postgres 12 release. This is an append-only compressed pluggable storage, [pg_cryogen](https://github.com/adjust/pg_cryogen). Here is a patch for your gh-pages index.html in case you consider it reasonable replacement.

Thanks!