### PR TITLE
Remove tests from .travis.yml (part 2/2) 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,20 +95,20 @@ matrix:
 #     script:
 #       - make -C tests test-frametest32 test-fuzzer32
 #
-    - name: (Trusty) gcc-6 standard C compilation
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-      env:
-        - CC=gcc-6
-      script:
-        - make c_standards
-        - make -C tests test-lz4 MOREFLAGS=-Werror
-
+#   - name: (Trusty) gcc-6 standard C compilation
+#     dist: trusty
+#     addons:
+#       apt:
+#         sources:
+#           - ubuntu-toolchain-r-test
+#         packages:
+#           - gcc-6
+#     env:
+#       - CC=gcc-6
+#     script:
+#       - make c_standards
+#       - make -C tests test-lz4 MOREFLAGS=-Werror
+#
 #   - name: (Trusty) arm + aarch64 compilation
 #     dist: trusty
 #     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,15 +165,15 @@ matrix:
 #       - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static
 #       - make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static MOREFLAGS=-m64
 #
-    - name: (Trusty) scan-build + cppcheck
-      dist: trusty
-      compiler: clang
-      install:
-        - sudo apt-get install -qq cppcheck
-      script:
-        - make staticAnalyze
-        - make cppcheck
-
+#   - name: (Trusty) scan-build + cppcheck
+#     dist: trusty
+#     compiler: clang
+#     install:
+#       - sudo apt-get install -qq cppcheck
+#     script:
+#       - make staticAnalyze
+#       - make cppcheck
+#
     - name: (Trusty) gcc-4.4 compilation
       dist: trusty
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ matrix:
 #     script:
 #       - make -C tests test MOREFLAGS=-mx32
 #
-    # 14.04 LTS Server Edition 64 bit
-    # presume clang >= v3.9.0
-    - name: (Trusty) USan test
-      dist: trusty
-      compiler: clang
-      script:
-        - make usan MOREFLAGS=-Wcomma -Werror
-
+#   # 14.04 LTS Server Edition 64 bit
+#   # presume clang >= v3.9.0
+#   - name: (Trusty) USan test
+#     dist: trusty
+#     compiler: clang
+#     script:
+#       - make usan MOREFLAGS=-Wcomma -Werror
+#
     - name: (Trusty) valgrind test
       dist: trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ matrix:
 #       - make clean
 #       - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
 #
-    - name: (Precise) g++ and clang CMake test
-      dist: precise
-      script:
-        - make cxxtest
-        - make clean
-        - make examples
-        - make clean cmake
-        - make clean travis-install
-        - make clean clangtest
-
+#   - name: (Precise) g++ and clang CMake test
+#     dist: precise
+#     script:
+#       - make cxxtest
+#       - make clean
+#       - make examples
+#       - make clean cmake
+#       - make clean travis-install
+#       - make clean clangtest
+#
     - name: x32 compatibility test
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ matrix:
 #       - make clean travis-install
 #       - make clean clangtest
 #
-    - name: x32 compatibility test
-      addons:
-        apt:
-          packages:
-            - gcc-multilib
-      script:
-        - make -C tests test MOREFLAGS=-mx32
-
+#   - name: x32 compatibility test
+#     addons:
+#       apt:
+#         packages:
+#           - gcc-multilib
+#     script:
+#       - make -C tests test MOREFLAGS=-mx32
+#
     # 14.04 LTS Server Edition 64 bit
     # presume clang >= v3.9.0
     - name: (Trusty) USan test

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,18 +145,18 @@ matrix:
 #     script:
 #       - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
 #
-    - name: (Trusty) clang-3.8 compilation
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.8
-          packages:
-            - clang-3.8
-      script:
-        - make -C tests test-lz4 CC=clang-3.8
-
+#   - name: (Trusty) clang-3.8 compilation
+#     dist: trusty
+#     addons:
+#       apt:
+#         sources:
+#           - ubuntu-toolchain-r-test
+#           - llvm-toolchain-precise-3.8
+#         packages:
+#           - clang-3.8
+#     script:
+#       - make -C tests test-lz4 CC=clang-3.8
+#
 #   - name: (Trusty) PowerPC + PPC64 compilation
 #     dist: trusty
 #     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ matrix:
 #       - make clean
 #       - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
 #
-    # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
-    - name: (Precise) benchmark test
-      dist: precise
-      script:
-        - make -C tests test-lz4 test-lz4c test-fullbench
-
+#   # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
+#   - name: (Precise) benchmark test
+#     dist: precise
+#     script:
+#       - make -C tests test-lz4 test-lz4c test-fullbench
+#
     - name: (Precise) frame and fuzzer test
       dist: precise
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,13 +138,13 @@ matrix:
       script:
         - make test
 
-    - name: (Xenial) gcc-5 compilation
-      dist: xenial
-      install:
-        - sudo apt-get install -qq libc6-dev-i386 gcc-multilib
-      script:
-        - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
-
+#   - name: (Xenial) gcc-5 compilation
+#     dist: xenial
+#     install:
+#       - sudo apt-get install -qq libc6-dev-i386 gcc-multilib
+#     script:
+#       - make -C tests test-lz4 clean test-lz4c32 MOREFLAGS=-Werror
+#
     - name: (Trusty) clang-3.8 compilation
       dist: trusty
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,20 +174,20 @@ matrix:
 #       - make staticAnalyze
 #       - make cppcheck
 #
-    - name: (Trusty) gcc-4.4 compilation
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - libc6-dev-i386
-            - gcc-multilib
-            - gcc-4.4
-      script:
-        - make clean all CC=gcc-4.4 MOREFLAGS=-Werror
-        - make clean
-        - CFLAGS=-fPIC LDFLAGS='-pie -fPIE -D_FORTIFY_SOURCE=2' make -C programs
+#   - name: (Trusty) gcc-4.4 compilation
+#     dist: trusty
+#     addons:
+#       apt:
+#         sources:
+#           - ubuntu-toolchain-r-test
+#         packages:
+#           - libc6-dev-i386
+#           - gcc-multilib
+#           - gcc-4.4
+#     script:
+#       - make clean all CC=gcc-4.4 MOREFLAGS=-Werror
+#       - make clean
+#       - CFLAGS=-fPIC LDFLAGS='-pie -fPIE -D_FORTIFY_SOURCE=2' make -C programs
 
     # tag-specific test
     - name: tag build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ matrix:
 #     script:
 #       - make -C tests test-lz4 test-lz4c test-fullbench
 #
-    - name: (Precise) frame and fuzzer test
-      dist: precise
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - make -C tests test-frametest test-fuzzer
-
+#   - name: (Precise) frame and fuzzer test
+#     dist: precise
+#     install:
+#       - sudo sysctl -w vm.mmap_min_addr=4096
+#     script:
+#       - make -C tests test-frametest test-fuzzer
+#
     - name: ASAN tests with fuzzer and frametest
       install:
         - sudo sysctl -w vm.mmap_min_addr=4096

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ language: c
 matrix:
   fast_finish: true
   include:
-    # OS X Mavericks
-    - name: (macOS) General Test
-      os: osx
-      compiler: clang
-      script:
-        - make   # test library build
-        - make clean
-        - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
-
+#   # OS X Mavericks
+#   - name: (macOS) General Test
+#     os: osx
+#     compiler: clang
+#     script:
+#       - make   # test library build
+#       - make clean
+#       - make test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee # test scenario where `stdout` is not the console
+#
     # Container-based 12.04 LTS Server Edition 64 bit (doesn't support 32-bit includes)
     - name: (Precise) benchmark test
       dist: precise

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,16 @@ matrix:
 #     script:
 #       - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
 #
-    - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
-      script:
-        - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
-        - make clean
-        - make -C programs lz4-wlib
-        - make clean
-        - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
-        - make clean
-        - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
-
+#   - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
+#     script:
+#       - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check
+#       - make clean
+#       - make -C programs lz4-wlib
+#       - make clean
+#       - make -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
+#       - make clean
+#       - CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc  # stricter function signature check
+#
     - name: (Precise) g++ and clang CMake test
       dist: precise
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,11 @@ matrix:
 #       - make c_standards
 #       - make -C tests test-lz4 test-mem
 #
-    - name: (Trusty) c-to-c++ test
-      dist: trusty
-      script:
-        - make ctocpptest
-
+#   - name: (Trusty) c-to-c++ test
+#     dist: trusty
+#     script:
+#       - make ctocpptest
+#
     - name: (Trusty) i386 benchmark + version test
       dist: trusty
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,14 +67,14 @@ matrix:
 #     script:
 #       - make usan MOREFLAGS=-Wcomma -Werror
 #
-    - name: (Trusty) valgrind test
-      dist: trusty
-      install:
-        - sudo apt-get install -qq valgrind
-      script:
-        - make c_standards
-        - make -C tests test-lz4 test-mem
-
+#   - name: (Trusty) valgrind test
+#     dist: trusty
+#     install:
+#       - sudo apt-get install -qq valgrind
+#     script:
+#       - make c_standards
+#       - make -C tests test-lz4 test-mem
+#
     - name: (Trusty) c-to-c++ test
       dist: trusty
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ matrix:
 #     script:
 #       - make -C tests test-frametest test-fuzzer
 #
-    - name: ASAN tests with fuzzer and frametest
-      install:
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
-
+#   - name: ASAN tests with fuzzer and frametest
+#     install:
+#       - sudo sysctl -w vm.mmap_min_addr=4096
+#     script:
+#       - CC=clang MOREFLAGS=-fsanitize=address make -C tests test-frametest test-fuzzer
+#
     - name: Custom LZ4_DISTANCE_MAX ; lz4-wlib (CLI linked to dynamic library); LZ4_USER_MEMORY_FUNCTIONS
       script:
         - MOREFLAGS=-DLZ4_DISTANCE_MAX=8000 make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,14 +87,14 @@ matrix:
 #     script:
 #       - make -C tests test-lz4c32 test-fullbench32 versionsTest
 #
-    - name: (Trusty) i386 frame + fuzzer test
-      dist: trusty
-      install:
-        - sudo apt-get install -qq libc6-dev-i386 gcc-multilib
-        - sudo sysctl -w vm.mmap_min_addr=4096
-      script:
-        - make -C tests test-frametest32 test-fuzzer32
-
+#   - name: (Trusty) i386 frame + fuzzer test
+#     dist: trusty
+#     install:
+#       - sudo apt-get install -qq libc6-dev-i386 gcc-multilib
+#       - sudo sysctl -w vm.mmap_min_addr=4096
+#     script:
+#       - make -C tests test-frametest32 test-fuzzer32
+#
     - name: (Trusty) gcc-6 standard C compilation
       dist: trusty
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,13 @@ matrix:
 #     script:
 #       - make ctocpptest
 #
-    - name: (Trusty) i386 benchmark + version test
-      dist: trusty
-      install:
-        - sudo apt-get install -qq python3 libc6-dev-i386 gcc-multilib
-      script:
-        - make -C tests test-lz4c32 test-fullbench32 versionsTest
-
+#   - name: (Trusty) i386 benchmark + version test
+#     dist: trusty
+#     install:
+#       - sudo apt-get install -qq python3 libc6-dev-i386 gcc-multilib
+#     script:
+#       - make -C tests test-lz4c32 test-fullbench32 versionsTest
+#
     - name: (Trusty) i386 frame + fuzzer test
       dist: trusty
       install:


### PR DESCRIPTION
This is a follow up PR of #997

This PR disables the following sections in `.travis.yml`

- (Trusty) valgrind test
- (Trusty) c-to-c++ test
- (Trusty) i386 benchmark + version test
- (Trusty) i386 frame + fuzzer test
- (Trusty) gcc-6 standard C compilation
- (Xenial) gcc-5 compilation
- (Trusty) clang-3.8 compilation
- (Trusty) scan-build + cppcheck
- (Trusty) gcc-4.4 compilation

All commit log indicates corresponding part in `ci.yml`.
