### PR TITLE
lib/lz4: smatch warning in LZ4_decompress_generic()

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1862,7 +1862,7 @@ LZ4_decompress_generic(
              */
             if ( (endOnInput ? length != RUN_MASK : length <= 8)
                 /* strictly "less than" on input, to re-enter the loop with at least one byte */
-              && likely((endOnInput ? ip < shortiend : 1) & (op <= shortoend)) ) {
+              && likely((endOnInput ? ip < shortiend : 1) && (op <= shortoend)) ) {
                 /* Copy the literals */
                 memcpy(op, ip, endOnInput ? 16 : 8);
                 op += length; ip += length;


### PR DESCRIPTION
Found by smatch in linux kernel:
lib/lz4/lz4_decompress.c:150 LZ4_decompress_generic() warn: maybe use && instead of &

The code was coped from last lz4 mainstream
https://github.com/lz4/lz4/blob/dev/lib/lz4.c#L1865

I believe it is wrong and it was caused by typo in following patch
1a191b3