### PR TITLE
'--list' doesn't work stdin even it is a regular file

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -712,11 +712,6 @@ int main(int argc, const char** argv)
     }
 
     if (mode == om_list){
-        /* Exit if trying to read from stdin as this isn't supported in this mode */
-        if(!strcmp(input_filename, stdinmark)){
-            DISPLAYLEVEL(1, "refusing to read from standard input in --list mode\n");
-            exit(1);
-        }
         if(!multiple_inputs){
             inFileNames[ifnIdx++] = input_filename;
         }
@@ -729,7 +724,7 @@ int main(int argc, const char** argv)
     if (!output_filename) output_filename = "*\\dummy^!//";
 
     /* Check if output is defined as console; trigger an error in this case */
-    if (!strcmp(output_filename,stdoutmark) && IS_CONSOLE(stdout) && !forceStdout) {
+    if (!strcmp(output_filename,stdoutmark) && mode != om_list && IS_CONSOLE(stdout) && !forceStdout) {
         DISPLAYLEVEL(1, "refusing to write to console without -c \n");
         exit(1);
     }

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1639,7 +1639,7 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, size_t ifnIdx)
         /* Get file info */
         LZ4IO_cFileInfo_t cfinfo = LZ4IO_INIT_CFILEINFO;
         cfinfo.fileName = LZ4IO_baseName(inFileNames[idx]);
-        if (!UTIL_isRegFile(inFileNames[idx])) {
+        if (strcmp(inFileNames[idx], stdinmark) == 0 ? !UTIL_isRegFD(0) : !UTIL_isRegFile(inFileNames[idx])) {
             DISPLAYLEVEL(1, "lz4: %s is not a regular file \n", inFileNames[idx]);
             return 0;
         }


### PR DESCRIPTION
This is a following up of my comments on #708.

Listing information from a compressed file (via `--list`) requires seeking the input file, however the stdin could be a regular file and therefore seekable (ignoring seekable device files this time); for example:
```
$ lz4 --list < regular-file
```
This change fixes it:
```
# programs/lz4 --list < test.lz4
    Frames           Type Block  Compressed  Uncompressed     Ratio   Filename
         1       LZ4Frame   B6I     182.42K             -         -   stdin
```