### PR TITLE
[build] FreeBSD update version 12.0 -> 12.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-12-0
+  image_family: freebsd-12-1
 
 task:
   script: pkg install -y gmake && gmake test


### PR DESCRIPTION
FreeBSD looks like its failing all the time. We had this same issue in zstd. Updating the version should fix it.