### PR TITLE
examples: simple_buffer: We must explicit convert pointer after mallo…

### DIFF
--- a/examples/simple_buffer.c
+++ b/examples/simple_buffer.c
@@ -44,7 +44,7 @@ int main(void) {
   // LZ4 provides a function that will tell you the maximum size of compressed output based on input data via LZ4_compressBound().
   const int max_dst_size = LZ4_compressBound(src_size);
   // We will use that size for our destination boundary when allocating space.
-  char* compressed_data = malloc((size_t)max_dst_size);
+  char* compressed_data = (char*)malloc((size_t)max_dst_size);
   if (compressed_data == NULL)
     run_screaming("Failed to allocate memory for *compressed_data.", 1);
   // That's all the information and preparation LZ4 needs to compress *src into *compressed_data.
@@ -73,7 +73,7 @@ int main(void) {
   // Sometimes, the metadata can be extracted from the local context.
 
   // First, let's create a *new_src location of size src_size since we know that value.
-  char* const regen_buffer = malloc(src_size);
+  char* const regen_buffer = (char*)malloc(src_size);
   if (regen_buffer == NULL)
     run_screaming("Failed to allocate memory for *regen_buffer.", 1);
   // The LZ4_decompress_safe function needs to know where the compressed data is, how many bytes long it is,


### PR DESCRIPTION
…c in c++

Aim: To adapt C++

Compilation errors:
simple_buffer.c:47:9: error: cannot initialize a variable of type 'char *' with an rvalue of type 'void *'
  char* compressed_data = malloc((size_t)max_dst_size);
        ^                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
simple_buffer.c:76:15: error: cannot initialize a variable of type 'char *const' with an rvalue of type 'void *'
  char* const regen_buffer = malloc(src_size);
              ^              ~~~~~~~~~~~~~~~~
2 errors generated.

Generally, we need code that can be used in C and C++.I think this change will bring a better experience for visitors.

If this is unnecessary, please close this PR :)