### PR TITLE
Fix potential memory corruption with negative memmove() size

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1749,7 +1749,7 @@ LZ4_decompress_generic(
                  const size_t dictSize         /* note : = 0 if noDict */
                  )
 {
-    if (src == NULL) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) { return -1; }
 
     {   const BYTE* ip = (const BYTE*) src;
         const BYTE* const iend = ip + srcSize;


### PR DESCRIPTION
I noticed a crash with `lz4jsoncat` when using this script to craft a payload:

```python
   #!/usr/bin/env python3

    import sys

    def main():
        if len(sys.argv) != 3:
            print(f'[-] No filename or size given for payload')
            sys.exit(1)

        fname = sys.argv[1]
        size = sys.argv[2]

        # Handle arguments such as 0xffffffff if not provided as 4294967295
        if size[:2] == '0x':
            size = int(sys.argv[2], base=16)
        else:
            size = int(sys.argv[2])

        try:
            with open(fname, 'wb') as fh:
                # Start by writing out the magic bytes
                fh.write(bytearray(b'mozLz40\x00'))

                # Add the decompressed size followed by a stub frame descriptor
                fh.write(bytearray((size).to_bytes(4, 'little')))
                fh.write(bytearray([0x00, 0x00]))

                # Sample payload
                fh.write(bytearray(b'A' * 15))

        except Exception as e:
            print(f'[-] could not write payload to {fname}: {e}')
            sys.exit(1)

    if __name__ == '__main__':
        main()
```

If the decompressed size is big enough, e.g. `0xff000000`-`0xffffffff` it will lead to a crash in liblz4:

```
% python3 lz4_payload.py /tmp/crash.lz4 0xffffffff
% file /tmp/crash.lz4
/tmp/crash.lz4: Mozilla lz4 compressed data, originally 4294967295 bytes
% LD_LIBRARY_PATH=/home/kali/lz4/lib ./lz4jsoncat.asan /tmp/crash.lz4
=================================================================
==3482258==ERROR: AddressSanitizer: negative-size-param: (size=-1)
    #0 0x43576e in memmove (/home/kali/lz4json/lz4jsoncat.asan+0x43576e)
    #1 0x7f5853e40ba4 in LZ4_decompress_generic /home/kali/lz4/lib/lz4.c:2038:17
    #2 0x7f5853e40ba4 in LZ4_decompress_safe_partial /home/kali/lz4/lib/lz4.c:2182:12
    #3 0x4c92e3 in main /home/kali/lz4json/lz4jsoncat.c:72:7
    #4 0x7f5853a77d09 in __libc_start_main csu/../csu/libc-start.c:308:16
    #5 0x41f399 in _start (/home/kali/lz4json/lz4jsoncat.asan+0x41f399)

Address 0x7f5850ed800d is a wild pointer.
SUMMARY: AddressSanitizer: negative-size-param (/home/kali/lz4json/lz4jsoncat.asan+0x43576e) in memmove
==3482258==ABORTING
```

The crash is due mishandling of the provided size of the decompressed contents in `LZ4_decompress_generic()`.
With a size set in the payload as `0xffffffff`, `dstSize` became `-1` and eventually gets passed to `memmove()`:
  https://github.com/lz4/lz4/blob/909aae82604ad605bb60623731d825431cdf6b49/lib/lz4.c#L2038

The original crash as observed from GDB:

```
    Stopped reason: SIGSEGV
    __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:500
    500     ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S: No such file or directory.
    gdb-peda$ bt
    #0  __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:500
    #1  0x00007ffff7f62ba5 in LZ4_decompress_generic (src=0x7ffff7ffb00c "", dst=0x7ffef7d02010 "", srcSize=0x11, outputSize=0xffffffff, endOnInput=endOnInputSize, partialDecoding=partial_decode, dict=noDict, lowPrefix=0x7ffef7d02010 "", dictStart=0x0, dictSize=0x0) at lz4.c:2039
    #2  LZ4_decompress_safe_partial (src=0x7ffff7ffb00c "", dst=0x7ffef7d02010 "", compressedSize=0x11, targetOutputSize=0xffffffff, dstCapacity=0xffffffff) at lz4.c:2183
    #3  0x00005555555551e1 in main (ac=ac@entry=0x2, av=0x7fffffffe7f0, av@entry=0x7fffffffe7e8) at lz4jsoncat.c:72
    #4  0x00007ffff7d2cd0a in __libc_start_main (main=0x555555555120 <main>, argc=0x2, argv=0x7fffffffe7e8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffe7d8) at ../csu/libc-start.c:308
    #5  0x000055555555536a in _start ()
    gdb-peda$
```

When liblz4 is built with `-DLZ4_DEBUG=N` where N > 0, an assert is triggered instead: https://github.com/lz4/lz4/blob/909aae82604ad605bb60623731d825431cdf6b49/lib/lz4.c#L2020 and if the system allows for core dumps a file up to 4GB is generated which might lead to other problems.
The result is an abort of the application without making it to `memmove()`. The default configuration  is with `LZ4_DEBUG` undefined (i.e. the assert is not hit).

The crasher was originally produced by AFL on Kali Linux and libz4+lz4jsoncat from git. This PR provides a simple check upfront to ensure no obviously invalid sizes are handled.