### PR TITLE
Force inline small functions used by LZ4_compress_generic.

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -632,7 +632,7 @@ int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
 /*-******************************
 *  Compression functions
 ********************************/
-static U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
 {
     if (tableType == byU16)
         return ((sequence * 2654435761U) >> ((MINMATCH*8)-(LZ4_HASHLOG+1)));
@@ -640,7 +640,7 @@ static U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
         return ((sequence * 2654435761U) >> ((MINMATCH*8)-LZ4_HASHLOG));
 }
 
-static U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
 {
     const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
     if (LZ4_isLittleEndian()) {
@@ -658,7 +658,7 @@ LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tab
     return LZ4_hash4(LZ4_read32(p), tableType);
 }
 
-static void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
 {
     switch (tableType)
     {
@@ -670,7 +670,7 @@ static void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
     }
 }
 
-static void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
 {
     switch (tableType)
     {
@@ -682,7 +682,7 @@ static void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t cons
     }
 }
 
-static void LZ4_putPositionOnHash(const BYTE* p, U32 h,
+LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h,
                                   void* tableBase, tableType_t const tableType,
                             const BYTE* srcBase)
 {
@@ -707,7 +707,7 @@ LZ4_FORCE_INLINE void LZ4_putPosition(const BYTE* p, void* tableBase, tableType_
  * Assumption 1 : only valid if tableType == byU32 or byU16.
  * Assumption 2 : h is presumed valid (within limits of hash table)
  */
-static U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_t tableType)
+LZ4_FORCE_INLINE U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_t tableType)
 {
     LZ4_STATIC_ASSERT(LZ4_MEMORY_USAGE > 2);
     if (tableType == byU32) {


### PR DESCRIPTION
This change fixes compiler misjudgement on whether small functions should be inlined into `LZ4_compress_generic`. Since `LZ4_compress_generic` is a big function and it is force inlined, the compiler heuristics prevent inlining of small functions, which results in excessive code size.

For example, `LZ4_getIndexOnHash` is compiled by MSVC 2019 as:
```
00007FF6739A58A0  mov         eax,ecx  
00007FF6739A58A2  mov         eax,dword ptr [rdx+rax*4]  
00007FF6739A58A5  ret
```

With the following call site in `LZ4_compress_generic`:
```
; pass tableType, even though it is unused
00007FF6739A62A3  mov         r8d,2
; store h on stack, as it is later used in the function, but may be changed during the call
00007FF6739A62A9  mov         dword ptr [rsp+0F0h],ecx
...
00007FF6739A62B6  call        tracy::LZ4_getIndexOnHash (07FF6739A58A0h)  
```

With the proposed changes the entire `LZ4_getIndexOnHash` call is compiled as:
```
00007FF7809F5048  mov         ecx,dword ptr [r9+rdx*4]
```

This has the following effect on compression speed:

Ryzen 3900X @3.8GHz (turbo disabled):

```
 dickens :
Compression functions :
 1-LZ4_compress_default            :  10192446 ->  6431106 (63.10%),  347.0 MB/s -> 358.6 MB/s
 2-LZ4_compress_default(small dst) :  10192446 ->  6431106 (63.10%),  334.6 MB/s -> 366.2 MB/s
 3-LZ4_compress_destSize           :  10192446 ->  6431106 (63.10%),  331.9 MB/s -> 359.4 MB/s
 4-LZ4_compress_fast(0)            :  10192446 ->  6431106 (63.10%),  345.7 MB/s -> 363.2 MB/s
 5-LZ4_compress_fast(1)            :  10192446 ->  6431106 (63.10%),  346.4 MB/s -> 364.9 MB/s
 6-LZ4_compress_fast(2)            :  10192446 ->  6763934 (66.36%),  380.2 MB/s -> 412.9 MB/s
 7-LZ4_compress_fast(17)           :  10192446 ->  9222511 (90.48%),  990.8 MB/s -> 1053.8 MB/s
 8-LZ4_compress_fast_extState(0)   :  10192446 ->  6431106 (63.10%),  385.0 MB/s -> 382.3 MB/s
 9-LZ4_compress_fast_continue(0)   :  10192446 ->  6428753 (63.07%),  366.2 MB/s -> 363.6 MB/s
10-LZ4_compress_HC                 :  10192446 ->  4441354 (43.57%),   20.1 MB/s -> 20.2 MB/s
12-LZ4_compress_HC_extStateHC      :  10192446 ->  4441354 (43.57%),   20.1 MB/s -> 20.1 MB/s
14-LZ4_compress_HC_continue        :  10192446 ->  4432831 (43.49%),   20.0 MB/s -> 20.0 MB/s
20-LZ4_compress_forceDict          :  10192446 ->  6428753 (63.07%),  356.8 MB/s -> 336.6 MB/s
```

```
 ooffice :
Compression functions :
 1-LZ4_compress_default            :   6152192 ->  4339312 (70.53%),  486.5 MB/s -> 498.6 MB/s
 2-LZ4_compress_default(small dst) :   6152192 ->  4339312 (70.53%),  470.0 MB/s -> 488.7 MB/s
 3-LZ4_compress_destSize           :   6152192 ->  4339312 (70.53%),  450.6 MB/s -> 471.7 MB/s
 4-LZ4_compress_fast(0)            :   6152192 ->  4339312 (70.53%),  484.8 MB/s -> 498.6 MB/s
 5-LZ4_compress_fast(1)            :   6152192 ->  4339312 (70.53%),  486.7 MB/s -> 498.4 MB/s
 6-LZ4_compress_fast(2)            :   6152192 ->  4552666 (74.00%),  608.1 MB/s -> 621.6 MB/s
 7-LZ4_compress_fast(17)           :   6152192 ->  5531363 (89.91%), 1619.8 MB/s -> 1648.1 MB/s
 8-LZ4_compress_fast_extState(0)   :   6152192 ->  4339312 (70.53%),  501.6 MB/s -> 485.1 MB/s
 9-LZ4_compress_fast_continue(0)   :   6152192 ->  4338923 (70.53%),  458.2 MB/s -> 456.6 MB/s
10-LZ4_compress_HC                 :   6152192 ->  3546025 (57.64%),   35.9 MB/s -> 35.7 MB/s
12-LZ4_compress_HC_extStateHC      :   6152192 ->  3546025 (57.64%),   35.6 MB/s -> 35.7 MB/s
14-LZ4_compress_HC_continue        :   6152192 ->  3543767 (57.60%),   35.6 MB/s -> 35.6 MB/s
20-LZ4_compress_forceDict          :   6152192 ->  4338923 (70.53%),  471.0 MB/s -> 456.3 MB/s
```

Odroid C2 (ARM64):

```
 ooffice :
Compression functions :
 1-LZ4_compress_default            :   6152192 ->  4339312 (70.53%),   68.2 MB/s -> 68.9 MB/s
 2-LZ4_compress_default(small dst) :   6152192 ->  4339312 (70.53%),   67.1 MB/s -> 67.4 MB/s
 3-LZ4_compress_destSize           :   6152192 ->  4339312 (70.53%),   57.2 MB/s -> 57.5 MB/s
 4-LZ4_compress_fast(0)            :   6152192 ->  4339312 (70.53%),   68.2 MB/s -> 68.9 MB/s
 5-LZ4_compress_fast(1)            :   6152192 ->  4339312 (70.53%),   68.2 MB/s -> 68.9 MB/s
 6-LZ4_compress_fast(2)            :   6152192 ->  4552666 (74.00%),   83.1 MB/s -> 83.8 MB/s
 7-LZ4_compress_fast(17)           :   6152192 ->  5531363 (89.91%),  283.2 MB/s -> 284.2 MB/s
 8-LZ4_compress_fast_extState(0)   :   6152192 ->  4339312 (70.53%),   63.8 MB/s -> 70.2 MB/s
 9-LZ4_compress_fast_continue(0)   :   6152192 ->  4338923 (70.53%),   58.2 MB/s -> 63.0 MB/s
10-LZ4_compress_HC                 :   6152192 ->  3546025 (57.64%),    7.1 MB/s -> 7.0 MB/s
12-LZ4_compress_HC_extStateHC      :   6152192 ->  3546025 (57.64%),    7.1 MB/s -> 7.1 MB/s
14-LZ4_compress_HC_continue        :   6152192 ->  3543767 (57.60%),    7.1 MB/s -> 7.1 MB/s
20-LZ4_compress_forceDict          :   6152192 ->  4338923 (70.53%),   58.6 MB/s -> 63.1 MB/s
```