### PR TITLE
Fix package related GH-Actions errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
           # gcc
           { pkgs: '',                                                   cc: gcc,       cxx: g++,         stdc11: 'true',  stdc90: 'true',  x32: 'true',  x86: 'true', cxxtest: 'true',  os: ubuntu-latest, },
-          { pkgs: 'gcc-11 lib32gcc-11-dev libx32gcc-11-dev',            cc: gcc-11,    cxx: g++-11,      stdc11: 'true',  stdc90: 'true',  x32: 'fail',  x86: 'fail', cxxtest: 'true',  os: ubuntu-20.04,  },
+          { pkgs: 'gcc-11 g++-11 lib32gcc-11-dev libx32gcc-11-dev',     cc: gcc-11,    cxx: g++-11,      stdc11: 'true',  stdc90: 'true',  x32: 'fail',  x86: 'fail', cxxtest: 'true',  os: ubuntu-20.04,  },
           { pkgs: 'gcc-10 lib32gcc-10-dev libx32gcc-10-dev',            cc: gcc-10,    cxx: g++-10,      stdc11: 'true',  stdc90: 'true',  x32: 'true',  x86: 'true', cxxtest: 'true',  os: ubuntu-20.04,  },
           { pkgs: 'gcc-9  lib32gcc-9-dev  libx32gcc-9-dev',             cc: gcc-9,     cxx: g++-9,       stdc11: 'true',  stdc90: 'true',  x32: 'true',  x86: 'true', cxxtest: 'true',  os: ubuntu-20.04,  },
           { pkgs: 'gcc-8 g++-8 lib32gcc-8-dev libx32gcc-8-dev',         cc: gcc-8,     cxx: g++-8,       stdc11: 'true',  stdc90: 'true',  x32: 'true',  x86: 'true', cxxtest: 'true',  os: ubuntu-20.04,  },
@@ -80,6 +80,7 @@ jobs:
 
     - name: apt-get install
       run: |
+        sudo apt-get update
         sudo apt-get install gcc-multilib
         sudo apt-get install ${{ matrix.pkgs }}
 
@@ -171,7 +172,9 @@ jobs:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
 
     - name: apt-get install
-      run: sudo apt-get install gcc-multilib
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib
 
     - name: benchmark (-C tests test-lz4)
       run: make V=1 -C tests test-lz4
@@ -196,7 +199,9 @@ jobs:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
 
     - name: apt-get install
-      run: sudo apt-get install gcc-multilib
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib
 
     - name: setup
       run: sudo sysctl -w vm.mmap_min_addr=4096
@@ -215,7 +220,9 @@ jobs:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
 
     - name: apt-get install
-      run: sudo apt-get install gcc-multilib
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib
 
     - name: make -C tests versionsTest
       run: make V=1 -C tests versionsTest
@@ -228,7 +235,9 @@ jobs:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
 
     - name: apt-get install
-      run: sudo apt-get install gcc-multilib
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-multilib
 
     - name: LZ4 frame test
       run: make V=1 -C tests test-frametest
@@ -271,7 +280,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: apt-get install
-      run: sudo apt-get install cppcheck
+      run: |
+        sudo apt-get update
+        sudo apt-get install cppcheck
 
     - name: Environment info
       run: echo && type cppcheck && which cppcheck && cppcheck --version
@@ -288,7 +299,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: apt-get install
-      run: sudo apt-get install clang-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install clang-tools
 
     - name: Environment info
       run: |
@@ -308,7 +321,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: apt-get install
-      run: sudo apt-get install valgrind
+      run: |
+        sudo apt-get update
+        sudo apt-get install valgrind
 
     - name: Environment info
       run: |
@@ -346,6 +361,7 @@ jobs:
 
     - name: apt-get install
       run: |
+        sudo apt-get update
         sudo apt-get install gcc-multilib
         sudo apt-get install lib32gcc-11-dev
 
@@ -425,6 +441,7 @@ jobs:
 
     - name: apt-get install
       run: |
+        sudo apt-get update
         sudo apt-get install gcc-multilib
         sudo apt-get install qemu-utils qemu-user-static
         sudo apt-get install ${{ matrix.pkgs }}
@@ -564,6 +581,7 @@ jobs:
 
     - name: Install
       run: |
+        sudo apt-get update
         sudo apt-get install tree ninja-build
         python -m pip install --upgrade pip
         pip3 install --user meson
@@ -630,6 +648,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
+
+    - name: init
+      run: |
+        sudo apt-get update
 
     - name: cc --version
       run: echo && type cc && which cc && cc --version


### PR DESCRIPTION
Add explicit "apt-get update" for all test cases which uses "apt-get".
- It may help to stabilize fetching from apt archive.

As for "CC=gcc-11"
- Add "g++-11" package.
- "g++-11" [has been removed](https://github.com/actions/virtual-environments/issues/3467) from the default virtual environment.

This PR also fixes test errors which had been reported in #1001 .

Here's actual [test log](https://github.com/t-mat/lz4/runs/2835599388) of this PR.
