### PR TITLE
nit(programs/platform.h): replace Unicode character #1018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -231,6 +231,12 @@ matrix:
     - name: Compile OSS-Fuzz targets
       script:
         - ./ossfuzz/travisoss.sh
+        
+    # Unicode lint
+    # See https://github.com/lz4/lz4/issues/1018
+    - name: Run Unicode lint
+      script:
+        - ./tests/unicode_lint.sh
 
   allow_failures:
     - env: ALLOW_FAILURES=true

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -80,7 +80,7 @@ extern "C" {
 ************************************************************** */
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__)) /* UNIX-like OS */ \
    || defined(__midipix__) || defined(__VMS))
-#  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1–2001 (SUSv3) conformant */ \
+#  if (defined(__APPLE__) && defined(__MACH__)) || defined(__SVR4) || defined(_AIX) || defined(__hpux) /* POSIX.1-2001 (SUSv3) conformant */ \
      || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)  || defined(__MidnightBSD__) /* BSD distros */ \
      || defined(__HAIKU__)
 #    define PLATFORM_POSIX_VERSION 200112L

--- a/tests/unicode_lint.sh
+++ b/tests/unicode_lint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# `unicode_lint.sh' determines whether source files under the ./lib/ and ./programs/ directories
+# contain Unicode characters, and fails if any do.
+#
+# See https://github.com/lz4/lz4/issues/1018
+
+pass=true
+
+# Scan ./lib/ for Unicode in source (*.c, *.h) files
+result=$(
+	find ./lib/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "FAIL: {}" \;
+)
+if [[ $result ]]; then
+	echo "$result"
+	pass=false
+fi
+
+# Scan ./programs/ for Unicode in source (*.c, *.h) files
+result=$(
+	find ./programs/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "{}: FAIL" \;
+)
+if [[ $result ]]; then
+	echo "$result"
+	pass=false
+fi
+
+if [ "$pass" = true ]; then
+	echo "All tests successful."
+	echo "Result: PASS"
+	exit 0
+else
+	echo "Result: FAIL"
+	exit 1
+fi

--- a/tests/unicode_lint.sh
+++ b/tests/unicode_lint.sh
@@ -9,7 +9,7 @@ pass=true
 
 # Scan ./lib/ for Unicode in source (*.c, *.h) files
 result=$(
-	find ./lib/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "FAIL: {}" \;
+	find ./lib/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "{}: FAIL" \;
 )
 if [[ $result ]]; then
 	echo "$result"


### PR DESCRIPTION
On line 83 of `programs/platform.h`, <kbd>U+2013</kbd> was replaced with <kbd>U+002D</kbd> in order to improve compatibility with MSVC 2019 and older compilers. Fixes #1018.

#### Note
Unicode is also present in `examples/frameCompress.c`:
https://github.com/lz4/lz4/blob/de45d6e0fa59e1c5dc21f611dd73f91ba04aaff1/examples/frameCompress.c#L2
https://github.com/lz4/lz4/blob/de45d6e0fa59e1c5dc21f611dd73f91ba04aaff1/examples/frameCompress.c#L359