### PR TITLE
fix cmake build of shared dll with visual

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -107,6 +107,10 @@ if(BUILD_SHARED_LIBS)
     OUTPUT_NAME lz4
     SOVERSION "${LZ4_VERSION_MAJOR}"
     VERSION "${LZ4_VERSION_STRING}")
+  if(MSVC)
+    target_compile_definitions(lz4_shared PRIVATE
+      LZ4_DLL_EXPORT=1)
+  endif()
   list(APPEND LZ4_LIBRARIES_BUILT lz4_shared)
 endif()
 if(BUILD_STATIC_LIBS)


### PR DESCRIPTION
tentatively try to fix #883 

to be fair, I'm not able to test it, so this is a blind fix.
The modification is inspired from #891