### PR TITLE
Change definitions of LZ4_xxxSIZE defines for OS400

### DIFF
--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -219,8 +219,26 @@ struct LZ4HC_CCtx_internal
 
 /* Do not use these definitions directly !
  * Declare or allocate an LZ4_streamHC_t instead.
+ * Note : OS400 uses 16 byte pointers and so the structure size is larger than other
+ *        platforms
+ *        |===========================================================
+ *        |      Offset       |      Length       | Member Name       
+ *        |===========================================================
+ *        |       0           |  131072           |  hashTable[32768] 
+ *        |  131072           |  131072           |  chainTable[65536]
+ *        |  262144           |      16           |  end              
+ *        |  262160           |      16           |  base             
+ *        |  262176           |      16           |  dictBase         
+ *        |  262192           |       4           |  dictLimit        
+ *        |  262196           |       4           |  lowLimit         
+ *        |  262200           |       4           |  nextToUpdate     
+ *        |  262204           |       2           |  compressionLevel 
+ *        |  262206           |       1           |  favorDecSpeed    
+ *        |  262207           |       1           |  dirty            
+ *        |  262208           |      16           |  dictCtx           
+ *        ============================================================
  */
-#define LZ4_STREAMHCSIZE       262200  /* static size, for inter-version compatibility */
+#define LZ4_STREAMHCSIZE       (262200 + ((sizeof(void*)==16) ? 24 : 0)) /* static size, for inter-version compatibility */
 #define LZ4_STREAMHCSIZE_VOIDP (LZ4_STREAMHCSIZE / sizeof(void*))
 union LZ4_streamHC_u {
     void* table[LZ4_STREAMHCSIZE_VOIDP];


### PR DESCRIPTION
Change definitions of various definitions of LS4_xxxSIZE to factor in pointer length and structure alignment rules.

This addresses issue #1065 .