### PR TITLE
Fix g++-4.4 warning

### DIFF
--- a/tests/checkFrame.c
+++ b/tests/checkFrame.c
@@ -153,7 +153,7 @@ int frameCheck(cRess_t ress, FILE* const srcFile, unsigned bsid, size_t blockSiz
                 if (LZ4F_isError(nextToLoad))
                     EXM_THROW(22, "Error getting frame info: %s",
                                 LZ4F_getErrorName(nextToLoad));
-                if (frameInfo.blockSizeID != bsid)
+                if (frameInfo.blockSizeID != (LZ4F_blockSizeID_t) bsid)
                     EXM_THROW(23, "Block size ID %u != expected %u",
                                 frameInfo.blockSizeID, bsid);
                 pos += remaining;


### PR DESCRIPTION
This PR fixes the following warning from `make cxxtest` with `g++-4.4`.

```
g++-4.4 -Wno-deprecated -O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror -I../lib -I../programs -DXXH_NAMESPACE=LZ4_  lz4frame.o lz4.o lz4hc.o xxhash.o checkFrame.c -o checkFrame
checkFrame.c: In function ‘int frameCheck(cRess_t, FILE*, unsigned int, size_t)’:
checkFrame.c:156: error: comparison between signed and unsigned integer expressions
```
