### PR TITLE
added target aarch64, ppc64lw and s390x to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,21 @@ matrix:
         - make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static
         - make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static
 
+    - name: aarch64 real-hw tests
+      arch: arm64
+      script:
+        - make test
+
+    - name: PPC64LE real-hw tests
+      arch: ppc64le
+      script:
+        - make test
+
+    - name: IBM s390x real-hw tests
+      arch: s390x
+      script:
+        - make test
+
     - name: (Xenial) gcc-5 compilation
       dist: xenial
       install:


### PR DESCRIPTION
adding portability tests for 3 more targets,
pass the complete `test` suite, including `fuzzer` tests and examples