### PR TITLE
Fix lz4cli --list option

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -670,7 +670,7 @@ int main(int argc, const char** argv)
 
     /* No output filename ==> try to select one automatically (when possible) */
     while ((!output_filename) && (multiple_inputs==0)) {
-        if (!IS_CONSOLE(stdout)) {
+        if (!IS_CONSOLE(stdout) && mode != om_list) {
             /* Default to stdout whenever stdout is not the console.
              * Note : this policy may change in the future, therefore don't rely on it !
              * To ensure `stdout` is explicitly selected, use `-c` command flag.

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -90,6 +90,7 @@
 *  Macros
 **************************************/
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
+#define DISPLAYOUT(...)      fprintf(stdout, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
 static int g_displayLevel = 0;   /* 0 : no display  ; 1: errors  ; 2 : + result + interaction + warnings ; 3 : + progression; 4 : + information */
 
@@ -1561,7 +1562,7 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, size_t ifnIdx)
     int result = 0;
     size_t idx = 0;
     if (g_displayLevel < 3) {
-        DISPLAY("%10s %14s %5s %11s %13s %9s   %s\n",
+        DISPLAYOUT("%10s %14s %5s %11s %13s %9s   %s\n",
                 "Frames", "Type", "Block", "Compressed", "Uncompressed", "Ratio", "Filename");
     }
     for (; idx < ifnIdx; idx++) {
@@ -1586,7 +1587,7 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, size_t ifnIdx)
         if (g_displayLevel < 3) {
             /* Display Summary */
             {   char buffers[3][10];
-                DISPLAY("%10llu %14s %5s %11s %13s ",
+                DISPLAYOUT("%10llu %14s %5s %11s %13s ",
                         cfinfo.frameCount,
                         cfinfo.eqFrameTypes ? LZ4IO_frameTypeNames[cfinfo.frameSummary.frameType] : "-" ,
                         cfinfo.eqBlockTypes ? LZ4IO_blockTypeID(cfinfo.frameSummary.lz4FrameInfo.blockSizeID,
@@ -1595,9 +1596,9 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, size_t ifnIdx)
                         cfinfo.allContentSize ? LZ4IO_toHuman((long double)cfinfo.frameSummary.lz4FrameInfo.contentSize, buffers[2]) : "-");
                 if (cfinfo.allContentSize) {
                     double const ratio = (double)cfinfo.fileSize / cfinfo.frameSummary.lz4FrameInfo.contentSize * 100;
-                    DISPLAY("%9.2f%%  %s \n", ratio, cfinfo.fileName);
+                    DISPLAYOUT("%9.2f%%  %s \n", ratio, cfinfo.fileName);
                 } else {
-                    DISPLAY("%9s   %s\n",
+                    DISPLAYOUT("%9s   %s\n",
                             "-",
                             cfinfo.fileName);
                 }


### PR DESCRIPTION
Improvements:

Redirect lz4cli --list content to stdout.
Suppress warning message when option lz4cli is selected. 