### PR TITLE
Microoptimize decompression

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -287,12 +287,12 @@ static unsigned LZ4_isLittleEndian(void)
 #if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
 /* lie to the compiler about data alignment; use with caution */
 
-static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
-static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
-static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+LZ4_FORCE_INLINE U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
+LZ4_FORCE_INLINE U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
+LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
 
-static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
-static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
+LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
 
 #elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
 
@@ -300,36 +300,36 @@ static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
 /* currently only defined for gcc and icc */
 typedef union { U16 u16; U32 u32; reg_t uArch; } __attribute__((packed)) unalign;
 
-static U16 LZ4_read16(const void* ptr) { return ((const unalign*)ptr)->u16; }
-static U32 LZ4_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
-static reg_t LZ4_read_ARCH(const void* ptr) { return ((const unalign*)ptr)->uArch; }
+LZ4_FORCE_INLINE U16 LZ4_read16(const void* ptr) { return ((const unalign*)ptr)->u16; }
+LZ4_FORCE_INLINE U32 LZ4_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* ptr) { return ((const unalign*)ptr)->uArch; }
 
-static void LZ4_write16(void* memPtr, U16 value) { ((unalign*)memPtr)->u16 = value; }
-static void LZ4_write32(void* memPtr, U32 value) { ((unalign*)memPtr)->u32 = value; }
+LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value) { ((unalign*)memPtr)->u16 = value; }
+LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value) { ((unalign*)memPtr)->u32 = value; }
 
 #else  /* safe and portable access using memcpy() */
 
-static U16 LZ4_read16(const void* memPtr)
+LZ4_FORCE_INLINE U16 LZ4_read16(const void* memPtr)
 {
     U16 val; memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-static U32 LZ4_read32(const void* memPtr)
+LZ4_FORCE_INLINE U32 LZ4_read32(const void* memPtr)
 {
     U32 val; memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-static reg_t LZ4_read_ARCH(const void* memPtr)
+LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* memPtr)
 {
     reg_t val; memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-static void LZ4_write16(void* memPtr, U16 value)
+LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value)
 {
     memcpy(memPtr, &value, sizeof(value));
 }
 
-static void LZ4_write32(void* memPtr, U32 value)
+LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value)
 {
     memcpy(memPtr, &value, sizeof(value));
 }
@@ -337,7 +337,7 @@ static void LZ4_write32(void* memPtr, U32 value)
 #endif /* LZ4_FORCE_MEMORY_ACCESS */
 
 
-static U16 LZ4_readLE16(const void* memPtr)
+LZ4_FORCE_INLINE U16 LZ4_readLE16(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
         return LZ4_read16(memPtr);
@@ -347,7 +347,7 @@ static U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
-static void LZ4_writeLE16(void* memPtr, U16 value)
+LZ4_FORCE_INLINE void LZ4_writeLE16(void* memPtr, U16 value)
 {
     if (LZ4_isLittleEndian()) {
         LZ4_write16(memPtr, value);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -438,7 +438,7 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
 
     switch(offset) {
     case 1:
-        if(sizeof(void*) == 8) {
+        if(sizeof(reg_t) == 8) {
             u64 = *srcPtr * 0x0101010101010101;
             memcpy(v, &u64, 8);
         } else {
@@ -446,7 +446,7 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
         }
         break;
     case 2:
-        if(sizeof(void*) == 8) {
+        if(sizeof(reg_t) == 8) {
             memcpy(&u16, srcPtr, 2);
             u64 = u16 * 0x0001000100010001;
             memcpy(v, &u64, 8);
@@ -457,7 +457,7 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
         }
         break;
     case 4:
-        if(sizeof(void*) == 8) {
+        if(sizeof(reg_t) == 8) {
             memcpy(&u32, srcPtr, 4);
             u64 = u32 | (((U64)u32) << 32);
             memcpy(v, &u64, 8);


### PR DESCRIPTION
There are two changes here.

The first one just forces inlining of the read/write helpers, with similar results like in PR #826. In my use case it decreases data load time on MSVC from 10.38 s to 10.05 s.

The second change eliminates writes to the on-stack `v` variable, keeping everything in the registers. Since data size is 8 bytes, it is only enabled on 64-bit architectures, leaving the old implementation for 32-bit ones. In my use case I can't see an improvement from this change, but it exists, as discussed below.

`LZ4_memcpy_using_offset` in its original form (slightly outdated here, and omitting the call to `LZ4_memcpy_using_offset_base`) on MSVC is compiled as follows:

```
        sub     rsp, 8
; switch dispatch
        sub     r9, 1
        je      SHORT $LN6@LZ4_memcpy
        sub     r9, 1
        je      SHORT $LN10@LZ4_memcpy
        cmp     r9, 2
        jne     SHORT $LN5@LZ4_memcpy
; case 4
        mov     eax, DWORD PTR [rdx]
        mov     DWORD PTR v$[rsp], eax
        mov     DWORD PTR v$[rsp+4], eax
        jmp     SHORT $copy_loop$27
$LN10@LZ4_memcpy:
; case 2
        movzx   eax, WORD PTR [rdx]
        mov     WORD PTR v$[rsp], ax
        mov     WORD PTR v$[rsp+2], ax
        mov     eax, DWORD PTR v$[rsp]
        mov     DWORD PTR v$[rsp+4], eax
        jmp     SHORT $copy_loop$27
$LN6@LZ4_memcpy:
; case 1
        movzx   eax, BYTE PTR [rdx]
        mov     BYTE PTR v$[rsp], al
        mov     BYTE PTR v$[rsp+1], al
        mov     BYTE PTR v$[rsp+2], al
        mov     BYTE PTR v$[rsp+3], al
        mov     BYTE PTR v$[rsp+4], al
        mov     BYTE PTR v$[rsp+5], al
        mov     BYTE PTR v$[rsp+6], al
        mov     BYTE PTR v$[rsp+7], al
$copy_loop$27:
        mov     rax, QWORD PTR v$[rsp]
        xor     edx, edx
        mov     QWORD PTR [rcx], rax
        mov     QWORD PTR [rsp], rdi
        lea     rdi, QWORD PTR [rcx+8]
        mov     rcx, r8
        sub     rcx, rdi
        add     rcx, 7
        shr     rcx, 3
        cmp     rdi, r8
        cmova   rcx, rdx
        test    rcx, rcx
        je      SHORT $LN24@LZ4_memcpy
        rep stosq
$LN24@LZ4_memcpy:
        mov     rdi, QWORD PTR [rsp]
$LN5@LZ4_memcpy:
        add     rsp, 8
        ret     0
```

As can be seen, the `v` variable is composed in-memory depending on the `offset` value, then it is read from memory to be used in the `copy_loop`. The improved version looks as follows:

```
        sub     rsp, 8
        sub     r9, 1
        je      SHORT $LN6@LZ4_memcpy
        sub     r9, 1
        je      SHORT $LN10@LZ4_memcpy
        cmp     r9, 2
        jne     SHORT $LN5@LZ4_memcpy
; case 4
        mov     edx, DWORD PTR [rdx]
        mov     eax, edx
        shl     rax, 32                             ; 00000020H
        or      rax, rdx
        jmp     SHORT $copy_loop$28
$LN10@LZ4_memcpy:
; case 2
        movzx   eax, WORD PTR [rdx]
        mov     rdx, 281479271743489                  ; 0001000100010001H
        jmp     SHORT $LN25@LZ4_memcpy
$LN6@LZ4_memcpy:
; case 1
        movzx   eax, BYTE PTR [rdx]
        mov     rdx, 72340172838076673                    ; 0101010101010101H
$LN25@LZ4_memcpy:
        imul    rax, rdx
$copy_loop$28:
        mov     QWORD PTR [rcx], rax
        xor     edx, edx
        mov     QWORD PTR [rsp], rdi
        lea     rdi, QWORD PTR [rcx+8]
        mov     rcx, r8
        sub     rcx, rdi
        add     rcx, 7
        shr     rcx, 3
        cmp     rdi, r8
        cmova   rcx, rdx
        test    rcx, rcx
        je      SHORT $LN24@LZ4_memcpy
        rep stosq
$LN24@LZ4_memcpy:
        mov     rdi, QWORD PTR [rsp]
$LN5@LZ4_memcpy:
        add     rsp, 8
        ret     0
```

Here everything is performed in the `eax` register.

Clang and gcc are trying to perform this optimization, but fail to do it completely, as seen here in the original code disassembly:

```
; gcc case 1
        movzx   eax, BYTE PTR [rsi]
        movabs  rcx, 72340172838076673
        imul    rax, rcx
        mov     QWORD PTR [rsp-32], rax

; gcc case 2
        movzx   eax, WORD PTR [rsi]
        mov     WORD PTR [rsp-32], ax
        mov     WORD PTR [rsp-30], ax
        mov     eax, DWORD PTR [rsp-32]
        mov     DWORD PTR [rsp-28], eax

; clang case 1
        movzx   eax, byte ptr [rsi]
        imul    eax, eax, 16843009

; clang case 2
        movzx   ecx, word ptr [rsi]
        mov     eax, ecx
        shl     eax, 16
        or      eax, ecx
```

Gcc is unable to optimize `offset=2` case and is always writing `v` to memory. Clang notices that upper half of `v` is always identical to the lower half and issues two 4-byte writes. The improved version of the code compiles on gcc as follows (clang looks very similar):

```
; case 1
        movzx   r8d, BYTE PTR [rsi]
        movabs  rax, 72340172838076673
        imul    r8, rax

; case 2
        movzx   r8d, WORD PTR [rsi]
        movabs  rax, 281479271743489
        imul    r8, rax

; case 4
        mov     eax, DWORD PTR [rsi]
        mov     r8, rax
        sal     r8, 32
        or      r8, rax
```

It should be noted however, that clang goes a bit crazy with `copy_loop` unroll:

```
        vmovdqu ymmword ptr [rsi + 8*rax - 992], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 960], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 928], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 896], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 864], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 832], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 800], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 768], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 736], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 704], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 672], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 640], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 608], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 576], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 544], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 512], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 480], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 448], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 416], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 384], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 352], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 320], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 288], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 256], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 224], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 192], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 160], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 128], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 96], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 64], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax - 32], ymm0
        vmovdqu ymmword ptr [rsi + 8*rax], ymm0
```

As for benchmarks, running `fullbench` compiled with MSVC on Ryzen gives me just noise:

```
*** LZ4 speed analyzer v1.9.2 64-bits, by Yann Collet ***
 dickens :
Decompression functions :
 1-LZ4_decompress_fast                :  10192446 ->  3102.6 MB/s -> 3118.9 MB/s -> 3114.8
 2-LZ4_decompress_fast_usingDict(pref :  10192446 ->  3118.9 MB/s -> 3118.9 MB/s -> 3114.8
 3-LZ4_decompress_fast_using(Ext)Dict :  10192446 ->  3008.8 MB/s -> 3041.4 MB/s -> 3012.9
 4-LZ4_decompress_safe                :  10192446 ->  3477.7 MB/s -> 3457.3 MB/s -> 3453.2
 6-LZ4_decompress_safe_usingDict      :  10192446 ->  3257.5 MB/s -> 3245.3 MB/s -> 3326.8
 7-LZ4_decompress_safe_partial        :  10192446 ->  3648.9 MB/s -> 3640.7 MB/s -> 3640.7
 8-LZ4_decompress_safe_forceExtDict   :  10192446 ->  3457.3 MB/s -> 3465.4 MB/s -> 3473.6
10-LZ4F_decompress                    :  10192446 ->  3257.5 MB/s -> 3241.2 MB/s -> 3330.9
11-LZ4F_decompress_followHint         :  10192446 ->  1973.3 MB/s -> 2001.8 MB/s -> 1977.3

 ooffice :
Decompression functions :
 1-LZ4_decompress_fast                :   6152192 ->  2581.5 MB/s -> 2583.9 MB/s -> 2566.7
 2-LZ4_decompress_fast_usingDict(pref :   6152192 ->  2581.5 MB/s -> 2569.2 MB/s -> 2583.9
 3-LZ4_decompress_fast_using(Ext)Dict :   6152192 ->  2542.1 MB/s -> 2571.6 MB/s -> 2539.6
 4-LZ4_decompress_safe                :   6152192 ->  3300.0 MB/s -> 3277.9 MB/s -> 3275.4
 6-LZ4_decompress_safe_usingDict      :   6152192 ->  3157.3 MB/s -> 3181.9 MB/s -> 3108.1
 7-LZ4_decompress_safe_partial        :   6152192 ->  3231.1 MB/s -> 3250.8 MB/s -> 3213.9
 8-LZ4_decompress_safe_forceExtDict   :   6152192 ->  3248.4 MB/s -> 3236.3 MB/s -> 3258.2
10-LZ4F_decompress                    :   6152192 ->  3157.3 MB/s -> 3113.0 MB/s -> 3068.7
11-LZ4F_decompress_followHint         :   6152192 ->  2598.7 MB/s -> 2591.3 MB/s -> 2591.3
```

It is very frustrating, especially when you remember that in real world use case I do see an improvement.

More reliable results can be obtained by running `fullbench` compiled with gcc on ARM64:

```
*** LZ4 speed analyzer v1.9.2 64-bits, by Yann Collet ***
 dickens :
Decompression functions :
 1-LZ4_decompress_fast                :  10192446 ->   388.2 MB/s -> 388.0 MB/s -> 388.3 MB/s
 2-LZ4_decompress_fast_usingDict(pref :  10192446 ->   388.1 MB/s -> 387.9 MB/s -> 388.4 MB/s
 3-LZ4_decompress_fast_using(Ext)Dict :  10192446 ->   374.7 MB/s -> 374.5 MB/s -> 374.9 MB/s
 4-LZ4_decompress_safe                :  10192446 ->   357.8 MB/s -> 357.5 MB/s -> 358.1 MB/s
 6-LZ4_decompress_safe_usingDict      :  10192446 ->   365.0 MB/s -> 364.8 MB/s -> 365.3 MB/s
 7-LZ4_decompress_safe_partial        :  10192446 ->   379.6 MB/s -> 379.4 MB/s -> 365.7 MB/s
 8-LZ4_decompress_safe_forceExtDict   :  10192446 ->   363.8 MB/s -> 363.7 MB/s -> 364.1 MB/s
10-LZ4F_decompress                    :  10192446 ->   363.8 MB/s -> 363.6 MB/s -> 364.3 MB/s
11-LZ4F_decompress_followHint         :  10192446 ->   322.1 MB/s -> 321.8 MB/s -> 321.9 MB/s

 ooffice :
Decompression functions :
 1-LZ4_decompress_fast                :   6152192 ->   477.8 MB/s -> 478.1 MB/s -> 481.3 MB/s
 2-LZ4_decompress_fast_usingDict(pref :   6152192 ->   477.8 MB/s -> 478.0 MB/s -> 481.3 MB/s
 3-LZ4_decompress_fast_using(Ext)Dict :   6152192 ->   468.2 MB/s -> 468.4 MB/s -> 471.9 MB/s
 4-LZ4_decompress_safe                :   6152192 ->   471.3 MB/s -> 471.8 MB/s -> 476.5 MB/s
 6-LZ4_decompress_safe_usingDict      :   6152192 ->   475.9 MB/s -> 476.4 MB/s -> 480.9 MB/s
 7-LZ4_decompress_safe_partial        :   6152192 ->   484.8 MB/s -> 485.3 MB/s -> 480.9 MB/s
 8-LZ4_decompress_safe_forceExtDict   :   6152192 ->   471.8 MB/s -> 472.1 MB/s -> 475.6 MB/s
10-LZ4F_decompress                    :   6152192 ->   474.8 MB/s -> 474.8 MB/s -> 479.1 MB/s
11-LZ4F_decompress_followHint         :   6152192 ->   430.7 MB/s -> 431.0 MB/s -> 433.2 MB/s
```

Here things get interesting. The first change provides a small, but consistent perf hit on `dickens`, but a similarly small perf gain on `ooffice`. The second change gives a small perf gain on `dickens` and a more sizeable gain on `ooffice` in all tests but `LZ4_decompress_safe_partial`, which is a consistent perf loss.