### PR TITLE
ci: merge unicode lint to github actions and expand test coverage to ./tests/ directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: unicode lint
-      run: sh ./tests/unicode_lint.sh
+      run: bash ./tests/unicode_lint.sh
 
 
 ###############################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
 # - valgrind
 # - ubsan
 # - asan
+# - unicode-lint
 #
   lz4-cppcheck:
     name: make cppcheck
@@ -382,6 +383,15 @@ jobs:
     - name: fuzzer
       run: CC=clang MOREFLAGS=-fsanitize=address make V=1 -C tests clean test-fuzzer
 
+  unicode-lint:
+    name: lint unicode in ./lib/, ./tests/ and ./programs/
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+    - name: unicode lint
+      run: |
+      chmod +x ./tests/unicode_lint.sh
+      ./tests/unicode_lint.sh
 
 
 ###############################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,9 +389,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: unicode lint
-      run: |
-      chmod +x ./tests/unicode_lint.sh
-      ./tests/unicode_lint.sh
+      run: ./tests/unicode_lint.sh
 
 
 ###############################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # https://github.com/actions/checkout
     - name: unicode lint
-      run: ./tests/unicode_lint.sh
+      run: sh ./tests/unicode_lint.sh
 
 
 ###############################################################

--- a/tests/unicode_lint.sh
+++ b/tests/unicode_lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# `unicode_lint.sh' determines whether source files under the ./lib/ and ./programs/ directories
+# `unicode_lint.sh' determines whether source files under the ./lib/, ./tests/ and ./programs/ directories
 # contain Unicode characters, and fails if any do.
 #
 # See https://github.com/lz4/lz4/issues/1018
@@ -10,6 +10,15 @@ pass=true
 # Scan ./lib/ for Unicode in source (*.c, *.h) files
 result=$(
 	find ./lib/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "{}: FAIL" \;
+)
+if [[ $result ]]; then
+	echo "$result"
+	pass=false
+fi
+
+# Scan ./tests/ for Unicode in source (*.c, *.h) files
+result=$(
+	find ./tests/ -regex '.*\.\(c\|h\)$' -exec grep -P -n "[^\x00-\x7F]" {} \; -exec echo "{}: FAIL" \;
 )
 if [[ $result ]]; then
 	echo "$result"


### PR DESCRIPTION
A unicode lint action was added to the Github workflow, since Travis CI is nonoperational, and the unicode lint was expanded to lint source files (`*.c`, `*.h`) under the `./tests` directory. Expands on changes made in #1019.

/ref #1018 