### PR TITLE
Fetch trailing bytes in a branchless way during match length encoding

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -939,8 +939,8 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
         outputDirective == notLimited && /* Cannot be relaxed, ip changes between match and table update. */
         dictDirective == noDict &&       /* Cannot be relaxed, ip changes between match and table update. */
         dictIssue == noDictIssue &&      /* Cannot be relaxed, ip changes between match and table update. */
-        LZ4_isLittleEndian() &&          /* Can be relaxed. */
-        sizeof(reg_t) == 8               /* Can be relaxed. */
+        LZ4_isLittleEndian() &&          /* Can be relaxed for 64 bit BIG ENDIAN. */
+        sizeof(reg_t) == 8               /* Can be relaxed but not all hacks can be applied. */
         ;
 
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -271,7 +271,6 @@ static int LZ4_isAligned(const void* ptr, size_t alignment)
 *  Types
 **************************************/
 #include <limits.h>
-#include <stdio.h>
 #if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
 # include <stdint.h>
   typedef  uint8_t BYTE;
@@ -1293,7 +1292,6 @@ _next_match:
             assert(matchIndex < current);
             if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
               && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
-              // TODO(Danlark): fix.
               && (eligibleForTrailByteLoopOpt ? (LZ4_read32(match) == (U32)(last5Bytes)) : (LZ4_read32(match) == LZ4_read32(ip))) ) {
                 token=op++;
                 *token=0;


### PR DESCRIPTION
Disclaimer: I want maintainers to verify the speedup and generally open to comments if this direction even makes sense

The idea is to fetch last 5 bytes during LZ4_count given we are allowed to read 4 bytes beyond buffer. These 5 bytes can be used for testing next positions without any pointer load and thus improve the dependency chain.

The idea is taken from google/snappy. I was wondering if this gives a better codegen for lz4 as well and it turns out that yes. For all comments on all assembly, etc, see this https://github.com/google/snappy/blob/8dd58a519f79f0742d4c68fbccb2aed2ddb651e8/snappy-internal.h#L191

Preliminary benchmarks:

clang: 5-10%

Silesia.tar

```
BM_ZFlatLZ4/silesia.tar                  -0.0447         -0.0446     355984938     340079628     355931342     340051698
```

gcc: 0.5-1%

```
BM_ZFlatLZ4/silesia.tar                  -0.0049         -0.0048     327836186     326238017     327743015     326154035
```

Other benchmarks TBD but generally we see improvements in cases when there are lots of matches. For example, xml data set from silesia gives more improvements even for gcc

clang:
```
BM_ZFlatLZ4/xml_mean                -0.0466         -0.0466       6292872       5999359       6292167       5999121
```

gcc:

```
BM_ZFlatLZ4/xml_mean                -0.0325         -0.0321       5840298       5650403       5837447       5650165
```