### PR TITLE
removed LZ4_compress_fast_force()

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1288,22 +1288,6 @@ int LZ4_compress_default(const char* src, char* dst, int srcSize, int maxOutputS
 }
 
 
-/* hidden debug function */
-/* strangely enough, gcc generates faster code when this function is uncommented, even if unused */
-int LZ4_compress_fast_force(const char* src, char* dst, int srcSize, int dstCapacity, int acceleration)
-{
-    LZ4_stream_t ctx;
-    LZ4_initStream(&ctx, sizeof(ctx));
-
-    if (srcSize < LZ4_64Klimit) {
-        return LZ4_compress_generic(&ctx.internal_donotuse, src, dst, srcSize, NULL, dstCapacity, limitedOutput, byU16,    noDict, noDictIssue, acceleration);
-    } else {
-        tableType_t const addrMode = (sizeof(void*) > 4) ? byU32 : byPtr;
-        return LZ4_compress_generic(&ctx.internal_donotuse, src, dst, srcSize, NULL, dstCapacity, limitedOutput, addrMode, noDict, noDictIssue, acceleration);
-    }
-}
-
-
 /* Note!: This function leaves the stream in an unclean/broken state!
  * It is not safe to subsequently use the same state with a _fastReset() or
  * _continue() call without resetting it. */


### PR DESCRIPTION
which serves no more purpose.

The comment implies that the simple presence of this unused function was affecting performance,
and that's why it was not removed earlier.

This is probably another side effect of instruction alignment.
It's obviously unreliable to rely on it in this way,
as the impact will be different, positive of negative,
with any minor code change, and any minor compiler, version, even parameter change.