### PR TITLE
fix: allocate  LZ4HC_optimal_t opt on heap each time (#837)

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1290,7 +1290,7 @@ static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
     int retval = 0;
 #define TRAILING_LITERALS 3
 #ifdef LZ4HC_HEAPMODE
-    LZ4HC_optimal_t* opt = (LZ4HC_optimal_t*)malloc(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
+    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)malloc(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
 #else
     LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS];   /* ~64 KB, which is a bit large for stack... */
 #endif
@@ -1305,6 +1305,9 @@ static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
     BYTE* oend = op + dstCapacity;
 
     /* init */
+#ifdef LZ4HC_HEAPMODE
+    if (opt == NULL) goto _return_label;
+#endif
     DEBUGLOG(5, "LZ4HC_compress_optimal(dst=%p, dstCapa=%u)", dst, (unsigned)dstCapacity);
     *srcSizePtr = 0;
     if (limit == fillOutput) oend -= LASTLITERALS;   /* Hack for support LZ4 format restriction */


### PR DESCRIPTION
Also fixed #837 with one allocation in `stack_frame` branch.