### PR TITLE
Turning on fast dec for visual

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -374,7 +374,7 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 
 
 #ifndef LZ4_FAST_DEC_LOOP
-#  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
+#  if defined _MSC_VER || defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 #    define LZ4_FAST_DEC_LOOP 1
 #  elif defined(__aarch64__) && !defined(__clang__)
      /* On aarch64, we disable this optimization for clang because on certain


### PR DESCRIPTION
Benchmarked compression on Windows vm with ./lz4.exe -b1 -e9

Level 1: +3%
Level 2: +2% 
Level 3: +2% 
Level 4: +3%
Level 5: -1%
Level 6: +0%
Level 7: +6%
Level 8: +6%
Level 9: +5%