### PR TITLE
[NO COMMIT][Hackathon] LZ4 decoder in assembly

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 # ################################################################
-# LZ4 library - Makefile
+
 # Copyright (C) Yann Collet 2011-2020
 # All rights reserved.
 #
@@ -31,7 +31,7 @@
 #  - LZ4 source repository : https://github.com/lz4/lz4
 #  - LZ4 forum froup : https://groups.google.com/forum/#!forum/lz4c
 # ################################################################
-SED = sed
+SED = sedjk
 
 # Version numbers
 LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`
@@ -55,7 +55,7 @@ DEBUGFLAGS:= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
 CFLAGS  += $(DEBUGFLAGS)
 FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
-SRCFILES := $(sort $(wildcard *.c))
+SRCFILES := $(sort $(wildcard *.c) $(wildcard *.S))
 
 include ../Makefile.inc
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 # ################################################################
-
+# LZ4 library - Makefile
 # Copyright (C) Yann Collet 2011-2020
 # All rights reserved.
 #
@@ -31,7 +31,7 @@
 #  - LZ4 source repository : https://github.com/lz4/lz4
 #  - LZ4 forum froup : https://groups.google.com/forum/#!forum/lz4c
 # ################################################################
-SED = sedjk
+SED = sed
 
 # Version numbers
 LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < ./lz4.h`

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -961,7 +961,6 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType, base);
 
             } while ( (match+LZ4_DISTANCE_MAX < ip)
-                   || (ip - match < 16)
                    || (LZ4_read32(match) != LZ4_read32(ip)) );
 
         } else {   /* byU32, byU16 */
@@ -1012,7 +1011,6 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
 
                 DEBUGLOG(7, "candidate at pos=%u  (offset=%u \n", matchIndex, current - matchIndex);
-                if (current - matchIndex < 16) continue;
                 if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) { continue; }    /* match outside of valid area */
                 assert(matchIndex < current);
                 if ( ((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX))
@@ -1166,7 +1164,6 @@ _next_match:
             match = LZ4_getPosition(ip, cctx->hashTable, tableType, base);
             LZ4_putPosition(ip, cctx->hashTable, tableType, base);
             if ( (match+LZ4_DISTANCE_MAX >= ip)
-              && (ip - match >= 16)
               && (LZ4_read32(match) == LZ4_read32(ip)) )
             { token=op++; *token=0; goto _next_match; }
 
@@ -1203,8 +1200,7 @@ _next_match:
             assert(matchIndex < current);
             if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
               && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
-              && (LZ4_read32(match) == LZ4_read32(ip))
-              && (ip - match >= 16)) {
+              && (LZ4_read32(match) == LZ4_read32(ip))) {
                 token=op++;
                 *token=0;
                 if (maybe_extMem) offset = current - matchIndex;
@@ -1829,8 +1825,7 @@ LZ4_decompress_generic(
             goto safe_decode;
         }
 
-        if (    1 &&
-                (iend - ip) >= FASTLOOP_SAFE_DISTANCE &&
+        if (    (iend - ip) >= FASTLOOP_SAFE_DISTANCE &&
                 endOnInput == endOnInputSize &&
                 partialDecoding == decode_full_block &&
                 dict == noDict) {

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -31,7 +31,6 @@
     - LZ4 homepage : http://www.lz4.org
     - LZ4 source repository : https://github.com/lz4/lz4
 */
-#include <stdio.h>
 
 /*-************************************
 *  Tuning parameters
@@ -239,9 +238,6 @@ static const int LZ4_minLength = (MFLIMIT+1);
 /*-************************************
 *  Error detection
 **************************************/
-#ifndef LZ4_DEBUG
-#define LZ4_DEBUG 0
-#endif
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
 #  include <assert.h>
 #else
@@ -1200,7 +1196,7 @@ _next_match:
             assert(matchIndex < current);
             if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
               && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
-              && (LZ4_read32(match) == LZ4_read32(ip))) {
+              && (LZ4_read32(match) == LZ4_read32(ip)) ) {
                 token=op++;
                 *token=0;
                 if (maybe_extMem) offset = current - matchIndex;
@@ -1834,18 +1830,11 @@ LZ4_decompress_generic(
             args.iend = iend;
             args.op = op;
             args.oend = oend;
-        #if LZ4_DEBUG >= 1
-            fprintf(stderr, "0x%p=istart=ip\n0x%p=ostart=op\n0x%p=iend\n0x%p=oend\n%zu=isize\n%zu=osize\n", ip, op, iend, oend, (size_t)(iend - ip), (size_t)(oend - op));
-        #endif
             {
                 int const fail = LZ4_decompress_asm_loop(&args);
                 op = args.op;
                 ip = args.ip;
-        #if LZ4_DEBUG >= 1
-                fprintf(stderr, "0x%p=istart=ip\n0x%p=ostart=op\n0x%p=iend\n0x%p=oend\n%zu=isize\n%zu=osize\n", ip, op, iend, oend, (size_t)(iend - ip), (size_t)(oend - op));
-        #endif
                 if (fail) {
-                    fprintf(stderr, "Failed!\n");
                     goto _output_error;
                 }
             }
@@ -1903,7 +1892,6 @@ LZ4_decompress_generic(
             offset = LZ4_readLE16(ip); ip+=2;
             match = op - offset;
             assert(match <= op);
-            assert(offset >= 16);
 
             /* get matchlength */
             length = token & ML_MASK;

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -1,12 +1,10 @@
 .global LZ4_decompress_asm_loop
 .text
-
 #define ip	rcx
 #define op	rdx
 #define ilimit	r8
 #define olimit	r9
 #define ostart	r10
-#define oend	r11
 
 #define LIMIT	64
 
@@ -42,19 +40,21 @@ LZ4_decompress_asm_loop:
 	movq 0(%rdi), %ip
 	movq 8(%rdi), %op
 	movq 16(%rdi), %ilimit
-	movq 24(%rdi), %oend
+	movq 24(%rdi), %olimit
 
 	push %rdi
 
-	movq %oend, %olimit
 	subq $LIMIT, %ilimit
 	subq $LIMIT, %olimit
+
+	leaq pattern_forward(%rip), %r14
+	leaq pattern(%rip), %r15
 
 	movq %op, %ostart
 
 .L_match_copied:
-	movq %ip, %r13
-	movq %op, %r14
+	movq %ip, %r12
+	movq %op, %r13
 	/* Load the token */
 	movzbq 0(%ip), %rax
 	addq $1, %ip
@@ -82,18 +82,18 @@ LZ4_decompress_asm_loop:
 
 .L_literals_copied:
 	movq %op, %rsi
-	movzwq 0(%ip), %rdi
+	movzwq 0(%ip), %r11
 	addq $2, %ip
-	subq %rdi, %rsi
+	subq %r11, %rsi
 
 	cmpq %ostart, %rsi
 	jb .L_output_error
 
-	/* TOOD: Handle short offsets */
 	cmpq $0xF, %rbx
 	je .L_long_match_length
 
-	addq $4, %rbx
+	cmpq $16, %r11
+	jb copy_short_offset
 
 	movdqu 0(%rsi), %xmm0
 	movups %xmm0, 0(%op)
@@ -101,6 +101,25 @@ LZ4_decompress_asm_loop:
 	movw %di, 16(%op)
 
 	addq %rbx, %op
+	addq $4,   %op
+
+	cmpq %op, %olimit
+	jb .L_exit_success
+
+	jmp .L_match_copied
+
+copy_short_offset:
+	salq $4, %r11
+	movdqu 0(%rsi), %xmm0
+	vpshufb (%r15, %r11), %xmm0, %xmm0
+	addq (%r14, %r11), %rsi
+
+	movdqu %xmm0, 0(%op)
+	movzwq 0(%rsi), %rdi
+	movw %di, 16(%op)
+
+	addq %rbx, %op
+	addq $4,   %op
 
 	cmpq %op, %olimit
 	jb .L_exit_success
@@ -166,6 +185,9 @@ very_long_literal_length:
 	cmpq %op, %olimit
 	jb .L_rewind_sequence
 
+	cmpq $16, %r11
+	jb copy_short_offset_loop_header
+
 	/* TODO: Handle short offsets */
 
 .L_match_copy_loop:
@@ -180,6 +202,15 @@ very_long_literal_length:
 	jb .L_match_copy_loop
 
 	jmp .L_match_copied
+
+copy_short_offset_loop_header:
+	salq $4, %r11
+	movdqu 0(%rsi), %xmm0
+	vpshufb (%r15, %r11), %xmm0, %xmm0
+	movdqu %xmm0, 0(%rdi)
+	addq (%r14, %r11), %rsi
+	addq $16, %rdi
+	jmp .L_match_copy_loop
 
 very_long_match_length:
 	movzbq 0(%ip), %rdi
@@ -200,8 +231,8 @@ very_long_match_length:
 	jmp .L_exit_success
 
 .L_rewind_sequence:
-	movq %r13, %ip
-	movq %r14, %op
+	movq %r12, %ip
+	movq %r13, %op
 	jmp .L_exit_success
 
 .L_output_error:
@@ -239,5 +270,300 @@ very_long_match_length:
 	ret
 
 #ifndef NDEBUG
-.assert_fail:
+.L_assert_fail:
 #endif
+        .section        .rodata
+	.align 8
+pattern_forward:
+	.quad 0 /* 0 */
+	.quad 0 /* padding */
+	.quad 0 /* 1 */
+	.quad 0 /* padding */
+	.quad 0 /* 2 */
+	.quad 0 /* padding */
+	.quad 1 /* 3 */
+	.quad 0 /* padding */
+	.quad 0 /* 4 */
+	.quad 0 /* padding */
+	.quad 1 /* 5 */
+	.quad 0 /* padding */
+	.quad 4 /* 6 */
+	.quad 0 /* padding */
+	.quad 2 /* 7 */
+	.quad 0 /* padding */
+	.quad 0 /* 8 */
+	.quad 0 /* padding */
+	.quad 7 /* 9 */
+	.quad 0 /* padding */
+	.quad 6 /* 10 */
+	.quad 0 /* padding */
+	.quad 5 /* 11 */
+	.quad 0 /* padding */
+	.quad 4 /* 12 */
+	.quad 0 /* padding */
+	.quad 3 /* 13 */
+	.quad 0 /* padding */
+	.quad 2 /* 14 */
+	.quad 0 /* padding */
+	.quad 1 /* 15 */
+	.align 16
+pattern:
+	.quad   0 /* padding */
+	.quad   0 /* padding */
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   0
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   11
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   11
+        .byte   12
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   11
+        .byte   12
+        .byte   13
+        .byte   0
+        .byte   1
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   11
+        .byte   12
+        .byte   13
+        .byte   14
+        .byte   0
+        .byte   0
+        .byte   1
+        .byte   2
+        .byte   3
+        .byte   4
+        .byte   5
+        .byte   6
+        .byte   7
+        .byte   8
+        .byte   9
+        .byte   10
+        .byte   11
+        .byte   12
+        .byte   13
+        .byte   14
+        .byte   15
+	.text

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -93,7 +93,9 @@ LZ4_decompress_asm_loop:
 	je .L_long_match_length
 
 	cmpq $16, %r11
-	jb copy_short_offset
+	jb .L_copy_short_offset
+
+	addq $4, %rbx
 
 	movdqu 0(%rsi), %xmm0
 	movups %xmm0, 0(%op)
@@ -101,14 +103,14 @@ LZ4_decompress_asm_loop:
 	movw %di, 16(%op)
 
 	addq %rbx, %op
-	addq $4,   %op
 
 	cmpq %op, %olimit
 	jb .L_exit_success
 
 	jmp .L_match_copied
 
-copy_short_offset:
+.L_copy_short_offset:
+	addq $4, %rbx
 	salq $4, %r11
 	movdqu 0(%rsi), %xmm0
 	vpshufb (%r15, %r11), %xmm0, %xmm0
@@ -119,7 +121,6 @@ copy_short_offset:
 	movw %di, 16(%op)
 
 	addq %rbx, %op
-	addq $4,   %op
 
 	cmpq %op, %olimit
 	jb .L_exit_success
@@ -132,7 +133,7 @@ copy_short_offset:
 	addq $1, %ip
 
 	cmpq $0xFF, %rsi
-	je very_long_literal_length
+	je .L_very_long_literal_length
 
 .L_literal_length_computed:
 	movq %ip, %rsi
@@ -158,14 +159,14 @@ copy_short_offset:
 
 	jmp .L_literals_copied
 
-very_long_literal_length:
+.L_very_long_literal_length:
 	movzbq 0(%ip), %rdi
 	addq %rdi, %rax
 	addq $1, %ip
 	cmpq %ip, %ilimit
 	jb .L_rewind_sequence
 	cmpq $0xFF, %rdi
-	je very_long_literal_length
+	je .L_very_long_literal_length
 
 	jmp .L_literal_length_computed
 
@@ -176,7 +177,7 @@ very_long_literal_length:
 	addq $1, %ip
 
 	cmpq $0xFF, %rdi
-	je very_long_match_length
+	je .L_very_long_match_length
 
 .L_match_length_computed:
 	movq %op, %rdi
@@ -186,7 +187,7 @@ very_long_literal_length:
 	jb .L_rewind_sequence
 
 	cmpq $16, %r11
-	jb copy_short_offset_loop_header
+	jb .L_copy_short_offset_loop_header
 
 	/* TODO: Handle short offsets */
 
@@ -203,7 +204,7 @@ very_long_literal_length:
 
 	jmp .L_match_copied
 
-copy_short_offset_loop_header:
+.L_copy_short_offset_loop_header:
 	salq $4, %r11
 	movdqu 0(%rsi), %xmm0
 	vpshufb (%r15, %r11), %xmm0, %xmm0
@@ -212,14 +213,14 @@ copy_short_offset_loop_header:
 	addq $16, %rdi
 	jmp .L_match_copy_loop
 
-very_long_match_length:
+.L_very_long_match_length:
 	movzbq 0(%ip), %rdi
 	addq %rdi, %rbx
 	addq $1, %ip
 	cmpq %ip, %ilimit
 	jb .L_rewind_sequence
 	cmpq $0xFF, %rdi
-	je very_long_match_length
+	je .L_very_long_match_length
 
 	jmp .L_match_length_computed
 

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -172,8 +172,8 @@ LZ4_decompress_asm_loop:
 
 .L_long_match_length:
 	movzbq 0(%ip), %rdi
-	addq %rdi, %rbx
 	addq $4, %rbx
+	addq %rdi, %rbx
 	addq $1, %ip
 
 	cmpq $0xFF, %rdi

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -63,9 +63,8 @@ LZ4_decompress_asm_loop:
 	/* %rax = literal length */
 	/* %rbx = match length */
 	movq %rax, %rbx
-	shrq $4, %rax
-	andq $0xF, %rbx
 
+	shrq $4, %rax
 	cmpq $0xF, %rax
 	je .L_long_literal_length
 
@@ -89,6 +88,7 @@ LZ4_decompress_asm_loop:
 	cmpq %ostart, %rsi
 	jb .L_output_error
 
+	andq $0xF, %rbx
 	cmpq $0xF, %rbx
 	je .L_long_match_length
 

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -189,15 +189,15 @@ LZ4_decompress_asm_loop:
 	cmpq $16, %r11
 	jb .L_copy_short_offset_loop_header
 
-	/* TODO: Handle short offsets */
-
 .L_match_copy_loop:
 	movdqu  0(%rsi), %xmm0
 	movups %xmm0,  0(%rdi)
-	movdqu 16(%rsi), %xmm0
-	movups %xmm0, 16(%rdi)
-	addq $32, %rsi
-	addq $32, %rdi
+	movdqu 16(%rsi), %xmm1
+	movups %xmm1, 16(%rdi)
+	movdqu 32(%rsi), %xmm2
+	movups %xmm2, 32(%rdi)
+	addq $48, %rsi
+	addq $48, %rdi
 
 	cmpq %op, %rdi
 	jb .L_match_copy_loop

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -6,21 +6,34 @@
 #define ilimit	r8
 #define olimit	r9
 #define ostart	r10
+#define oend	r11
 
 #define LIMIT	64
 
+#ifndef NDEBUG
+
+#define assert_le(r1, r2)
+
+#else
+
+#define assert_le(r1, r2)
+
+#endif
+
+
+
 LZ4_decompress_asm_loop:
-	# push %rax
+	/* push %rax */
 	push %rbx
-	# push %rcx
-	# push %rdx
+	/* push %rcx */
+	/* push %rdx */
 	push %rbp
-	# push %rsi
-	# push %rdi
-	# push %r8
-	# push %r9
-	# push %r10
-	# push %r11
+	/* push %rsi */
+	/* push %rdi */
+	/* push %r8 */
+	/* push %r9 */
+	/* push %r10 */
+	/* push %r11 */
 	push %r12
 	push %r13
 	push %r14
@@ -28,33 +41,36 @@ LZ4_decompress_asm_loop:
 
 	movq 0(%rdi), %ip
 	movq 8(%rdi), %op
-	movq 16(%rdi), %iend
+	movq 16(%rdi), %ilimit
 	movq 24(%rdi), %oend
 
 	push %rdi
 
-	subq $LIMIT, %iend
-	subq $LIMIT, %oend
+	movq %oend, %olimit
+	subq $LIMIT, %ilimit
+	subq $LIMIT, %olimit
 
 	movq %op, %ostart
 
-.loop:
-	# Load the token
-	movzbl 0(%ip), %rax
+.L_match_copied:
+	movq %ip, %r13
+	movq %op, %r14
+	/* Load the token */
+	movzbq 0(%ip), %rax
 	addq $1, %ip
 
-	# Load the literal length and match length
-	# %rax = literal length
-	# %rbx = match length
+	/* Load the literal length and match length */
+	/* %rax = literal length */
+	/* %rbx = match length */
 	movq %rax, %rbx
 	shrq $4, %rax
 	andq $0xF, %rbx
 
-	cmpq %rax, $0xF
-	je .long_literal_length
+	cmpq $0xF, %rax
+	je .L_long_literal_length
 
-	# %rax = literal length
-	# There is enough space to decode the literals < 15 bytes
+	/* %rax = literal length */
+	/* There is enough space to decode the literals < 15 bytes */
 	movdqu 0(%ip), %xmm0
 	movups %xmm0, 0(%op)
 
@@ -62,64 +78,166 @@ LZ4_decompress_asm_loop:
 	addq %rax, %op
 
 	cmpq %ip, %ilimit
-	jb .exit
+	jb .L_rewind_sequence
 
-.literals_copied:
+.L_literals_copied:
 	movq %op, %rsi
-	movzwl %ip, %rdi
+	movzwq 0(%ip), %rdi
 	addq $2, %ip
 	subq %rdi, %rsi
 
 	cmpq %ostart, %rsi
-	jb .output_error
+	jb .L_output_error
 
-	cmpq %rbx, $0xF
-	je .long_match_length
+	/* TOOD: Handle short offsets */
+	cmpq $0xF, %rbx
+	je .L_long_match_length
+
+	addq $4, %rbx
 
 	movdqu 0(%rsi), %xmm0
-	movzwl 16(%rsi), %rdi
 	movups %xmm0, 0(%op)
-	movw %rdi, 16(%op)
+	movzwq 16(%rsi), %rdi
+	movw %di, 16(%op)
 
 	addq %rbx, %op
 
 	cmpq %op, %olimit
-	jb .exit
+	jb .L_exit_success
 
-.match_copied:
+	jmp .L_match_copied
 
-	movq $0, %rax
-	jmp .exit
+.L_long_literal_length:
+	movzbq 0(%ip), %rsi
+	addq %rsi, %rax
+	addq $1, %ip
 
-.long_literal_length:
-	jmp .literals_copied
+	cmpq $0xFF, %rsi
+	je very_long_literal_length
 
-.long_match_length:
-	jmp .match_copied
+.L_literal_length_computed:
+	movq %ip, %rsi
+	movq %op, %rdi
+	addq %rax, %ip
+	addq %rax, %op
 
+	cmpq %ip, %ilimit
+	jb .L_rewind_sequence
+	cmpq %op, %olimit
+	jb .L_rewind_sequence
 
-.output_error:
+.L_literal_copy_loop:
+	movdqu  0(%rsi), %xmm0
+	movdqu 16(%rsi), %xmm1
+	addq $32, %rsi
+	movups %xmm0,  0(%rdi)
+	movups %xmm1, 16(%rdi)
+	addq $32, %rdi
+
+	cmpq %ip, %rsi
+	jb .L_literal_copy_loop
+
+	jmp .L_literals_copied
+
+very_long_literal_length:
+	movzbq 0(%ip), %rdi
+	addq %rdi, %rax
+	addq $1, %ip
+	cmpq %ip, %ilimit
+	jb .L_rewind_sequence
+	cmpq $0xFF, %rdi
+	je very_long_literal_length
+
+	jmp .L_literal_length_computed
+
+.L_long_match_length:
+	movzbq 0(%ip), %rdi
+	addq %rdi, %rbx
+	addq $4, %rbx
+	addq $1, %ip
+
+	cmpq $0xFF, %rdi
+	je very_long_match_length
+
+.L_match_length_computed:
+	movq %op, %rdi
+	addq %rbx, %op
+
+	cmpq %op, %olimit
+	jb .L_rewind_sequence
+
+	/* TODO: Handle short offsets */
+
+.L_match_copy_loop:
+	movdqu  0(%rsi), %xmm0
+	movups %xmm0,  0(%rdi)
+	movdqu 16(%rsi), %xmm0
+	movups %xmm0, 16(%rdi)
+	addq $32, %rsi
+	addq $32, %rdi
+
+	cmpq %op, %rdi
+	jb .L_match_copy_loop
+
+	jmp .L_match_copied
+
+very_long_match_length:
+	movzbq 0(%ip), %rdi
+	addq %rdi, %rbx
+	addq $1, %ip
+	cmpq %ip, %ilimit
+	jb .L_rewind_sequence
+	cmpq $0xFF, %rdi
+	je very_long_match_length
+
+	jmp .L_match_length_computed
+
+.L_very_long_match_length_too_long:
+	movq %r12, %ip
+	subq $4, %ip
+	subq %rax, %ip
+	subq %rax, %op
+	jmp .L_exit_success
+
+.L_rewind_sequence:
+	movq %r13, %ip
+	movq %r14, %op
+	jmp .L_exit_success
+
+.L_output_error:
 	movq $1, %rax
-	jmp .exit
+	jmp .L_exit
 
-.exit:
+.L_exit_success:
+	movq $0, %rax
+	jmp .L_exit
+
+.L_exit:
 	pop %rdi
 	movq %ip, 0(%rdi)
 	movq %op, 8(%rdi)
 
-	# Restore registers
+	/* Restore registers */
 	pop %r15
 	pop %r14
 	pop %r13
 	pop %r12
-	# pop %r11
-	# pop %r10
-	# pop %r9
-	# pop %r8
-	# pop %rdi
-	# pop %rsi
+	/* pop %r11
+	 * pop %r10
+	 * pop %r9
+	 * pop %r8
+	 * pop %rdi
+	 * pop %rsi
+	 */
 	pop %rbp
-	# pop %rdx
-	# pop %rcx
+	/* pop %rdx
+	 * pop %rcx
+	 */
 	pop %rbx
-	# pop %rax
+	/* pop %rax */
+
+	ret
+
+#ifndef NDEBUG
+.assert_fail:
+#endif

--- a/lib/lz4_decompress_x86_64_asm.S
+++ b/lib/lz4_decompress_x86_64_asm.S
@@ -1,0 +1,125 @@
+.global LZ4_decompress_asm_loop
+.text
+
+#define ip	rcx
+#define op	rdx
+#define ilimit	r8
+#define olimit	r9
+#define ostart	r10
+
+#define LIMIT	64
+
+LZ4_decompress_asm_loop:
+	# push %rax
+	push %rbx
+	# push %rcx
+	# push %rdx
+	push %rbp
+	# push %rsi
+	# push %rdi
+	# push %r8
+	# push %r9
+	# push %r10
+	# push %r11
+	push %r12
+	push %r13
+	push %r14
+	push %r15
+
+	movq 0(%rdi), %ip
+	movq 8(%rdi), %op
+	movq 16(%rdi), %iend
+	movq 24(%rdi), %oend
+
+	push %rdi
+
+	subq $LIMIT, %iend
+	subq $LIMIT, %oend
+
+	movq %op, %ostart
+
+.loop:
+	# Load the token
+	movzbl 0(%ip), %rax
+	addq $1, %ip
+
+	# Load the literal length and match length
+	# %rax = literal length
+	# %rbx = match length
+	movq %rax, %rbx
+	shrq $4, %rax
+	andq $0xF, %rbx
+
+	cmpq %rax, $0xF
+	je .long_literal_length
+
+	# %rax = literal length
+	# There is enough space to decode the literals < 15 bytes
+	movdqu 0(%ip), %xmm0
+	movups %xmm0, 0(%op)
+
+	addq %rax, %ip
+	addq %rax, %op
+
+	cmpq %ip, %ilimit
+	jb .exit
+
+.literals_copied:
+	movq %op, %rsi
+	movzwl %ip, %rdi
+	addq $2, %ip
+	subq %rdi, %rsi
+
+	cmpq %ostart, %rsi
+	jb .output_error
+
+	cmpq %rbx, $0xF
+	je .long_match_length
+
+	movdqu 0(%rsi), %xmm0
+	movzwl 16(%rsi), %rdi
+	movups %xmm0, 0(%op)
+	movw %rdi, 16(%op)
+
+	addq %rbx, %op
+
+	cmpq %op, %olimit
+	jb .exit
+
+.match_copied:
+
+	movq $0, %rax
+	jmp .exit
+
+.long_literal_length:
+	jmp .literals_copied
+
+.long_match_length:
+	jmp .match_copied
+
+
+.output_error:
+	movq $1, %rax
+	jmp .exit
+
+.exit:
+	pop %rdi
+	movq %ip, 0(%rdi)
+	movq %op, 8(%rdi)
+
+	# Restore registers
+	pop %r15
+	pop %r14
+	pop %r13
+	pop %r12
+	# pop %r11
+	# pop %r10
+	# pop %r9
+	# pop %r8
+	# pop %rdi
+	# pop %rsi
+	pop %rbp
+	# pop %rdx
+	# pop %rcx
+	pop %rbx
+	# pop %rax

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -42,7 +42,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
 LIBVER   := $(shell echo $(LIBVER_SCRIPT))
 
-LIBFILES  = $(wildcard $(LZ4DIR)/*.c)
+LIBFILES  = $(wildcard $(LZ4DIR)/*.c) $(wildcard $(LZ4DIR)/*.S)
 SRCFILES  = $(sort $(LIBFILES) $(wildcard *.c))
 OBJFILES  = $(SRCFILES:.c=.o)
 

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -457,6 +457,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                             break;
                         }
                         blockTable[blockNb].resSize = (size_t)regenSize;
+                        assert(blockTable[blockNb].resSize == blockTable[blockNb].srcSize);
                 }   }
                 {   U64 const clockSpan = UTIL_clockSpanNano(clockStart);
                     if (clockSpan > 0) {

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -457,7 +457,6 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                             break;
                         }
                         blockTable[blockNb].resSize = (size_t)regenSize;
-                        assert(blockTable[blockNb].resSize == blockTable[blockNb].srcSize);
                 }   }
                 {   U64 const clockSpan = UTIL_clockSpanNano(clockStart);
                     if (clockSpan > 0) {


### PR DESCRIPTION
I experimented with writing an assembly version of the LZ4 decoder.

```
> ./dev-lz4 -b1e1 ~/datasets/silesia.tar
 1#silesia.tar       : 211957760 -> 100881205 (2.101), 509.0 MB/s ,3074.9 MB/s 
> ./asm-lz4 -b1e1 ~/datsets/silesia.tar
 1#silesia.tar       : 211957760 -> 100881205 (2.101), 512.8 MB/s ,3657.9 MB/s
```

We see a +19% speed boost.

This is a first version that I haven't really optimized. I only got it working. In previous versions, before I added short offset support (< 16 bytes) I saw a +20% speed boost. I expect to be able to get that back.

This is certainly not ready for merge right now. And I'm not sure if we ever want to merge it. This is more just for exposition.