### PR TITLE
Add some functionality to contrib cmake_unofficial

### DIFF
--- a/contrib/cmake_unofficial/CMakeLists.txt
+++ b/contrib/cmake_unofficial/CMakeLists.txt
@@ -170,14 +170,17 @@ endforeach (flag)
 
 if(NOT LZ4_BUNDLED_MODE)
   include(GNUInstallDirs)
+  set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 
   install(TARGETS ${LZ4_PROGRAMS_BUILT}
     BUNDLE	DESTINATION "${CMAKE_INSTALL_BINDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
   install(TARGETS ${LZ4_LIBRARIES_BUILT}
+    EXPORT "${TARGETS_EXPORT_NAME}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
   install(FILES
     "${LZ4_LIB_SOURCE_DIR}/lz4.h"
     "${LZ4_LIB_SOURCE_DIR}/lz4frame.h"
@@ -187,6 +190,13 @@ if(NOT LZ4_BUNDLED_MODE)
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblz4.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+  install(EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${PROJECT_NAME}::"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
   # install lz4cat and unlz4 symlinks on *nix
   if(UNIX)
@@ -226,3 +236,16 @@ endif()
 # for liblz4.pc substitution
 set(VERSION ${LZ4_VERSION_STRING})
 configure_file(${LZ4_LIB_SOURCE_DIR}/liblz4.pc.in liblz4.pc @ONLY)
+
+# cmake package
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+  "Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+)

--- a/contrib/cmake_unofficial/CMakeLists.txt
+++ b/contrib/cmake_unofficial/CMakeLists.txt
@@ -168,13 +168,17 @@ foreach (flag
   unset(flag_to_test)
 endforeach (flag)
 
+option(LZ4_INSTALL_BINARIES "Install binaries as well as libraries and headers (if applicable)" ON)
+
 if(NOT LZ4_BUNDLED_MODE)
   include(GNUInstallDirs)
   set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 
-  install(TARGETS ${LZ4_PROGRAMS_BUILT}
-    BUNDLE	DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  if(LZ4_INSTALL_BINARIES)
+    install(TARGETS ${LZ4_PROGRAMS_BUILT}
+      BUNDLE	DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  endif(LZ4_INSTALL_BINARIES)
   install(TARGETS ${LZ4_LIBRARIES_BUILT}
     EXPORT "${TARGETS_EXPORT_NAME}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
@@ -186,8 +190,10 @@ if(NOT LZ4_BUNDLED_MODE)
     "${LZ4_LIB_SOURCE_DIR}/lz4frame.h"
     "${LZ4_LIB_SOURCE_DIR}/lz4hc.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-  install(FILES "${LZ4_PROG_SOURCE_DIR}/lz4.1"
-    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+  if(LZ4_INSTALL_BINARIES)
+    install(FILES "${LZ4_PROG_SOURCE_DIR}/lz4.1"
+      DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+  endif(LZ4_INSTALL_BINARIES)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblz4.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
   install(FILES
@@ -199,7 +205,7 @@ if(NOT LZ4_BUNDLED_MODE)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
   # install lz4cat and unlz4 symlinks on *nix
-  if(UNIX)
+  if(UNIX AND LZ4_INSTALL_BINARIES)
     install(CODE "
       foreach(f lz4cat unlz4)
         set(dest \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/\${f}\")
@@ -215,7 +221,7 @@ if(NOT LZ4_BUNDLED_MODE)
       install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${f}.1"
         DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
     endforeach()
-  endif(UNIX)
+  endif(UNIX AND LZ4_INSTALL_BINARIES)
 endif(NOT LZ4_BUNDLED_MODE)
 
 # pkg-config

--- a/contrib/cmake_unofficial/Config.cmake.in
+++ b/contrib/cmake_unofficial/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
I am updating lz4 version in the hunter package manager, which relies a lot on CMake features and currently has a fork with it's own CMake implementation for lz4. I have instead made the minimal changes on the current contrib CMake support to work with hunter (and anyone else using a CMake package based system).

There are 2 commits, one adds support for CMake packages (https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html)
The other just adds an option to skip installation of binaries