### PR TITLE
Fix compilation with TinyCC

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -514,7 +514,7 @@ static unsigned LZ4_NbCommonBytes (reg_t val)
             return (unsigned)r >> 3;
 #       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
                             ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_ctz((U32)val) >> 3;
 #       else
             const U32 m = 0x01010101;
@@ -525,7 +525,7 @@ static unsigned LZ4_NbCommonBytes (reg_t val)
         if (sizeof(val)==8) {
 #       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
                             ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_clzll((U64)val) >> 3;
 #       else
 #if 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203261/94360702-12072880-00e2-11eb-9340-be75dddb48d6.png)

As part of the [effort to make radare2 buildable with TinyCC](https://github.com/radareorg/radare2/pull/17295), which is the only option on some systems since easier to port rather than GCC or Clang.

Current [TinyCC compiler](https://bellard.org/tcc/) version is at https://repo.or.cz/tinycc.git/ - `mob` branch.

TinyCC doesn't have support for `__builtin_ctz` and `__builtin_clzll` intrinsics.