### PR TITLE
fix compressing into NULL

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1236,6 +1236,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic(
 
     if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) { return 0; }  /* Unsupported srcSize, too large (or negative) */
     if (srcSize == 0) {   /* src == NULL supported if srcSize == 0 */
+        if (outputDirective != notLimited && dstCapacity <= 0) return 0;  /* no output, can't write anything */
         DEBUGLOG(5, "Generating an empty block");
         assert(outputDirective == notLimited || dstCapacity >= 1);
         assert(dst != NULL);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1056,15 +1056,24 @@ static void FUZ_unitTests(int compressionLevel)
     }   }
 
 
-    /* useful to trigger undefined sanitizer */
-    DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input \n");
+    /* to be tested with undefined sanitizer */
+    DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input:");
     {	int const maxCSize = LZ4_compressBound(0);
         int const cSize = LZ4_compress_default(NULL, testCompressed, 0, maxCSize);
         FUZ_CHECKTEST(!(cSize==1 && testCompressed[0]==0),
                     "compressing empty should give byte 0"
-                    " (maxCSize == %u) (cSize == %u)",
-                    (unsigned)maxCSize, (unsigned)cSize);
+                    " (maxCSize == %i) (cSize == %i) (byte == 0x%02X)",
+                    maxCSize, cSize, testCompressed[0]);
     }
+    DISPLAYLEVEL(3, " OK \n");
+
+    DISPLAYLEVEL(3, "LZ4_compress_default() with both NULL input and output:");
+    {	int const cSize = LZ4_compress_default(NULL, NULL, 0, 0);
+        FUZ_CHECKTEST(cSize != 0,
+                    "compressing into NULL must fail"
+                    " (cSize == %i !=  0)", cSize);
+    }
+    DISPLAYLEVEL(3, " OK \n");
 
     /* in-place compression test */
     DISPLAYLEVEL(3, "in-place compression using LZ4_compress_default() :");


### PR DESCRIPTION
fails properly
bug discovered by `oss-fuzz`