### PR TITLE
Remove CMake test from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,12 @@ matrix:
         - make clean
         - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
 
-    - name: (Precise) g++ and clang CMake test
+    - name: (Precise) g++ and clang test
       dist: precise
       script:
         - make cxxtest
         - make clean
         - make examples
-        - make clean cmake
         - make clean travis-install
         - make clean clangtest
 


### PR DESCRIPTION
Since we've confirmed CMake test has [successfully passed at GitHub Actions](https://github.com/lz4/lz4/runs/2692005339?check_suite_focus=true), we can safely remove it from .travis.yml.

It also helps to merge #980.
