### PR TITLE
proposal for LZ4_USER_MEMORY_FUNCTIONS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - make clean
         - make -C programs lz4-wlib
         - make clean
-        - make fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
+        - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
 
     - name: (Precise) g++ and clang CMake test
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
         - make -C programs lz4-wlib
         - make clean
         - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
+        - make clean
+        - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
 
     - name: (Precise) g++ and clang CMake test
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,13 @@ matrix:
       script:
         - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 
-    - name: Custom LZ4_DISTANCE_MAX ; Build lz4-wlib (CLI linked to dynamic library)
+    - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
       script:
         - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
         - make clean
         - make -C programs lz4-wlib
+        - make clean
+        - make fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
 
     - name: (Precise) g++ and clang CMake test
       dist: precise

--- a/lib/README.md
+++ b/lib/README.md
@@ -69,6 +69,10 @@ The following build macro can be selected to adjust source code behavior at comp
   This build macro offers another project-specific method
   by defining `LZ4_DISABLE_DEPRECATE_WARNINGS` before including the LZ4 header files.
 
+- `LZ4_USER_MEMORY_FUNCTIONS` : replace calls to <stdlib>'s `malloc`, `calloc` and `free`
+  by user-defined functions, which must be called `LZ4_malloc()`, `LZ4_calloc()` and `LZ4_free()`.
+  User functions must be available at link time.
+
 - `LZ4_FORCE_SW_BITCOUNT` : by default, the compression algorithm tries to determine lengths
   by using bitcount instructions, generally implemented as fast single instructions in many cpus.
   In case the target cpus doesn't support it, or compiler intrinsic doesn't work, or feature bad performance,

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -188,10 +188,23 @@
 /*-************************************
 *  Memory routines
 **************************************/
-#include <stdlib.h>   /* malloc, calloc, free */
-#define ALLOC(s)          malloc(s)
-#define ALLOC_AND_ZERO(s) calloc(1,s)
-#define FREEMEM(p)        free(p)
+#ifdef LZ4_USER_MEMORY_FUNCTIONS
+/* memory management functions can be customized by user project.
+ * Below functions must exist somewhere in the Project
+ * and be available at link time */
+void* LZ4_malloc(size_t s);
+void* LZ4_calloc(size_t s);
+void  LZ4_free(void* p);
+# define ALLOC(s)          LZ4_malloc(s)
+# define ALLOC_AND_ZERO(s) LZ4_calloc(s)
+# define FREEMEM(p)        LZ4_free(p)
+#else
+# include <stdlib.h>   /* malloc, calloc, free */
+# define ALLOC(s)          malloc(s)
+# define ALLOC_AND_ZERO(s) calloc(1,s)
+# define FREEMEM(p)        free(p)
+#endif
+
 #include <string.h>   /* memset, memcpy */
 #define MEM_INIT(p,v,s)   memset((p),(v),(s))
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -193,10 +193,10 @@
  * Below functions must exist somewhere in the Project
  * and be available at link time */
 void* LZ4_malloc(size_t s);
-void* LZ4_calloc(size_t s);
+void* LZ4_calloc(size_t n, size_t s);
 void  LZ4_free(void* p);
 # define ALLOC(s)          LZ4_malloc(s)
-# define ALLOC_AND_ZERO(s) LZ4_calloc(s)
+# define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
 # define FREEMEM(p)        LZ4_free(p)
 #else
 # include <stdlib.h>   /* malloc, calloc, free */

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -71,8 +71,8 @@
  * towards another library or solution of their choice
  * by modifying below section.
  */
-#include <stdlib.h>   /* malloc, calloc, free */
 #ifndef LZ4_SRC_INCLUDED   /* avoid redefinition when sources are coalesced */
+#  include <stdlib.h>   /* malloc, calloc, free */
 #  define ALLOC(s)          malloc(s)
 #  define ALLOC_AND_ZERO(s) calloc(1,(s))
 #  define FREEMEM(p)        free(p)

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -93,7 +93,7 @@ static U32 LZ4HC_hashPtr(const void* ptr) { return HASH_FUNCTION(LZ4_read32(ptr)
 **************************************/
 static void LZ4HC_clearTables (LZ4HC_CCtx_internal* hc4)
 {
-    MEM_INIT((void*)hc4->hashTable, 0, sizeof(hc4->hashTable));
+    MEM_INIT(hc4->hashTable, 0, sizeof(hc4->hashTable));
     MEM_INIT(hc4->chainTable, 0xFF, sizeof(hc4->chainTable));
 }
 
@@ -983,11 +983,10 @@ int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* s
 /* allocation */
 LZ4_streamHC_t* LZ4_createStreamHC(void)
 {
-    LZ4_streamHC_t* const state = (LZ4_streamHC_t*)ALLOC(sizeof(LZ4_streamHC_t));
-    if (LZ4_initStreamHC(state, sizeof(*state)) == NULL) {
-        free(state);
-        return NULL;
-    }
+    LZ4_streamHC_t* const state =
+        (LZ4_streamHC_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamHC_t));
+    if (state == NULL) return NULL;
+    LZ4_setCompressionLevel(state, LZ4HC_CLEVEL_DEFAULT);
     return state;
 }
 
@@ -1323,7 +1322,7 @@ static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
     int retval = 0;
 #define TRAILING_LITERALS 3
 #ifdef LZ4HC_HEAPMODE
-    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)malloc(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
+    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)ALLOC(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
 #else
     LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS];   /* ~64 KB, which is a bit large for stack... */
 #endif
@@ -1606,7 +1605,7 @@ if (limit == fillOutput) {
 }
 _return_label:
 #ifdef LZ4HC_HEAPMODE
-     free(opt);
+     FREEMEM(opt);
 #endif
      return retval;
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -53,6 +53,7 @@ TEST_FILES   := COPYING
 FUZZER_TIME  := -T90s
 NB_LOOPS     ?= -i1
 
+.PHONY: default
 default: all
 
 all: fullbench fuzzer frametest roundTripTest datagen checkFrame decompress-partial
@@ -89,6 +90,10 @@ fullbench-dll: fullbench.c $(LZ4DIR)/xxhash.c
 	$(MAKE) -C $(LZ4DIR) liblz4
 	$(CC) $(FLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
 
+# test LZ4_USER_MEMORY_FUNCTIONS
+fullbench-wmalloc: CPPFLAGS += -DLZ4_USER_MEMORY_FUNCTIONS
+fullbench-wmalloc: fullbench
+
 fuzzer  : lz4.o lz4hc.o xxhash.o fuzzer.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
@@ -107,6 +112,7 @@ checkFrame : lz4frame.o lz4.o lz4hc.o xxhash.o checkFrame.c
 decompress-partial: lz4.o decompress-partial.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
+.PHONY: clean
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
@@ -169,9 +175,6 @@ test32: CFLAGS+=-m32
 test32: test
 
 test-amalgamation: lz4_all.o
-
-lz4_all.o: lz4_all.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) -c $^ -o $@
 
 lz4_all.c: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c
 	$(CAT) $^ > $@

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -159,7 +159,7 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 *  Memory management, to test LZ4_USER_MEMORY_FUNCTIONS
 *********************************************************/
 void* LZ4_malloc(size_t s) { return malloc(s); }
-void* LZ4_calloc(size_t s) { return calloc(1,s); }
+void* LZ4_calloc(size_t n, size_t s) { (void)n; return calloc(1,s); }
 void  LZ4_free(void* p) { free(p); }
 
 

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -160,7 +160,7 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 *********************************************************/
 void* LZ4_malloc(size_t s) { return malloc(s); }
 void* LZ4_calloc(size_t s) { return calloc(1,s); }
-void  LZ4_free(void* p) { return free(p); }
+void  LZ4_free(void* p) { free(p); }
 
 
 /*********************************************************

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -156,6 +156,14 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 
 
 /*********************************************************
+*  Memory management, to test LZ4_USER_MEMORY_FUNCTIONS
+*********************************************************/
+void* LZ4_malloc(size_t s) { return malloc(s); }
+void* LZ4_calloc(size_t s) { return calloc(1,s); }
+void  LZ4_free(void* p) { return free(p); }
+
+
+/*********************************************************
 *  Benchmark function
 *********************************************************/
 static LZ4_stream_t LZ4_stream;

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -159,7 +159,7 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 *  Memory management, to test LZ4_USER_MEMORY_FUNCTIONS
 *********************************************************/
 void* LZ4_malloc(size_t s) { return malloc(s); }
-void* LZ4_calloc(size_t n, size_t s) { (void)n; return calloc(1,s); }
+void* LZ4_calloc(size_t n, size_t s) { return calloc(n,s); }
 void  LZ4_free(void* p) { free(p); }
 
 


### PR DESCRIPTION
makes it possible to replace _at link time_
`malloc()`, `calloc()` and `free()` from `<stdlib.h>`
by user-provided functions
which must be named `LZ4_malloc()`, `LZ4_calloc()` and `LZ4_free()`.

answer #937