### PR TITLE
Fix -Wshorten-64-to-32 warning

### DIFF
--- a/examples/blockStreaming_lineByLine.c
+++ b/examples/blockStreaming_lineByLine.c
@@ -65,7 +65,7 @@ static void test_compress(
 
         {
             const int cmpBytes = LZ4_compress_fast_continue(
-                lz4Stream, inpPtr, cmpBuf, inpBytes, cmpBufBytes, 1);
+                lz4Stream, inpPtr, cmpBuf, inpBytes, (int) cmpBufBytes, 1);
             if (cmpBytes <= 0) break;
             write_uint16(outFp, (uint16_t) cmpBytes);
             write_bin(outFp, cmpBuf, cmpBytes);


### PR DESCRIPTION
Fix -Wshorten-64-to-32 warning

The following Travis-CI test (macOS) reports "-Wshorten-64-to-32" warning

```
make V=1 clean test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion'
```

```
blockStreaming_lineByLine.c:68:54: error: implicit conversion loses integer precision: 'const size_t' (aka 'const unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
                lz4Stream, inpPtr, cmpBuf, inpBytes, cmpBufBytes, 1);
                                                     ^~~~~~~~~~~
```