### PR TITLE
fix #847

### DIFF
--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1059,8 +1059,11 @@ static void FUZ_unitTests(int compressionLevel)
     /* useful to trigger undefined sanitizer */
     DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input \n");
     {	int const maxCSize = LZ4_compressBound(0);
-	int const cSize = LZ4_compress_default(NULL, testCompressed, 0, maxCSize);
-	FUZ_CHECKTEST(cSize==1 && testCompressed[0]==0, "compressed empty is byte 0");
+        int const cSize = LZ4_compress_default(NULL, testCompressed, 0, maxCSize);
+        FUZ_CHECKTEST(!(cSize==1 && testCompressed[0]==0),
+                    "compressing empty should give byte 0"
+                    " (maxCSize == %u) (cSize == %u)",
+                    (unsigned)maxCSize, (unsigned)cSize);
     }
 
     /* in-place compression test */

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1055,6 +1055,14 @@ static void FUZ_unitTests(int compressionLevel)
             FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail");
     }   }
 
+
+    /* useful to trigger undefined sanitizer */
+    DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input \n");
+    {	int const maxCSize = LZ4_compressBound(0);
+	int const cSize = LZ4_compress_default(NULL, testCompressed, 0, maxCSize);
+	FUZ_CHECKTEST(cSize==1 && testCompressed[0]==0, "compressed empty is byte 0");
+    }
+
     /* in-place compression test */
     DISPLAYLEVEL(3, "in-place compression using LZ4_compress_default() :");
     {   int const sampleSize = 65 KB;


### PR DESCRIPTION
fix #847 : support `NULL` input without triggering undefined sanitizer
added relevant test in `fuzzer` (triggers usan runtime error without the fix)