### PR TITLE
better MSVC conformance

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -121,10 +121,9 @@
 /*-************************************
 *  Compiler Options
 **************************************/
-#ifdef _MSC_VER    /* Visual Studio */
-#  include <intrin.h>
-#  pragma warning(disable : 4127)        /* disable: C4127: conditional expression is constant */
-#  pragma warning(disable : 4293)        /* disable: C4293: too large shift (32-bits) */
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Visual Studio 2005+ */
+#  include <intrin.h>               /* only present in VS2005+ */
+#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
 #endif  /* _MSC_VER */
 
 #ifndef LZ4_FORCE_INLINE

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -172,7 +172,8 @@ static unsigned
 LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 const pattern32)
 {
     const BYTE* const iStart = ip;
-    reg_t const pattern = (sizeof(pattern)==8) ? (reg_t)pattern32 + (((reg_t)pattern32) << 32) : pattern32;
+    reg_t const pattern = (sizeof(pattern)==8) ?
+        (reg_t)pattern32 + (((reg_t)pattern32) << (sizeof(pattern)*4)) : pattern32;
 
     while (likely(ip < iEnd-(sizeof(pattern)-1))) {
         reg_t const diff = LZ4_read_ARCH(ip) ^ pattern;

--- a/programs/util.h
+++ b/programs/util.h
@@ -594,15 +594,15 @@ UTIL_createFileList(const char** inputNames, unsigned inputNamesNb,
 
     for (i=0, pos=0, nbFiles=0; i<inputNamesNb; i++) {
         if (!UTIL_isDirectory(inputNames[i])) {
-            size_t const len = strlen(inputNames[i]);
+            size_t const len = strlen(inputNames[i]) + 1;  /* include nul char */
             if (pos + len >= bufSize) {
                 while (pos + len >= bufSize) bufSize += LIST_SIZE_INCREASE;
                 buf = (char*)UTIL_realloc(buf, bufSize);
                 if (!buf) return NULL;
             }
             assert(pos + len < bufSize);
-            strncpy(buf + pos, inputNames[i], bufSize - pos);
-            pos += len + 1;
+            memcpy(buf + pos, inputNames[i], len);
+            pos += len;
             nbFiles++;
         } else {
             char* bufend = buf + bufSize;

--- a/tests/checkFrame.c
+++ b/tests/checkFrame.c
@@ -24,15 +24,6 @@
   */
 
   /*-************************************
-  *  Compiler specific
-  **************************************/
-  #ifdef _MSC_VER    /* Visual Studio */
-  #  pragma warning(disable : 4127)        /* disable: C4127: conditional expression is constant */
-  #  pragma warning(disable : 4146)        /* disable: C4146: minus unsigned expression */
-  #endif
-
-
-  /*-************************************
   *  Includes
   **************************************/
   #include "util.h"       /* U32 */

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -27,8 +27,7 @@
 *  Compiler specific
 **************************************/
 #ifdef _MSC_VER    /* Visual Studio */
-#  pragma warning(disable : 4127)     /* disable: C4127: conditional expression is constant */
-#  pragma warning(disable : 4146)     /* disable: C4146: minus unsigned expression */
+#  pragma warning(disable : 26451)     /* disable: Arithmetic overflow */
 #endif
 
 

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -1060,7 +1060,7 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                 CHECK(op[dstEndSize] != canaryByte, "LZ4F_compressEnd writes beyond dstCapacity !");
                 if (LZ4F_isError(flushedSize)) {
                     if (tooSmallDstEnd) /* failure is allowed */ continue;
-                    CHECK(1, "Compression completion failed (error %i : %s)",
+                    CHECK(!tooSmallDstEnd, "Compression completion failed (error %i : %s)",
                             (int)flushedSize, LZ4F_getErrorName(flushedSize));
                 }
                 op += flushedSize;


### PR DESCRIPTION
- only include `<intrin.h>` on vs2005+ (#947)
- remove a few useless `#pragma`
- fix a few minor Visual warnings