### PR TITLE
Add LZ4FLIB_VISIBILITY for controlling library symbol visibility

### DIFF
--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -66,7 +66,7 @@ extern "C" {
  *****************************************************************/
 /*  LZ4_DLL_EXPORT :
  *  Enable exporting of functions when building a Windows DLL
- *  LZ4LIB_VISIBILITY :
+ *  LZ4FLIB_VISIBILITY :
  *  Control library symbols visibility.
  */
 #ifndef LZ4FLIB_VISIBILITY

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -66,17 +66,22 @@ extern "C" {
  *****************************************************************/
 /*  LZ4_DLL_EXPORT :
  *  Enable exporting of functions when building a Windows DLL
- *  LZ4FLIB_API :
+ *  LZ4LIB_VISIBILITY :
  *  Control library symbols visibility.
  */
+#ifndef LZ4FLIB_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LZ4FLIB_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define LZ4FLIB_VISIBILITY
+#  endif
+#endif
 #if defined(LZ4_DLL_EXPORT) && (LZ4_DLL_EXPORT==1)
-#  define LZ4FLIB_API __declspec(dllexport)
+#  define LZ4FLIB_API __declspec(dllexport) LZ4FLIB_VISIBILITY
 #elif defined(LZ4_DLL_IMPORT) && (LZ4_DLL_IMPORT==1)
-#  define LZ4FLIB_API __declspec(dllimport)
-#elif defined(__GNUC__) && (__GNUC__ >= 4)
-#  define LZ4FLIB_API __attribute__ ((__visibility__ ("default")))
+#  define LZ4FLIB_API __declspec(dllimport) LZ4FLIB_VISIBILITY
 #else
-#  define LZ4FLIB_API
+#  define LZ4FLIB_API LZ4FLIB_VISIBILITY
 #endif
 
 #ifdef LZ4F_DISABLE_DEPRECATE_WARNINGS


### PR DESCRIPTION
`lz4.h` defines an `LZ4LIB_VISIBILITY` macro that allows us to control the visibility of library symbols at build time without modifying the library itself. `lz4frame.h` lacks such a macro. This PR adds `LZ4FLIB_VISIBILITY` as an equivalent.