### PR TITLE
Reducing stack usage in _t_alignment checks

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1349,8 +1349,8 @@ LZ4_stream_t* LZ4_createStream(void)
                      while actually aligning LZ4_stream_t on 4 bytes. */
 static size_t LZ4_stream_t_alignment(void)
 {
-    struct { char c; LZ4_stream_t t; } t_a;
-    return sizeof(t_a) - sizeof(t_a.t);
+    typedef struct { char c; LZ4_stream_t t; } t_a;
+    return sizeof(t_a) - sizeof(LZ4_stream_t);
 }
 #endif
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -886,8 +886,8 @@ int LZ4_sizeofStateHC(void) { return (int)sizeof(LZ4_streamHC_t); }
                    * while actually aligning LZ4_streamHC_t on 4 bytes. */
 static size_t LZ4_streamHC_t_alignment(void)
 {
-    struct { char c; LZ4_streamHC_t t; } t_a;
-    return sizeof(t_a) - sizeof(t_a.t);
+    typedef struct { char c; LZ4_streamHC_t t; } t_a;
+    return sizeof(t_a) - sizeof(LZ4_streamHC_t);
 }
 #endif
 


### PR DESCRIPTION
Reduce stack usage during checks by removing unnecessary struct allocations on the stack.

A crash occurred when using a small stack size. This can be avoided by not allocating the struct during checks.