### PR TITLE
Makefile correctly export CFLAGS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     #   This would typically be a build job when using workflows, possibly combined with build
     # This is based on your 1.0 configuration file or project settings
     - run: CFLAGS= make clangtest && make clean
-    - run: g++ -v; make gpptest     && make clean
+    - run: g++ -v; make cxxtest   && make clean
     - run: gcc -v; g++ -v; make ctocpptest && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -Werror" make check && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
     - name: (Precise) g++ and clang CMake test
       dist: precise
       script:
-        - make gpptest
+        - make cxxtest
         - make clean
         - make examples
         - make clean cmake

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ test:
 	$(MAKE) -C $(EXDIR) $@
 
 .PHONY: clangtest
-clangtest: CFLAGS ?= -O3  # strangely, this line has the hidden side effect of `unexport CFLAGS`
+clangtest: CFLAGS ?= -O3  # make's bug (http://savannah.gnu.org/bugs/?func=detailitem&item_id=59230)
+# this line has the hidden side effect of `unexport CFLAGS`
 export CFLAGS   # fix the side effect by issuing export command
 clangtest: CFLAGS += -Werror -Wconversion -Wno-sign-conversion
 clangtest: CC = clang
@@ -189,7 +190,7 @@ versionsTest: clean
 	$(MAKE) -C $(TESTDIR) $@
 
 .PHONY: cxxtest cxx32test
-cxxtest cxx32test: CC = "$(CXX) -Wno-deprecated"
+cxxtest cxx32test: CC := "$(CXX) -Wno-deprecated"
 cxxtest cxx32test: CFLAGS = -O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror
 cxx32test: CFLAGS += -m32
 cxxtest cxx32test: clean

--- a/Makefile
+++ b/Makefile
@@ -168,10 +168,8 @@ usan32: clean
 SCANBUILD ?= scan-build
 SCANBUILD_FLAGS += --status-bugs -v --force-analyze-debug-code
 .PHONY: staticAnalyze
-staticAnalyze: CPPFLAGS = -DLZ4_DEBUG=1
-staticAnalyze: CFLAGS   = -g
 staticAnalyze: clean
-	$(SCANBUILD) $(SCANBUILD_FLAGS) $(MAKE) all V=1 DEBUGLEVEL=1
+	CPPFLAGS=-DLZ4_DEBUG=1 CFLAGS=-g $(SCANBUILD) $(SCANBUILD_FLAGS) $(MAKE) all V=1 DEBUGLEVEL=1
 
 .PHONY: cppcheck
 cppcheck:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,8 +1,34 @@
-ifeq ($(V), 1)
-Q =
-else
-Q = @
-endif
+# ################################################################
+# LZ4 - Makefile common definitions
+# Copyright (C) Yann Collet 2020
+# All rights reserved.
+#
+# BSD license
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice, this
+#   list of conditions and the following disclaimer in the documentation and/or
+#   other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# You can contact the author at :
+#  - LZ4 source repository : https://github.com/lz4/lz4
+#  - LZ4 forum froup : https://groups.google.com/forum/#!forum/lz4c
+# ################################################################
 
 TARGET_OS ?= $(shell uname)
 ifeq ($(TARGET_OS),)

--- a/contrib/gen_manual/Makefile
+++ b/contrib/gen_manual/Makefile
@@ -30,10 +30,10 @@
 # ################################################################
 
 
-CXXFLAGS ?= -O3
+CXXFLAGS ?= -O2
 CXXFLAGS += -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasing=1 -Wswitch-enum -Wno-comment
-CXXFLAGS += $(MOREFLAGS)
-FLAGS   = $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS)
+CPPFLAGS += $(MOREFLAGS)
+FLAGS   = $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 LZ4API = ../../lib/lz4.h
 LZ4MANUAL = ../../doc/lz4_manual.html
@@ -68,7 +68,7 @@ $(LZ4FMANUAL) : gen_manual $(LZ4FAPI)
 	./gen_manual $(LZ4VER) $(LZ4FAPI) $@
 
 .PHONY: manuals
-manuals: gen_manual $(LZ4MANUAL) $(LZ4FMANUAL)
+manuals: $(LZ4MANUAL) $(LZ4FMANUAL)
 
 .PHONY: clean
 clean:

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -31,11 +31,12 @@
 #  - LZ4 source repository : https://github.com/lz4/lz4
 #  - LZ4 forum froup : https://groups.google.com/forum/#!forum/lz4c
 # ################################################################
+SED = sed
 
 # Version numbers
-LIBVER_MAJOR_SCRIPT:=`sed -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
-LIBVER_MINOR_SCRIPT:=`sed -n '/define LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
-LIBVER_PATCH_SCRIPT:=`sed -n '/define LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
+LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
+LIBVER_MINOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
+LIBVER_PATCH_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
 LIBVER_SCRIPT:= $(LIBVER_MAJOR_SCRIPT).$(LIBVER_MINOR_SCRIPT).$(LIBVER_PATCH_SCRIPT)
 LIBVER_MAJOR := $(shell echo $(LIBVER_MAJOR_SCRIPT))
 LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
@@ -46,12 +47,13 @@ BUILD_SHARED:=yes
 BUILD_STATIC:=yes
 
 CPPFLAGS+= -DXXH_NAMESPACE=LZ4_
+CPPFLAGS+= $(MOREFLAGS)
 CFLAGS  ?= -O3
 DEBUGFLAGS:= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
              -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
              -Wundef -Wpointer-arith -Wstrict-aliasing=1
-CFLAGS  += $(DEBUGFLAGS) $(MOREFLAGS)
-FLAGS    = $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+CFLAGS  += $(DEBUGFLAGS)
+FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 SRCFILES := $(sort $(wildcard *.c))
 
@@ -74,27 +76,33 @@ endif
 .PHONY: default
 default: lib-release
 
+# silent mode by default; verbose can be triggered by V=1 or VERBOSE=1
+$(V)$(VERBOSE).SILENT:
+
 lib-release: DEBUGFLAGS :=
 lib-release: lib
 
+.PHONY: lib
 lib: liblz4.a liblz4
 
+.PHONY: all
 all: lib
 
+.PHONY: all32
 all32: CFLAGS+=-m32
 all32: all
 
 liblz4.a: $(SRCFILES)
 ifeq ($(BUILD_STATIC),yes)  # can be disabled on command line
 	@echo compiling static library
-	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) -c $^
-	$(Q)$(AR) rcs $@ *.o
+	$(COMPILE.c) $^
+	$(AR) rcs $@ *.o
 endif
 
 ifeq ($(WINBASED),yes)
 liblz4-dll.rc: liblz4-dll.rc.in
 	@echo creating library resource
-	$(Q)sed -e 's|@LIBLZ4@|$(LIBLZ4)|' \
+	$(SED) -e 's|@LIBLZ4@|$(LIBLZ4)|' \
          -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
          -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
          -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
@@ -104,31 +112,30 @@ liblz4-dll.o: liblz4-dll.rc
 	$(WINDRES) -i liblz4-dll.rc -o liblz4-dll.o
 
 $(LIBLZ4): $(SRCFILES) liblz4-dll.o
-else
-$(LIBLZ4): $(SRCFILES)
-endif
-ifeq ($(BUILD_SHARED),yes)  # can be disabled on command line
 	@echo compiling dynamic library $(LIBVER)
-  ifeq ($(WINBASED),yes)
-	$(Q)$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll -Wl,--out-implib,dll/$(LIBLZ4_EXP)
-  else
-	$(Q)$(CC) $(FLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
+	$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll -Wl,--out-implib,dll/$(LIBLZ4_EXP)
+
+else   # not windows
+
+$(LIBLZ4): $(SRCFILES)
+	@echo compiling dynamic library $(LIBVER)
+	$(CC) $(FLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
 	@echo creating versioned links
-	$(Q)$(LN_SF) $@ liblz4.$(SHARED_EXT_MAJOR)
-	$(Q)$(LN_SF) $@ liblz4.$(SHARED_EXT)
-  endif
+	$(LN_SF) $@ liblz4.$(SHARED_EXT_MAJOR)
+	$(LN_SF) $@ liblz4.$(SHARED_EXT)
+
 endif
 
-ifeq (,$(filter MINGW%,$(TARGET_OS)))
+.PHONY: liblz4
 liblz4: $(LIBLZ4)
-endif
 
+.PHONY: clean
 clean:
 ifeq ($(WINBASED),yes)
-	$(Q)$(RM) *.rc
+	$(RM) *.rc
 endif
-	$(Q)$(RM) core *.o liblz4.pc dll/$(LIBLZ4).dll dll/$(LIBLZ4_EXP)
-	$(Q)$(RM) *.a *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
+	$(RM) core *.o liblz4.pc dll/$(LIBLZ4).dll dll/$(LIBLZ4_EXP)
+	$(RM) *.a *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
 	@echo Cleaning library completed
 
 #-----------------------------------------------------------------------------
@@ -164,54 +171,54 @@ pkgconfigdir ?= $(PKGCONFIGDIR)
 
 liblz4.pc: liblz4.pc.in Makefile
 	@echo creating pkgconfig
-	$(Q)sed -e 's|@PREFIX@|$(prefix)|' \
+	$(SED) -e 's|@PREFIX@|$(prefix)|' \
          -e 's|@LIBDIR@|$(libdir)|' \
          -e 's|@INCLUDEDIR@|$(includedir)|' \
          -e 's|@VERSION@|$(LIBVER)|' \
           $< >$@
 
 install: lib liblz4.pc
-	$(Q)$(INSTALL_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
-	$(Q)$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(pkgconfigdir)/
+	$(INSTALL_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
+	$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(pkgconfigdir)/
 	@echo Installing libraries
   ifeq ($(BUILD_STATIC),yes)
-	$(Q)$(INSTALL_DATA) liblz4.a $(DESTDIR)$(libdir)/liblz4.a
-	$(Q)$(INSTALL_DATA) lz4frame_static.h $(DESTDIR)$(includedir)/lz4frame_static.h
+	$(INSTALL_DATA) liblz4.a $(DESTDIR)$(libdir)/liblz4.a
+	$(INSTALL_DATA) lz4frame_static.h $(DESTDIR)$(includedir)/lz4frame_static.h
   endif
   ifeq ($(BUILD_SHARED),yes)
 # Traditionnally, one installs the DLLs in the bin directory as programs
 # search them first in their directory. This allows to not pollute system
 # directories (like c:/windows/system32), nor modify the PATH variable.
     ifeq ($(WINBASED),yes)
-	$(Q)$(INSTALL_PROGRAM) dll/$(LIBLZ4).dll $(DESTDIR)$(bindir)
-	$(Q)$(INSTALL_PROGRAM) dll/$(LIBLZ4_EXP) $(DESTDIR)$(libdir)
+	$(INSTALL_PROGRAM) dll/$(LIBLZ4).dll $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) dll/$(LIBLZ4_EXP) $(DESTDIR)$(libdir)
     else
-	$(Q)$(INSTALL_PROGRAM) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)
-	$(Q)$(LN_SF) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
-	$(Q)$(LN_SF) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
+	$(INSTALL_PROGRAM) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)
+	$(LN_SF) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
+	$(LN_SF) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
     endif
   endif
 	@echo Installing headers in $(includedir)
-	$(Q)$(INSTALL_DATA) lz4.h $(DESTDIR)$(includedir)/lz4.h
-	$(Q)$(INSTALL_DATA) lz4hc.h $(DESTDIR)$(includedir)/lz4hc.h
-	$(Q)$(INSTALL_DATA) lz4frame.h $(DESTDIR)$(includedir)/lz4frame.h
+	$(INSTALL_DATA) lz4.h $(DESTDIR)$(includedir)/lz4.h
+	$(INSTALL_DATA) lz4hc.h $(DESTDIR)$(includedir)/lz4hc.h
+	$(INSTALL_DATA) lz4frame.h $(DESTDIR)$(includedir)/lz4frame.h
 	@echo lz4 libraries installed
 
 uninstall:
-	$(Q)$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
+	$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
   ifeq (WINBASED,1)
-	$(Q)$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4).dll
-	$(Q)$(RM) $(DESTDIR)$(libdir)/$(LIBLZ4_EXP)
+	$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4).dll
+	$(RM) $(DESTDIR)$(libdir)/$(LIBLZ4_EXP)
   else
-	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
-	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
-	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_VER)
+	$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)
+	$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
+	$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_VER)
   endif
-	$(Q)$(RM) $(DESTDIR)$(libdir)/liblz4.a
-	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4.h
-	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4hc.h
-	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4frame.h
-	$(Q)$(RM) $(DESTDIR)$(includedir)/lz4frame_static.h
+	$(RM) $(DESTDIR)$(libdir)/liblz4.a
+	$(RM) $(DESTDIR)$(includedir)/lz4.h
+	$(RM) $(DESTDIR)$(includedir)/lz4hc.h
+	$(RM) $(DESTDIR)$(includedir)/lz4frame.h
+	$(RM) $(DESTDIR)$(includedir)/lz4frame_static.h
 	@echo lz4 libraries successfully uninstalled
 
 endif

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1,6 +1,6 @@
 /*
    LZ4 - Fast LZ compression algorithm
-   Copyright (C) 2011-present, Yann Collet.
+   Copyright (C) 2011-2020, Yann Collet.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -1,7 +1,7 @@
 /*
  *  LZ4 - Fast LZ compression algorithm
  *  Header File
- *  Copyright (C) 2011-present, Yann Collet.
+ *  Copyright (C) 2011-2020, Yann Collet.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -28,13 +28,14 @@
 # lz4c  : CLU, supporting also legacy lz4demo arguments
 # lz4c32: Same as lz4c, but forced to compile in 32-bits mode
 # ##########################################################################
+SED = sed
 
 # Version numbers
 LZ4DIR   := ../lib
 LIBVER_SRC := $(LZ4DIR)/lz4.h
-LIBVER_MAJOR_SCRIPT:=`sed -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
-LIBVER_MINOR_SCRIPT:=`sed -n '/define LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
-LIBVER_PATCH_SCRIPT:=`sed -n '/define LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
+LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
+LIBVER_MINOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
+LIBVER_PATCH_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
 LIBVER_SCRIPT:= $(LIBVER_MAJOR_SCRIPT).$(LIBVER_MINOR_SCRIPT).$(LIBVER_PATCH_SCRIPT)
 LIBVER_MAJOR := $(shell echo $(LIBVER_MAJOR_SCRIPT))
 LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
@@ -61,6 +62,9 @@ include ../Makefile.inc
 
 default: lz4-release
 
+# silent mode by default; verbose can be triggered by V=1 or VERBOSE=1
+$(V)$(VERBOSE).SILENT:
+
 all: lz4 lz4c
 
 all32: CFLAGS+=-m32
@@ -69,7 +73,7 @@ all32: all
 ifeq ($(WINBASED),yes)
 lz4-exe.rc: lz4-exe.rc.in
 	@echo creating executable resource
-	$(Q)sed -e 's|@PROGNAME@|lz4|' \
+	$(SED) -e 's|@PROGNAME@|lz4|' \
          -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
          -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
          -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
@@ -110,7 +114,7 @@ lz4c32 : $(SRCFILES)
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
 lz4.1: lz4.1.md $(LIBVER_SRC)
-	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | sed -n '/^\.\\\".*/!p' > $@
+	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | $(SED) -n '/^\.\\\".*/!p' > $@
 
 man: lz4.1
 
@@ -122,10 +126,10 @@ preview-man: clean-man man
 
 clean:
 ifeq ($(WINBASED),yes)
-	$(Q)$(RM) *.rc
+	$(RM) *.rc
 endif
-	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
-	@$(RM) core *.o *.test tmp* \
+	$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
+	$(RM) core *.o *.test tmp* \
            lz4$(EXT) lz4c$(EXT) lz4c32$(EXT) lz4-wlib$(EXT) \
            unlz4$(EXT) lz4cat$(EXT)
 	@echo Cleaning completed
@@ -161,27 +165,27 @@ man1dir     ?= $(MAN1DIR)
 
 install: lz4
 	@echo Installing binaries
-	@$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
-	@$(INSTALL_PROGRAM) lz4$(EXT) $(DESTDIR)$(bindir)/lz4$(EXT)
-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)
-	@$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/unlz4$(EXT)
+	$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
+	$(INSTALL_PROGRAM) lz4$(EXT) $(DESTDIR)$(bindir)/lz4$(EXT)
+	$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
+	$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)
+	$(LN_S) lz4$(EXT) $(DESTDIR)$(bindir)/unlz4$(EXT)
 	@echo Installing man pages
-	@$(INSTALL_DATA) lz4.1 $(DESTDIR)$(man1dir)/lz4.1
-	@$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4c.1
-	@$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4cat.1
-	@$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/unlz4.1
+	$(INSTALL_DATA) lz4.1 $(DESTDIR)$(man1dir)/lz4.1
+	$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4c.1
+	$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4cat.1
+	$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/unlz4.1
 	@echo lz4 installation completed
 
 uninstall:
-	@$(RM) $(DESTDIR)$(bindir)/lz4cat$(EXT)
-	@$(RM) $(DESTDIR)$(bindir)/unlz4$(EXT)
-	@$(RM) $(DESTDIR)$(bindir)/lz4$(EXT)
-	@$(RM) $(DESTDIR)$(bindir)/lz4c$(EXT)
-	@$(RM) $(DESTDIR)$(man1dir)/lz4.1
-	@$(RM) $(DESTDIR)$(man1dir)/lz4c.1
-	@$(RM) $(DESTDIR)$(man1dir)/lz4cat.1
-	@$(RM) $(DESTDIR)$(man1dir)/unlz4.1
+	$(RM) $(DESTDIR)$(bindir)/lz4cat$(EXT)
+	$(RM) $(DESTDIR)$(bindir)/unlz4$(EXT)
+	$(RM) $(DESTDIR)$(bindir)/lz4$(EXT)
+	$(RM) $(DESTDIR)$(bindir)/lz4c$(EXT)
+	$(RM) $(DESTDIR)$(man1dir)/lz4.1
+	$(RM) $(DESTDIR)$(man1dir)/lz4c.1
+	$(RM) $(DESTDIR)$(man1dir)/lz4cat.1
+	$(RM) $(DESTDIR)$(man1dir)/unlz4.1
 	@echo lz4 programs successfully uninstalled
 
 endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 # ##########################################################################
 # LZ4 programs - Makefile
-# Copyright (C) Yann Collet 2011-present
+# Copyright (C) Yann Collet 2011-2020
 #
 # GPL v2 License
 #

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1136,12 +1136,12 @@ static void FUZ_unitTests(int compressionLevel)
         assert(shc != NULL);
         memset(shc, 0, sizeof(*shc));
         DISPLAYLEVEL(4, "state1(%p) state2(%p) state3(%p) LZ4_stream_t size(0x%x): ",
-                    &(shc->state1), &(shc->state2), &(shc->state3), (unsigned)sizeof(LZ4_stream_t));
-        FUZ_CHECKTEST( LZ4_initStream(&(shc->state1), sizeof(shc->state1)) == NULL, "state1 (%p) failed init", &(shc->state1) );
-        FUZ_CHECKTEST( LZ4_initStream(&(shc->state2), sizeof(shc->state2)) == NULL, "state2 (%p) failed init", &(shc->state2)  );
-        FUZ_CHECKTEST( LZ4_initStream(&(shc->state3), sizeof(shc->state3)) == NULL, "state3 (%p) failed init", &(shc->state3)  );
+                    (void*)&(shc->state1), (void*)&(shc->state2), (void*)&(shc->state3), (unsigned)sizeof(LZ4_stream_t));
+        FUZ_CHECKTEST( LZ4_initStream(&(shc->state1), sizeof(shc->state1)) == NULL, "state1 (%p) failed init", (void*)&(shc->state1) );
+        FUZ_CHECKTEST( LZ4_initStream(&(shc->state2), sizeof(shc->state2)) == NULL, "state2 (%p) failed init", (void*)&(shc->state2)  );
+        FUZ_CHECKTEST( LZ4_initStream(&(shc->state3), sizeof(shc->state3)) == NULL, "state3 (%p) failed init", (void*)&(shc->state3)  );
         FUZ_CHECKTEST( LZ4_initStream((char*)&(shc->state1) + 1, sizeof(shc->state1)) != NULL,
-                       "hc1+1 (%p) init must fail, due to bad alignment", (char*)&(shc->state1) + 1 );
+                       "hc1+1 (%p) init must fail, due to bad alignment", (void*)((char*)&(shc->state1) + 1) );
         free(shc);
     }
     DISPLAYLEVEL(3, "all inits OK \n");
@@ -1246,12 +1246,13 @@ static void FUZ_unitTests(int compressionLevel)
         assert(shc != NULL);
         memset(shc, 0, sizeof(*shc));
         DISPLAYLEVEL(4, "hc1(%p) hc2(%p) hc3(%p) size(0x%x): ",
-                    &(shc->hc1), &(shc->hc2), &(shc->hc3), (unsigned)sizeof(LZ4_streamHC_t));
-        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc1), sizeof(shc->hc1)) == NULL, "hc1 (%p) failed init", &(shc->hc1) );
-        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc2), sizeof(shc->hc2)) == NULL, "hc2 (%p) failed init", &(shc->hc2)  );
-        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc3), sizeof(shc->hc3)) == NULL, "hc3 (%p) failed init", &(shc->hc3)  );
+                    (void*)&(shc->hc1), (void*)&(shc->hc2), (void*)&(shc->hc3),
+                    (unsigned)sizeof(LZ4_streamHC_t));
+        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc1), sizeof(shc->hc1)) == NULL, "hc1 (%p) failed init", (void*)&(shc->hc1) );
+        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc2), sizeof(shc->hc2)) == NULL, "hc2 (%p) failed init", (void*)&(shc->hc2)  );
+        FUZ_CHECKTEST( LZ4_initStreamHC(&(shc->hc3), sizeof(shc->hc3)) == NULL, "hc3 (%p) failed init", (void*)&(shc->hc3)  );
         FUZ_CHECKTEST( LZ4_initStreamHC((char*)&(shc->hc1) + 1, sizeof(shc->hc1)) != NULL,
-                        "hc1+1 (%p) init must fail, due to bad alignment", (char*)&(shc->hc1) + 1 );
+                        "hc1+1 (%p) init must fail, due to bad alignment", (void*)((char*)&(shc->hc1) + 1) );
         free(shc);
     }
     DISPLAYLEVEL(3, "all inits OK \n");


### PR DESCRIPTION
It seems that forwarding of `CFLAGS` environment variable to sub-Makefiles was lost at some point,
and it seems related to a `make` bug, which accidentally `unexport` global variables
with the same name as a Target-specific Variable which is conditionally assigned: http://savannah.gnu.org/bugs/?func=detailitem&item_id=59230

fix #958 