### PR TITLE
disable allocs if HEAPMODE=0

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -187,6 +187,7 @@
 /*-************************************
 *  Memory routines
 **************************************/
+#if (LZ4_HEAPMODE)
 #ifdef LZ4_USER_MEMORY_FUNCTIONS
 /* memory management functions can be customized by user project.
  * Below functions must exist somewhere in the Project
@@ -202,6 +203,7 @@ void  LZ4_free(void* p);
 # define ALLOC(s)          malloc(s)
 # define ALLOC_AND_ZERO(s) calloc(1,s)
 # define FREEMEM(p)        free(p)
+#endif
 #endif
 
 #include <string.h>   /* memset, memcpy */
@@ -1420,6 +1422,7 @@ int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targe
 *  Streaming functions
 ********************************/
 
+#if (LZ4_HEAPMODE)
 LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
@@ -1429,6 +1432,7 @@ LZ4_stream_t* LZ4_createStream(void)
     LZ4_initStream(lz4s, sizeof(*lz4s));
     return lz4s;
 }
+#endif
 
 static size_t LZ4_stream_t_alignment(void)
 {
@@ -1462,6 +1466,7 @@ void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
     LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
 }
 
+#if (LZ4_HEAPMODE)
 int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
 {
     if (!LZ4_stream) return 0;   /* support free on NULL */
@@ -1469,6 +1474,7 @@ int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
     FREEMEM(LZ4_stream);
     return (0);
 }
+#endif
 
 
 #define HASH_UNIT sizeof(reg_t)
@@ -1786,7 +1792,7 @@ LZ4_decompress_generic(
         if ((!endOnInput) && (unlikely(outputSize==0))) { return (*ip==0 ? 1 : -1); }
         if ((endOnInput) && unlikely(srcSize==0)) { return -1; }
 
-	/* Currently the fast loop shows a regression on qualcomm arm chips. */
+  /* Currently the fast loop shows a regression on qualcomm arm chips. */
 #if LZ4_FAST_DEC_LOOP
         if ((oend - op) < FASTLOOP_SAFE_DISTANCE) {
             DEBUGLOG(6, "skip fast decode loop");
@@ -2262,6 +2268,7 @@ int LZ4_decompress_fast_doubleDict(const char* source, char* dest, int originalS
 
 /*===== streaming decompression functions =====*/
 
+#if (LZ4_HEAPMODE)
 LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 {
     LZ4_streamDecode_t* lz4s = (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
@@ -2275,6 +2282,7 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
     FREEMEM(LZ4_stream);
     return 0;
 }
+#endif
 
 /*! LZ4_setStreamDecode() :
  *  Use this function to instruct where to find the dictionary.
@@ -2480,11 +2488,13 @@ int LZ4_resetStreamState(void* state, char* inputBuffer)
     return 0;
 }
 
+#if (LZ4_HEAPMODE)
 void* LZ4_create (char* inputBuffer)
 {
     (void)inputBuffer;
     return LZ4_createStream();
 }
+#endif
 
 char* LZ4_slideInputBuffer (void* state)
 {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -984,6 +984,7 @@ int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* s
 *  Streaming Functions
 **************************************/
 /* allocation */
+#if (LZ4HC_HEAPMODE)
 LZ4_streamHC_t* LZ4_createStreamHC(void)
 {
     LZ4_streamHC_t* const state =
@@ -1000,6 +1001,7 @@ int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
     FREEMEM(LZ4_streamHCPtr);
     return 0;
 }
+#endif
 
 
 LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)
@@ -1217,6 +1219,7 @@ int LZ4_resetStreamStateHC(void* state, char* inputBuffer)
     return 0;
 }
 
+#if (LZ4HC_HEAPMODE)
 void* LZ4_createHC (const char* inputBuffer)
 {
     LZ4_streamHC_t* const hc4 = LZ4_createStreamHC();
@@ -1231,6 +1234,7 @@ int LZ4_freeHC (void* LZ4HC_Data)
     FREEMEM(LZ4HC_Data);
     return 0;
 }
+#endif // LZ4HC_HEAPMODE=1
 
 int LZ4_compressHC2_continue (void* LZ4HC_Data, const char* src, char* dst, int srcSize, int cLevel)
 {
@@ -1331,7 +1335,7 @@ static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
 {
     int retval = 0;
 #define TRAILING_LITERALS 3
-#ifdef LZ4HC_HEAPMODE
+#if (LZ4HC_HEAPMODE)
     LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)ALLOC(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
 #else
     LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS];   /* ~64 KB, which is a bit large for stack... */
@@ -1614,7 +1618,7 @@ if (limit == fillOutput) {
      goto _last_literals;
 }
 _return_label:
-#ifdef LZ4HC_HEAPMODE
+#if (LZ4HC_HEAPMODE)
      FREEMEM(opt);
 #endif
      return retval;


### PR DESCRIPTION
this PR #ifdefs out all alloc functions if HEAPMODE=0.

this PR also fixes a bug with lz4hc `#ifdef LZ4HC_HEAPMODE` which should instead be
`#if (LZ4HC_HEAPMODE)`. due to LZ4HC_HEAPMODE always being defined, even if set to 0, the heap routines will always be selected.

I am not sure if this PR is something you would accept, if not, i can create a seperate PR for the bug i mentioned above instead. Thanks!