### PR TITLE
Fix 'make usan'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ usan: CC      = clang
 usan: CFLAGS  = -O3 -g -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-recover=pointer-overflow
 usan: LDFLAGS = $(CFLAGS)
 usan: clean
-	$(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
+	CC=$(CC) CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' $(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
 
 .PHONY: usan32
 usan32: CFLAGS = -m32 -O3 -g -fsanitize=undefined


### PR DESCRIPTION
Currently, the following commands don't work as intended

```
cd
git clone https://github.com/lz4/lz4.git
cd lz4
make usan MOREFLAGS='-Wcomma -Werror'
```

```
Cleaning completed
cc: error: unrecognized command line option ‘-Wcomma’; did you mean ‘-Wcomment’?
make[3]: *** [<builtin>: ../lib/lz4.o] Error 1
make[2]: *** [Makefile:65: lz4] Error 2
make[1]: *** [Makefile:133: test] Error 2
make: *** [Makefile:158: usan] Error 2
```

Because the following part of the `Makefile` doesn't propagate `CC`, `CFLAGS` and `LDFLAGS` to child `$(MAKE)` properly.

```
.PHONY: usan
usan: CC      = clang
usan: CFLAGS  = -O3 -g -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-recover=pointer-overflow
usan: LDFLAGS = $(CFLAGS)
usan: clean
        $(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
```

In this case, we need explicit propagation for child process

```
-       $(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
+       CC=$(CC) CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) $(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
```

After that, `make usan` works.  And it reports expected runtime errors.

```
$ make usan MOREFLAGS='-Wcomma -Werror'
Cleaning completed

../lib/lz4frame.c:907:25: runtime error: applying non-zero offset 65536 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../lib/lz4frame.c:907:25 in
../lib/lz4frame.c:907:58: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../lib/lz4frame.c:907:58 in
...
```

Please note that `make usan` is working at travis-ci.  Because `.travis.yml` has the following [explicit `compiler:` setting](https://github.com/lz4/lz4/blob/7a966c1511816b53ac93aa2f2a2ff97e036a4a60/.travis.yml#L66).

```
    - name: (Trusty) USan test
      dist: trusty
      compiler: clang
      script:
        - make usan MOREFLAGS=-Wcomma -Werror
```
