### PR TITLE
meson: simplify version lookup and avoid deprecation warnings

### DIFF
--- a/contrib/meson/meson/meson.build
+++ b/contrib/meson/meson/meson.build
@@ -28,13 +28,8 @@ lz4_version = meson.project_version()
 
 lz4_h_file = join_paths(meson.current_source_dir(), '../../../lib/lz4.h')
 GetLz4LibraryVersion_py = find_program('GetLz4LibraryVersion.py', native : true)
-r = run_command(GetLz4LibraryVersion_py, lz4_h_file)
-if r.returncode() == 0
-  lz4_version = r.stdout().strip()
-  message('Project version is now: @0@'.format(lz4_version))
-else
-  error('Cannot find project version in @0@'.format(lz4_h_file))
-endif
+lz4_version = run_command(GetLz4LibraryVersion_py, lz4_h_file, check: true).stdout().strip()
+message('Project version is now: @0@'.format(lz4_version))
 
 lz4_libversion = lz4_version
 


### PR DESCRIPTION
run_command() in development versions of meson will warn when the `check: ` kwarg is not specified. At the same time, lz4 has some gnarly code to manually check the return code and raise an error if it failed.

Kill two birds with one stone, by making run_command inherently raise a fatal error when erroring out, then proceeding in the knowledge that it must have succeeded.