### PR TITLE
fix clang-cl _tzcnt_u64 not defined issue

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -516,8 +516,14 @@ static unsigned LZ4_NbCommonBytes (reg_t val)
     if (LZ4_isLittleEndian()) {
         if (sizeof(val) == 8) {
 #       if defined(_MSC_VER) && (_MSC_VER >= 1800) && defined(_M_AMD64) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#         if defined(__clang__) && (__clang_major__ < 10)
+            /* Avoid undefined clang-cl intrinics issue.
+             * See https://github.com/lz4/lz4/pull/1017 for details. */
+            return (unsigned)__builtin_ia32_tzcnt_u64(val) >> 3;
+#         else
             /* x64 CPUS without BMI support interpret `TZCNT` as `REP BSF` */
             return (unsigned)_tzcnt_u64(val) >> 3;
+#         endif
 #       elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
             unsigned long r = 0;
             _BitScanForward64(&r, (U64)val);


### PR DESCRIPTION
When building with Clang-cl on Windows, `_tzcnt_u64` was not properly defined until https://bugs.llvm.org/show_bug.cgi?id=30506 was fixed. 

This PR works around the issue by directly using the builtin intrinsic when it is building with Clang on Windows.

----

**Test Plan:**

 To build lz4 with clang-cl on Windows (Before):

```
$ & 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat' x64
$ $Env:CC="C:\tools\toolchains\LLVM9.0.1\bin\clang-cl.exe"
$ make
make[1]: Entering directory 'C:/Users/zeyi/GitHub/lz4/lib'
compiling static library
clang-cl: warning: argument unused during compilation: '-O3' [-Wunused-command-line-argument]
lz4.c(523,30): warning: implicit declaration of function '_tzcnt_u64' is invalid in C99 [-Wimplicit-function-declaration]
            return (unsigned)_tzcnt_u64(val) >> 3;
                             ^
1 warning generated.
In file included from lz4hc.c:66:
./lz4.c(523,30): warning: implicit declaration of function '_tzcnt_u64' is invalid in C99 [-Wimplicit-function-declaration]
            return (unsigned)_tzcnt_u64(val) >> 3;
                             ^
1 warning generated.
creating library resource
/bin/sh: gcc: command not found
windres: preprocessing failed.
make[1]: *** [Makefile:112: liblz4-dll.o] Error 1
make[1]: Leaving directory 'C:/Users/zeyi/GitHub/lz4/lib'
make: *** [Makefile:57: lib-release] Error 2
```

With changes in this PR applied:

```
$ make
make[1]: Entering directory 'C:/Users/zeyi/GitHub/lz4/lib'
compiling static library
clang-cl: warning: argument unused during compilation: '-O3' [-Wunused-command-line-argument]
/bin/sh: gcc: command not found
windres: preprocessing failed.
make[1]: *** [Makefile:112: liblz4-dll.o] Error 1
make[1]: Leaving directory 'C:/Users/zeyi/GitHub/lz4/lib'
make: *** [Makefile:57: lib-release] Error 2
```

(Also a `lib/Makefile` change is required to make this actually work: changing `.o` to `.obj`)

Unfortunately I can't get the rest of the build working due to `windres` issues so I can't really run the test suite. :(
