### PR TITLE
Remove tests from `.travis.yml` (part 1/2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ matrix:
 #     script:
 #       - make -C tests test MOREFLAGS=-mx32
 #
-    # 14.04 LTS Server Edition 64 bit
-    # presume clang >= v3.9.0
-    - name: (Trusty) USan test
-      dist: trusty
-      compiler: clang
-      script:
-        - make usan MOREFLAGS=-Wcomma -Werror
-
+#   # 14.04 LTS Server Edition 64 bit
+#   # presume clang >= v3.9.0
+#   - name: (Trusty) USan test
+#     dist: trusty
+#     compiler: clang
+#     script:
+#       - make usan MOREFLAGS=-Wcomma -Werror
+#
     - name: (Trusty) valgrind test
       dist: trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ matrix:
 #       - make clean
 #       - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
 #
-    - name: (Precise) g++ and clang CMake test
-      dist: precise
-      script:
-        - make cxxtest
-        - make clean
-        - make examples
-        - make clean cmake
-        - make clean travis-install
-        - make clean clangtest
-
+#   - name: (Precise) g++ and clang CMake test
+#     dist: precise
+#     script:
+#       - make cxxtest
+#       - make clean
+#       - make examples
+#       - make clean cmake
+#       - make clean travis-install
+#       - make clean clangtest
+#
     - name: x32 compatibility test
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ matrix:
 #       - make clean travis-install
 #       - make clean clangtest
 #
-    - name: x32 compatibility test
-      addons:
-        apt:
-          packages:
-            - gcc-multilib
-      script:
-        - make -C tests test MOREFLAGS=-mx32
-
+#   - name: x32 compatibility test
+#     addons:
+#       apt:
+#         packages:
+#           - gcc-multilib
+#     script:
+#       - make -C tests test MOREFLAGS=-mx32
+#
     # 14.04 LTS Server Edition 64 bit
     # presume clang >= v3.9.0
     - name: (Trusty) USan test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ matrix:
 #       - make clean
 #       - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
 #
-    # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
-    - name: (Precise) benchmark test
-      dist: precise
-      script:
-        - make -C tests test-lz4 test-lz4c test-fullbench
-
+#   # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
+#   - name: (Precise) benchmark test
+#     dist: precise
+#     script:
+#       - make -C tests test-lz4 test-lz4c test-fullbench
+#
     - name: (Precise) frame and fuzzer test
       dist: precise
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ matrix:
 #     script:
 #       - make -C tests test-lz4 test-lz4c test-fullbench
 #
-    - name: (Precise) frame and fuzzer test
-      dist: precise
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - make -C tests test-frametest test-fuzzer
-
+#   - name: (Precise) frame and fuzzer test
+#     dist: precise
+#     install:
+#       - sudo sysctl -w vm.mmap_min_addr=4096
+#     script:
+#       - make -C tests test-frametest test-fuzzer
+#
     - name: ASAN tests with fuzzer and frametest
       install:
         - sudo sysctl -w vm.mmap_min_addr=4096

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ language: c
 matrix:
   fast_finish: true
   include:
-    # OS X Mavericks
-    - name: (macOS) General Test
-      os: osx
-      compiler: clang
-      script:
-        - make   # test library build
-        - make clean
-        - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
-
+#   # OS X Mavericks
+#   - name: (macOS) General Test
+#     os: osx
+#     compiler: clang
+#     script:
+#       - make   # test library build
+#       - make clean
+#       - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
+#
     # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
     - name: (Precise) benchmark test
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,16 @@ matrix:
 #     script:
 #       - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 #
-    - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
-      script:
-        - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
-        - make clean
-        - make -C programs lz4-wlib
-        - make clean
-        - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
-        - make clean
-        - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
-
+#   - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
+#     script:
+#       - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
+#       - make clean
+#       - make -C programs lz4-wlib
+#       - make clean
+#       - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
+#       - make clean
+#       - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
+#
     - name: (Precise) g++ and clang CMake test
       dist: precise
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ matrix:
 #     script:
 #       - make -C tests test-frametest test-fuzzer
 #
-    - name: ASAN tests with fuzzer and frametest
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
-
+#   - name: ASAN tests with fuzzer and frametest
+#     install:
+#       - sudo sysctl -w vm.mmap_min_addr=4096
+#     script:
+#       - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
+#
     - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
       script:
         - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check


### PR DESCRIPTION
This is a follow up PR of #996

This PR disables the following sections in `.travis.yml`

- (macOS) General Test
- (Precise) benchmark test
- (Precise) frame and fuzzer test
- ASAN tests with fuzzer and frametest
- Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
- (Precise) g++ and clang CMake test
- x32 compatibility test
- (Trusty) USan test

Each commit comment has corresponding part in new `.guthub/workflows/ci.yml`.
