### PR TITLE
Add virtual environment checking for Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,6 +666,7 @@ jobs:
       matrix:
         include: [
           { os: ubuntu-latest,  }, # https://github.com/actions/virtual-environments/
+          { os: ubuntu-22.04,   }, # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2204-Readme.md
           { os: ubuntu-20.04,   }, # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
           { os: ubuntu-18.04,   }, # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-Readme.md
         ]


### PR DESCRIPTION
GitHub Actions recently provides public beta version of Ubuntu 22.04
https://github.com/actions/virtual-environments/issues/5490

This PR just adds Ubuntu 22.04 to check its environment.
