### PR TITLE
Fix -Wshorten-64-to-32 warning

### DIFF
--- a/examples/dictionaryRandomAccess.c
+++ b/examples/dictionaryRandomAccess.c
@@ -97,7 +97,7 @@ void test_compress(FILE* outFp, FILE* inpFp, void *dict, int dictSize)
         while (ptr != offsetsEnd) {
             write_int(outFp, *ptr++);
         }
-        write_int(outFp, offsetsEnd - offsets);
+        write_int(outFp, (int) (offsetsEnd - offsets));
     }
 }
 


### PR DESCRIPTION
This trivial PR fixes warning for implicit cast of `ptrdiff_t` to `int`.
