### PR TITLE
Add aarch64, ppc64le, and s390x to Travis CI for Xenial targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,6 @@ matrix:
       script:
         - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 
-    - name: ASAN tests with fuzzer and frametest (s390x)
-      arch: s390x
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
-
     - name: Custom LZ4_DISTANCE_MAX (amd64)
       arch: amd64
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -274,20 +274,5 @@ matrix:
       script:
         - ./ossfuzz/travisoss.sh
 
-    - name: Compile OSS-Fuzz targets (arm64)
-      arch: arm64
-      script:
-        - ./ossfuzz/travisoss.sh
-
-    - name: Compile OSS-Fuzz targets (ppc64le)
-      arch: ppc64le
-      script:
-        - ./ossfuzz/travisoss.sh
-
-    - name: Compile OSS-Fuzz targets (s390x)
-      arch: s390x
-      script:
-        - ./ossfuzz/travisoss.sh
-
   allow_failures:
     - env: ALLOW_FAILURES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,51 @@ matrix:
       script:
         - make -C tests test-frametest test-fuzzer
 
-    - name: ASAN tests with fuzzer and frametest
+    - name: ASAN tests with fuzzer and frametest (amd64)
+      arch: amd64
       install:
         - sudo sysctl -w vm.mmap_min_addr=4096
       script:
         - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 
-    - name: Custom LZ4_DISTANCE_MAX
+    - name: ASAN tests with fuzzer and frametest (arm64)
+      arch: arm64
+      install:
+        - sudo sysctl -w vm.mmap_min_addr=4096
+      script:
+        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
+
+    - name: ASAN tests with fuzzer and frametest (ppc64le)
+      arch: ppc64le
+      install:
+        - sudo sysctl -w vm.mmap_min_addr=4096
+      script:
+        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
+
+    - name: ASAN tests with fuzzer and frametest (s390x)
+      arch: s390x
+      install:
+        - sudo sysctl -w vm.mmap_min_addr=4096
+      script:
+        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
+
+    - name: Custom LZ4_DISTANCE_MAX (amd64)
+      arch: amd64
+      script:
+        - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
+
+    - name: Custom LZ4_DISTANCE_MAX (arm64)
+      arch: arm64
+      script:
+        - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
+
+    - name: Custom LZ4_DISTANCE_MAX (ppc64le)
+      arch: ppc64le
+      script:
+        - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
+
+    - name: Custom LZ4_DISTANCE_MAX (s390x)
+      arch: s390x
       script:
         - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
 
@@ -108,7 +146,7 @@ matrix:
         - make c_standards
         - make -C tests test-lz4 MOREFLAGS=-Werror
 
-    - name: (Trusty) arm + aarch64 compilation
+    - name: (Trusty) arm + arm64 compilation
       dist: trusty
       install:
         - sudo apt-get install -qq
@@ -116,16 +154,41 @@ matrix:
             qemu-user-static
             gcc-arm-linux-gnueabi
             libc6-dev-armel-cross
-            gcc-aarch64-linux-gnu
+            gcc-arm64-linux-gnu
             libc6-dev-arm64-cross
       script:
         - make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static
-        - make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static
+        - make platformTest CC=arm64-linux-gnu-gcc QEMU_SYS=qemu-arm64-static
 
-    - name: (Xenial) gcc-5 compilation
+    - name: (Xenial) gcc-5 compilation (amd64)
       dist: xenial
+      arch: amd64
       install:
         - sudo apt-get install -qq libc6-dev-i386 gcc-multilib
+      script:
+        - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
+
+    - name: (Xenial) gcc-5 compilation (arm64)
+      dist: xenial
+      arch: arm64
+      install:
+        - sudo apt-get install -qq gcc-multilib-arm-linux-gnueabihf
+      script:
+        - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
+
+    - name: (Xenial) gcc-5 compilation (ppc64le)
+      dist: xenial
+      arch: ppc64le
+      install:
+        - sudo apt-get install -qq libc6-dev-powerpc-ppc64-cross gcc-multilib-powerpc-linux-gnu
+      script:
+        - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
+
+    - name: (Xenial) gcc-5 compilation (s390x)
+      dist: xenial
+      arch: s390x
+      install:
+        - sudo apt-get install -qq libc6-dev-s390-s390x-cross gcc-multilib
       script:
         - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
 
@@ -184,6 +247,7 @@ matrix:
     - name: (Xenial) Meson + clang build
       #env: ALLOW_FAILURES=true
       dist: xenial
+      arch: amd64
       language: cpp
       compiler: clang
       install:
@@ -212,7 +276,23 @@ matrix:
         - tree ./staging
 
     # oss-fuzz compilation test
-    - name: Compile OSS-Fuzz targets
+    - name: Compile OSS-Fuzz targets (amd64)
+      arch: amd64
+      script:
+        - ./ossfuzz/travisoss.sh
+
+    - name: Compile OSS-Fuzz targets (arm64)
+      arch: arm64
+      script:
+        - ./ossfuzz/travisoss.sh
+
+    - name: Compile OSS-Fuzz targets (ppc64le)
+      arch: ppc64le
+      script:
+        - ./ossfuzz/travisoss.sh
+
+    - name: Compile OSS-Fuzz targets (s390x)
+      arch: s390x
       script:
         - ./ossfuzz/travisoss.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,6 @@ matrix:
       script:
         - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 
-    - name: ASAN tests with fuzzer and frametest (arm64)
-      arch: arm64
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
-
     - name: ASAN tests with fuzzer and frametest (ppc64le)
       arch: ppc64le
       install:


### PR DESCRIPTION
This PR allows testing on multiple architectures via Travis-CI.