### PR TITLE
Expand use of pkg-config variables.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -175,6 +175,7 @@ liblz4.pc: liblz4.pc.in Makefile
          -e 's|@LIBDIR@|$(libdir)|' \
          -e 's|@INCLUDEDIR@|$(includedir)|' \
          -e 's|@VERSION@|$(LIBVER)|' \
+         -e 's|=${prefix}/|=$${prefix}/|' \
           $< >$@
 
 install: lib liblz4.pc

--- a/lib/liblz4.pc.in
+++ b/lib/liblz4.pc.in
@@ -10,5 +10,5 @@ Name: lz4
 Description: extremely fast lossless compression algorithm library
 URL: http://www.lz4.org/
 Version: @VERSION@
-Libs: -L@LIBDIR@ -llz4
-Cflags: -I@INCLUDEDIR@
+Libs: -L${libdir} -llz4
+Cflags: -I${includedir}


### PR DESCRIPTION
Change pkg-config generation (`liblz4.pc`) such that the path variables, not their values, are used in the definitions of `Libs` and `Cflags`, and that `$prefix` is substituted into `libdir` and `includedir` iff they start with its value.

To make the changes more clear, here's the the original output (excl. comments):
```
prefix=/usr/local
libdir=/usr/local/lib
includedir=/usr/local/include

Name: lz4
Description: extremely fast lossless compression algorithm library
URL: http://www.lz4.org/
Version: 1.9.3
Libs: -L/usr/local/lib -llz4
Cflags: -I/usr/local/include
```

The new output is:
```
prefix=/usr/local
libdir=${prefix}/lib
includedir=${prefix}/include

Name: lz4
Description: extremely fast lossless compression algorithm library
URL: http://www.lz4.org/
Version: 1.9.3
Libs: -L${libdir} -llz4
Cflags: -I${includedir}
```