### PR TITLE
Add LZ4_free size param

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -73,6 +73,9 @@ The following build macro can be selected to adjust source code behavior at comp
   by user-defined functions, which must be called `LZ4_malloc()`, `LZ4_calloc()` and `LZ4_free()`.
   User functions must be available at link time.
 
+- `LZ4_FREE_ACCEPTS_SIZE` : this will require a user-provided LZ4_free function to accept a second argument,
+  a size_t representing the size of the block to be freed
+
 - `LZ4_FORCE_SW_BITCOUNT` : by default, the compression algorithm tries to determine lengths
   by using bitcount instructions, generally implemented as fast single instructions in many cpus.
   In case the target cpus doesn't support it, or compiler intrinsic doesn't work, or feature bad performance,

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -193,10 +193,18 @@
  * and be available at link time */
 void* LZ4_malloc(size_t s);
 void* LZ4_calloc(size_t n, size_t s);
+#ifdef LZ4_FREE_ACCEPTS_SIZE
 void  LZ4_free(void* p, size_t s);
+#else
+void  LZ4_free(void* p);
+#endif
 # define ALLOC(s)          LZ4_malloc(s)
 # define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
+#ifdef LZ4_FREE_ACCEPTS_SIZE
 # define FREEMEM(p)        LZ4_free(p,sizeof(*(p)))
+#else
+# define FREEMEM(p)        LZ4_free(p)
+#endif
 #else
 # include <stdlib.h>   /* malloc, calloc, free */
 # define ALLOC(s)          malloc(s)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -201,15 +201,15 @@ void  LZ4_free(void* p);
 # define ALLOC(s)          LZ4_malloc(s)
 # define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
 #ifdef LZ4_FREE_ACCEPTS_SIZE
-# define FREEMEM(p)        LZ4_free(p,sizeof(*(p)))
+# define FREEMEM(p,s)      LZ4_free((p),(s))
 #else
-# define FREEMEM(p)        LZ4_free(p)
+# define FREEMEM(p,s)      (void)(s); LZ4_free((p))
 #endif
 #else
 # include <stdlib.h>   /* malloc, calloc, free */
 # define ALLOC(s)          malloc(s)
 # define ALLOC_AND_ZERO(s) calloc(1,s)
-# define FREEMEM(p)        free(p)
+# define FREEMEM(p,s)      (void)(s); free((p))
 #endif
 
 #include <string.h>   /* memset, memcpy */
@@ -1376,7 +1376,7 @@ int LZ4_compress_fast(const char* source, char* dest, int inputSize, int maxOutp
     result = LZ4_compress_fast_extState(ctxPtr, source, dest, inputSize, maxOutputSize, acceleration);
 
 #if (LZ4_HEAPMODE)
-    FREEMEM(ctxPtr);
+    FREEMEM(ctxPtr, sizeof(LZ4_stream_t));
 #endif
     return result;
 }
@@ -1421,7 +1421,7 @@ int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targe
     int result = LZ4_compress_destSize_extState(ctx, src, dst, srcSizePtr, targetDstSize);
 
 #if (LZ4_HEAPMODE)
-    FREEMEM(ctx);
+    FREEMEM(ctx, sizeof(LZ4_stream_t));
 #endif
     return result;
 }
@@ -1478,7 +1478,7 @@ int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
 {
     if (!LZ4_stream) return 0;   /* support free on NULL */
     DEBUGLOG(5, "LZ4_freeStream %p", LZ4_stream);
-    FREEMEM(LZ4_stream);
+    FREEMEM(LZ4_stream, sizeof(LZ4_stream_t));
     return (0);
 }
 
@@ -2293,7 +2293,7 @@ LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
 {
     if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
-    FREEMEM(LZ4_stream);
+    FREEMEM(LZ4_stream, sizeof(LZ4_streamDecode_t));
     return 0;
 }
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -193,10 +193,10 @@
  * and be available at link time */
 void* LZ4_malloc(size_t s);
 void* LZ4_calloc(size_t n, size_t s);
-void  LZ4_free(void* p);
+void  LZ4_free(void* p, size_t s);
 # define ALLOC(s)          LZ4_malloc(s)
 # define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
-# define FREEMEM(p)        LZ4_free(p)
+# define FREEMEM(p)        LZ4_free(p,sizeof(*(p)))
 #else
 # include <stdlib.h>   /* malloc, calloc, free */
 # define ALLOC(s)          malloc(s)

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -524,9 +524,6 @@ void LZ4F_freeCDict(LZ4F_CDict* cdict)
 {
     if (cdict==NULL) return;  /* support free on NULL */
     LZ4F_freeCDictWithSize(cdict,  cdict->fastCtx->internal_donotuse.dictSize);
-    LZ4_freeStream(cdict->fastCtx);
-    LZ4_freeStreamHC(cdict->HCCtx);
-    FREEMEM(cdict, sizeof(LZ4F_CDict));
 }
 
 

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1474,8 +1474,8 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
             {   size_t const bufferNeeded = dctx->maxBlockSize
                     + ((dctx->frameInfo.blockMode==LZ4F_blockLinked) ? 128 KB : 0);
                 if (bufferNeeded > dctx->maxBufferSize) {   /* tmp buffers too small */
-                    FREEMEM(dctx->tmpIn, dctx->tmpInSize);
                     size_t maxBufferSize = dctx->maxBufferSize;
+                    FREEMEM(dctx->tmpIn, dctx->tmpInSize);
                     dctx->maxBufferSize = 0;   /* ensure allocation will be re-attempted on next entry*/
                     dctx->tmpIn = (BYTE*)ALLOC(dctx->maxBlockSize + BFSize /* block checksum */);
                     if (dctx->tmpIn == NULL)

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1475,7 +1475,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                     + ((dctx->frameInfo.blockMode==LZ4F_blockLinked) ? 128 KB : 0);
                 if (bufferNeeded > dctx->maxBufferSize) {   /* tmp buffers too small */
                     FREEMEM(dctx->tmpIn, dctx->tmpInSize);
-                    int maxBufferSize = dctx->maxBufferSize;
+                    size_t maxBufferSize = dctx->maxBufferSize;
                     dctx->maxBufferSize = 0;   /* ensure allocation will be re-attempted on next entry*/
                     dctx->tmpIn = (BYTE*)ALLOC(dctx->maxBlockSize + BFSize /* block checksum */);
                     if (dctx->tmpIn == NULL)

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -963,7 +963,7 @@ int LZ4_compress_HC(const char* src, char* dst, int srcSize, int dstCapacity, in
 #endif
     cSize = LZ4_compress_HC_extStateHC(statePtr, src, dst, srcSize, dstCapacity, compressionLevel);
 #if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
-    FREEMEM(statePtr);
+    FREEMEM(statePtr, sizeof(LZ4_streamHC_t));
 #endif
     return cSize;
 }
@@ -997,7 +997,7 @@ int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
 {
     DEBUGLOG(4, "LZ4_freeStreamHC(%p)", LZ4_streamHCPtr);
     if (!LZ4_streamHCPtr) return 0;  /* support free on NULL */
-    FREEMEM(LZ4_streamHCPtr);
+    FREEMEM(LZ4_streamHCPtr, sizeof(LZ4_streamHC_t));
     return 0;
 }
 
@@ -1228,7 +1228,7 @@ void* LZ4_createHC (const char* inputBuffer)
 int LZ4_freeHC (void* LZ4HC_Data)
 {
     if (!LZ4HC_Data) return 0;  /* support free on NULL */
-    FREEMEM(LZ4HC_Data);
+    FREEMEM(LZ4HC_Data, sizeof(LZ4_streamHC_t));
     return 0;
 }
 
@@ -1615,7 +1615,7 @@ if (limit == fillOutput) {
 }
 _return_label:
 #if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
-     FREEMEM(opt);
+     FREEMEM(opt, sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
 #endif
      return retval;
 }

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -160,7 +160,7 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 *********************************************************/
 void* LZ4_malloc(size_t s) { return malloc(s); }
 void* LZ4_calloc(size_t n, size_t s) { return calloc(n,s); }
-void  LZ4_free(void* p) { free(p); }
+void  LZ4_free(void* p, size_t s) { (void)s; free(p); }
 
 
 /*********************************************************

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -160,7 +160,7 @@ static size_t BMK_findMaxMem(U64 requiredMem)
 *********************************************************/
 void* LZ4_malloc(size_t s) { return malloc(s); }
 void* LZ4_calloc(size_t n, size_t s) { return calloc(n,s); }
-void  LZ4_free(void* p, size_t s) { (void)s; free(p); }
+void  LZ4_free(void* p) { free(p); }
 
 
 /*********************************************************


### PR DESCRIPTION
Certain environments have allocators that don't track allocation size and thus have deallocators that accept a size parameter  (e.g., IOMalloc/IOFree in macOS kernel).  This change will allow for a user-replaceable free function to accept an additional size parameter.