### PR TITLE
Add CMake option LZ4_BUILD_CLI

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -12,6 +12,7 @@
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
+option(LZ4_BUILD_CLI "Build lz4 program" ON)
 option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c progam with legacy argument support" ON)
 
 # Parse version information
@@ -124,10 +125,12 @@ else()
 endif()
 
 # lz4
-set(LZ4_PROGRAMS_BUILT lz4cli)
-add_executable(lz4cli ${LZ4_CLI_SOURCES})
-set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
-target_link_libraries(lz4cli ${LZ4_LINK_LIBRARY})
+if (LZ4_BUILD_CLI)
+  set(LZ4_PROGRAMS_BUILT lz4cli)
+  add_executable(lz4cli ${LZ4_CLI_SOURCES})
+  set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
+  target_link_libraries(lz4cli ${LZ4_LINK_LIBRARY})
+endif()
 
 # lz4c
 if (LZ4_BUILD_LEGACY_LZ4C)
@@ -189,7 +192,7 @@ if(NOT LZ4_BUNDLED_MODE)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
   # install lz4cat and unlz4 symlinks on *nix
-  if(UNIX)
+  if(UNIX AND LZ4_BUILD_CLI)
     install(CODE "
       foreach(f lz4cat unlz4)
         set(dest \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/\${f}\")
@@ -205,7 +208,7 @@ if(NOT LZ4_BUNDLED_MODE)
       install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${f}.1"
         DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
     endforeach()
-  endif(UNIX)
+  endif(UNIX AND LZ4_BUILD_CLI)
 endif(NOT LZ4_BUNDLED_MODE)
 
 # pkg-config


### PR DESCRIPTION
Defaults to `ON` so nothing changes, but it can be set to `OFF` so that the CLI is not built at all, only the library, i.e. like so:

```sh
$ cmake -DLZ4_BUILD_CLI:BOOL=OFF
```

This is useful in combination with `-DLZ4_BUILD_LEGACY_LZ4C:BOOL=OFF` for builds where only the library is needed.