### PR TITLE
Enable fast decoding on Apple/AArch64 builds (18-25% faster decompression)

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -421,10 +421,12 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #ifndef LZ4_FAST_DEC_LOOP
 #  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 #    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__aarch64__) && defined(__APPLE__)
+#    define LZ4_FAST_DEC_LOOP 1
 #  elif defined(__aarch64__) && !defined(__clang__)
-     /* On aarch64, we disable this optimization for clang because on certain
-      * mobile chipsets, performance is reduced with clang. For information
-      * refer to https://github.com/lz4/lz4/pull/707 */
+     /* On non-Apple aarch64, we disable this optimization for clang because
+      * on certain mobile chipsets, performance is reduced with clang. For
+      * more information refer to https://github.com/lz4/lz4/pull/707 */
 #    define LZ4_FAST_DEC_LOOP 1
 #  else
 #    define LZ4_FAST_DEC_LOOP 0


### PR DESCRIPTION
This makes decoding significantly faster on M1; measured on compressed source
code, decompressing 294 MB to 1301 MB takes 513 ms (2.53 GB/s) before, and
406 ms (3.2 GB/s) after this change on M1 Pro.

There's no way to check if the target architecture is M1 specifically but the
gains are likely to be similar on recent iterations of Apple processors, and
the original performance issue was probably more specific to Qualcomm.