### PR TITLE
Remove QEMU test from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,20 +109,20 @@ matrix:
         - make c_standards
         - make -C tests test-lz4 MOREFLAGS=-Werror
 
-    - name: (Trusty) arm + aarch64 compilation
-      dist: trusty
-      install:
-        - sudo apt-get install -qq
-            qemu-system-arm
-            qemu-user-static
-            gcc-arm-linux-gnueabi
-            libc6-dev-armel-cross
-            gcc-aarch64-linux-gnu
-            libc6-dev-arm64-cross
-      script:
-        - make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static
-        - make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static
-
+#   - name: (Trusty) arm + aarch64 compilation
+#     dist: trusty
+#     install:
+#       - sudo apt-get install -qq
+#           qemu-system-arm
+#           qemu-user-static
+#           gcc-arm-linux-gnueabi
+#           libc6-dev-armel-cross
+#           gcc-aarch64-linux-gnu
+#           libc6-dev-arm64-cross
+#     script:
+#       - make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static
+#       - make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static
+#
     - name: aarch64 real-hw tests
       arch: arm64
       script:
@@ -157,14 +157,14 @@ matrix:
       script:
         - make -C tests test-lz4 CC=clang-3.8
 
-    - name: (Trusty) PowerPC + PPC64 compilation
-      dist: trusty
-      install:
-        - sudo apt-get install -qq qemu-system-ppc qemu-user-static gcc-powerpc-linux-gnu
-      script:
-        - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static
-        - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static MOREFLAGS=-m64
-
+#   - name: (Trusty) PowerPC + PPC64 compilation
+#     dist: trusty
+#     install:
+#       - sudo apt-get install -qq qemu-system-ppc qemu-user-static gcc-powerpc-linux-gnu
+#     script:
+#       - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static
+#       - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static MOREFLAGS=-m64
+#
     - name: (Trusty) scan-build + cppcheck
       dist: trusty
       compiler: clang


### PR DESCRIPTION
We have same test in GitHub Actions.

Here're recent build logs of both CIs.

- travis-ci.org
  - [(Trusty) arm + aarch64 compilation](https://travis-ci.org/github/lz4/lz4/jobs/772917826)
  - [(Trusty) PowerPC + PPC64 compilation](https://travis-ci.org/github/lz4/lz4/jobs/772917832)

- GH-Actions
  - [ARM](https://github.com/lz4/lz4/runs/2703738559#step:5:1)
  - [ARM64](https://github.com/lz4/lz4/runs/2703738576#step:6:1)
  - [PPC](https://github.com/lz4/lz4/runs/2703738588#step:7:1)
  - [PPC64LE](https://github.com/lz4/lz4/runs/2703738601#step:8:1)
