### PR TITLE
Optimized by replacing `endl` with `'\n'`

### DIFF
--- a/contrib/gen_manual/gen_manual.cpp
+++ b/contrib/gen_manual/gen_manual.cpp
@@ -96,10 +96,9 @@ void print_line(stringstream &sout, string line)
     epos = line.find("*/");
     if (spos!=string::npos && epos!=string::npos) {
         sout << line.substr(0, spos);
-        sout << "</b>" << line.substr(spos) << "<b>" << endl;
+        sout << "</b>" << line.substr(spos) << "<b>" << '\n';
     } else {
-      //  fprintf(stderr, "lines=%s\n", line.c_str());
-        sout << line << endl;
+        sout << line << '\n';
     }
 }
 


### PR DESCRIPTION
Optimized for best practice. `endl` was replaced with `'\n'` to speed it up. `std::endl` includes the writing of `std::flush`, which is not necessary in this context, and makes `'\n'` much faster.