### PR TITLE
Split c_standards into multiple Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,11 +215,20 @@ ctocpptest: clean
 	CC=$(TESTCC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" all
 
 .PHONY: c_standards
-c_standards: clean
+c_standards: clean c_standards_c11 c_standards_c99 c_standards_c90
+
+.PHONY: c_standards_c90
+c_standards_c90: clean
 	$(MAKE) clean; CFLAGS="-std=c90   -Werror -pedantic -Wno-long-long -Wno-variadic-macros" $(MAKE) allmost
 	$(MAKE) clean; CFLAGS="-std=gnu90 -Werror -pedantic -Wno-long-long -Wno-variadic-macros" $(MAKE) allmost
+
+.PHONY: c_standards_c99
+c_standards_c99: clean
 	$(MAKE) clean; CFLAGS="-std=c99   -Werror -pedantic" $(MAKE) all
 	$(MAKE) clean; CFLAGS="-std=gnu99 -Werror -pedantic" $(MAKE) all
+
+.PHONY: c_standards_c11
+c_standards_c11: clean
 	$(MAKE) clean; CFLAGS="-std=c11   -Werror" $(MAKE) all
 
 endif   # MSYS POSIX


### PR DESCRIPTION
To support older compiler which doesn't have gcc compatible style dialect option for C90, this change set split "c_standards" into multiple part.
- It's [gcc-4.4](https://gcc.gnu.org/onlinedocs/gcc-4.4.7/gcc/C-Dialect-Options.html#C-Dialect-Options).  Its option for C90 is different from other versions of gcc.

Original "make c_standards" still works as intended.  But this change gives extra freedom of choice for external program.  For example, CI can choose test for standards which are supported by specific compiler.

Also with this separation, we will be able to introduce C17 smoothly.