### PR TITLE
Revert "Replace "static" to "LZ4_FORCE_INLINE" for small functions"

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -310,7 +310,7 @@ typedef enum {
 #define LZ4_memcpy(dst, src, size) memcpy(dst, src, size)
 #endif
 
-LZ4_FORCE_INLINE unsigned LZ4_isLittleEndian(void)
+static unsigned LZ4_isLittleEndian(void)
 {
     const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental */
     return one.c[0];
@@ -320,12 +320,12 @@ LZ4_FORCE_INLINE unsigned LZ4_isLittleEndian(void)
 #if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
 /* lie to the compiler about data alignment; use with caution */
 
-LZ4_FORCE_INLINE U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
-LZ4_FORCE_INLINE U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
-LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
+static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
+static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
 
-LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
-LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
+static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
 
 #elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
 
@@ -333,36 +333,36 @@ LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = val
 /* currently only defined for gcc and icc */
 typedef union { U16 u16; U32 u32; reg_t uArch; } __attribute__((packed)) unalign;
 
-LZ4_FORCE_INLINE U16 LZ4_read16(const void* ptr) { return ((const unalign*)ptr)->u16; }
-LZ4_FORCE_INLINE U32 LZ4_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
-LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* ptr) { return ((const unalign*)ptr)->uArch; }
+static U16 LZ4_read16(const void* ptr) { return ((const unalign*)ptr)->u16; }
+static U32 LZ4_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
+static reg_t LZ4_read_ARCH(const void* ptr) { return ((const unalign*)ptr)->uArch; }
 
-LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value) { ((unalign*)memPtr)->u16 = value; }
-LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value) { ((unalign*)memPtr)->u32 = value; }
+static void LZ4_write16(void* memPtr, U16 value) { ((unalign*)memPtr)->u16 = value; }
+static void LZ4_write32(void* memPtr, U32 value) { ((unalign*)memPtr)->u32 = value; }
 
 #else  /* safe and portable access using memcpy() */
 
-LZ4_FORCE_INLINE U16 LZ4_read16(const void* memPtr)
+static U16 LZ4_read16(const void* memPtr)
 {
     U16 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-LZ4_FORCE_INLINE U32 LZ4_read32(const void* memPtr)
+static U32 LZ4_read32(const void* memPtr)
 {
     U32 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-LZ4_FORCE_INLINE reg_t LZ4_read_ARCH(const void* memPtr)
+static reg_t LZ4_read_ARCH(const void* memPtr)
 {
     reg_t val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
 }
 
-LZ4_FORCE_INLINE void LZ4_write16(void* memPtr, U16 value)
+static void LZ4_write16(void* memPtr, U16 value)
 {
     LZ4_memcpy(memPtr, &value, sizeof(value));
 }
 
-LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value)
+static void LZ4_write32(void* memPtr, U32 value)
 {
     LZ4_memcpy(memPtr, &value, sizeof(value));
 }
@@ -370,7 +370,7 @@ LZ4_FORCE_INLINE void LZ4_write32(void* memPtr, U32 value)
 #endif /* LZ4_FORCE_MEMORY_ACCESS */
 
 
-LZ4_FORCE_INLINE U16 LZ4_readLE16(const void* memPtr)
+static U16 LZ4_readLE16(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
         return LZ4_read16(memPtr);
@@ -380,7 +380,7 @@ LZ4_FORCE_INLINE U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
-LZ4_FORCE_INLINE void LZ4_writeLE16(void* memPtr, U16 value)
+static void LZ4_writeLE16(void* memPtr, U16 value)
 {
     if (LZ4_isLittleEndian()) {
         LZ4_write16(memPtr, value);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -159,7 +159,7 @@ int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
 #endif
 
 
-LZ4_FORCE_INLINE U32 LZ4HC_rotatePattern(size_t const rotate, U32 const pattern)
+static U32 LZ4HC_rotatePattern(size_t const rotate, U32 const pattern)
 {
     size_t const bitsToRotate = (rotate & (sizeof(pattern) - 1)) << 3;
     if (bitsToRotate == 0) return pattern;
@@ -223,7 +223,7 @@ LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
  * 4 byte MINMATCH would overflow.
  * @returns true if the match index is okay.
  */
-LZ4_FORCE_INLINE int LZ4HC_protectDictEnd(U32 const dictLimit, U32 const matchIndex)
+static int LZ4HC_protectDictEnd(U32 const dictLimit, U32 const matchIndex)
 {
     return ((U32)((dictLimit - 1) - matchIndex) >= 3);
 }


### PR DESCRIPTION
This reverts commit 0e3933edd435c54cc2e21e38f5d4ba7bf644a24e ,
which resulted in important performance regression.

Reverting the commit restores performance (`gcc v9.3.0`, i7-9700k noturbo) :

Silesia C.Speed : 513 MB/s ==> 532 MB/s  (+3.7%)
Calgary C.Speed : 426 MB/s ==> 443 MB/s  (+4.0%)

Silesia D.Speed : 3263 MB/s ==> 3386 MB/s  (+3.8%)
Calgary D.Speed : 3190 MB/s ==> 3326 MB/s  (+4.3%)

There might be a case for more selective inlining, but this would need to be more thoroughly analyzed.
On short term, just revert the commit, which was part of PR #930 (note: PR itself wasn't cancelled, other parts of this PR are fine).