### PR TITLE
refactor interface for static state allocation

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -686,7 +686,7 @@ typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
 int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
 const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
 int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState(void) { return LZ4_STREAMSIZE; }
+int LZ4_sizeofState(void) { return sizeof(LZ4_stream_t); }
 
 
 /*-****************************************
@@ -1443,7 +1443,7 @@ int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targe
 LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
-    LZ4_STATIC_ASSERT(LZ4_STREAMSIZE >= sizeof(LZ4_stream_t_internal));    /* A compilation error here means LZ4_STREAMSIZE is not large enough */
+    LZ4_STATIC_ASSERT(sizeof(LZ4_stream_t) >= sizeof(LZ4_stream_t_internal));
     DEBUGLOG(4, "LZ4_createStream %p", lz4s);
     if (lz4s == NULL) return NULL;
     LZ4_initStream(lz4s, sizeof(*lz4s));
@@ -2323,9 +2323,8 @@ int LZ4_decompress_fast_doubleDict(const char* source, char* dest, int originalS
 
 LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 {
-    LZ4_streamDecode_t* lz4s = (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
-    LZ4_STATIC_ASSERT(LZ4_STREAMDECODESIZE >= sizeof(LZ4_streamDecode_t_internal));    /* A compilation error here means LZ4_STREAMDECODESIZE is not large enough */
-    return lz4s;
+    LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
+    return (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
 }
 
 int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
@@ -2550,7 +2549,7 @@ int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize,
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState(void) { return LZ4_STREAMSIZE; }
+int LZ4_sizeofStreamState(void) { return sizeof(LZ4_stream_t); }
 
 int LZ4_resetStreamState(void* state, char* inputBuffer)
 {

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -623,34 +623,14 @@ typedef struct {
 
 
 /*! LZ4_stream_t :
- *  Do not use below internal definitions directly !
- *  Declare or allocate an LZ4_stream_t instead.
- *  LZ4_stream_t can also be created using LZ4_createStream(), which is recommended.
- *  The structure definition can be convenient for static allocation
- *  (on stack, or as part of larger structure).
- *  Init this structure with LZ4_initStream() before first use.
- *  note : only use this definition in association with static linking !
- *  this definition is not API/ABI safe, and may change in future versions.
- *  Note : OS400 pointers are 16 bytes and the compiler adds 8 bytes of padding after
- *  tableType and 12 bytes after dictSize to ensure the structure is word aligned:
- *  |=========================================================
- *  |      Offset       |      Length       | Member Name
- *  |=========================================================
- *  |       0           |   16384           |  hashTable[4096]
- *  |   16384           |       4           |  currentOffset
- *  |   16388           |       4           |  tableType
- *  |   16392           |       8           |  ***PADDING***
- *  |   16400           |      16           |  dictionary
- *  |   16416           |      16           |  dictCtx
- *  |   16432           |       4           |  dictSize
- *  |   16436           |      12           |  ***PADDING***
- *  ==========================================================
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_stream_t object.
  */
-#define LZ4_STREAMSIZE       ((1UL << LZ4_MEMORY_USAGE) + ((sizeof(void*)==16) ? 64 : 32))  /* static size, for inter-version compatibility */
-#define LZ4_STREAMSIZE_VOIDP (LZ4_STREAMSIZE / sizeof(void*))
+#define LZ4_STREAMSIZE  ((1UL << LZ4_MEMORY_USAGE) + 32)  /* static size, for inter-version compatibility */
 union LZ4_stream_u {
-    void* table[LZ4_STREAMSIZE_VOIDP];
     LZ4_stream_t_internal internal_donotuse;
+    char minStateSize[LZ4_STREAMSIZE];
 }; /* previously typedef'd to LZ4_stream_t */
 
 
@@ -672,29 +652,14 @@ LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
 
 
 /*! LZ4_streamDecode_t :
- *  information structure to track an LZ4 stream during decompression.
- *  init this structure  using LZ4_setStreamDecode() before first use.
- *  note : only use in association with static linking !
- *         this definition is not API/ABI safe,
- *         and may change in a future version !
- *  Note : Same story as LZ4_STREAMSIZE for OS400 in terms of additional padding to 
- *         ensure pointers start on and structures finish on 16 byte boundaries
- *         |=========================================================
- *         |      Offset       |      Length       | Member Name
- *         |=========================================================
- *         |       0           |      16           |    externalDict 
- *         |      16           |       4           |    extDictSize  
- *         |      20           |      12           |    ***PADDING***
- *         |      32           |      16           |    prefixEnd    
- *         |      48           |       4           |    prefixSize   
- *         |      52           |      12           |    ***PADDING***
- *         ==========================================================
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_streamDecode_t object.
  */
-#define LZ4_STREAMDECODESIZE_U64 (4 + ((sizeof(void*)==16) ? 4 : 0))
-#define LZ4_STREAMDECODESIZE     (LZ4_STREAMDECODESIZE_U64 * sizeof(unsigned long long))
+#define LZ4_STREAMDECODESIZE 32
 union LZ4_streamDecode_u {
-    unsigned long long table[LZ4_STREAMDECODESIZE_U64];
     LZ4_streamDecode_t_internal internal_donotuse;
+    char minStateSize[LZ4_STREAMDECODESIZE];
 } ;   /* previously typedef'd to LZ4_streamDecode_t */
 
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -107,10 +107,10 @@ extern "C" {
 #define LZ4_LIB_VERSION LZ4_VERSION_MAJOR.LZ4_VERSION_MINOR.LZ4_VERSION_RELEASE
 #define LZ4_QUOTE(str) #str
 #define LZ4_EXPAND_AND_QUOTE(str) LZ4_QUOTE(str)
-#define LZ4_VERSION_STRING LZ4_EXPAND_AND_QUOTE(LZ4_LIB_VERSION)
+#define LZ4_VERSION_STRING LZ4_EXPAND_AND_QUOTE(LZ4_LIB_VERSION)  /* requires v1.7.3+ */
 
-LZ4LIB_API int LZ4_versionNumber (void);  /**< library version number; useful to check dll version */
-LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; useful to check dll version */
+LZ4LIB_API int LZ4_versionNumber (void);  /**< library version number; useful to check dll version; requires v1.3.0+ */
+LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; useful to check dll version; requires v1.7.5+ */
 
 
 /*-************************************
@@ -604,6 +604,12 @@ LZ4LIB_STATIC_API void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const 
   typedef unsigned int   LZ4_u32;
 #endif
 
+/*! LZ4_stream_t :
+ *  Never ever use below internal definitions directly !
+ *  These definitions are not API/ABI safe, and may change in future versions.
+ *  If you need static allocation, declare or allocate an LZ4_stream_t object.
+**/
+
 typedef struct LZ4_stream_t_internal LZ4_stream_t_internal;
 struct LZ4_stream_t_internal {
     LZ4_u32 hashTable[LZ4_HASH_SIZE_U32];
@@ -614,23 +620,10 @@ struct LZ4_stream_t_internal {
     LZ4_u32 dictSize;
 };
 
-typedef struct {
-    const LZ4_byte* externalDict;
-    size_t extDictSize;
-    const LZ4_byte* prefixEnd;
-    size_t prefixSize;
-} LZ4_streamDecode_t_internal;
-
-
-/*! LZ4_stream_t :
- *  Never ever use below internal definitions directly !
- *  These definitions are not API/ABI safe, and may change in future versions.
- *  If you need static allocation, declare or allocate an LZ4_stream_t object.
- */
-#define LZ4_STREAMSIZE  ((1UL << LZ4_MEMORY_USAGE) + 32)  /* static size, for inter-version compatibility */
+#define LZ4_STREAM_MINSIZE  ((1UL << LZ4_MEMORY_USAGE) + 32)  /* static size, for inter-version compatibility */
 union LZ4_stream_u {
+    char minStateSize[LZ4_STREAM_MINSIZE];
     LZ4_stream_t_internal internal_donotuse;
-    char minStateSize[LZ4_STREAMSIZE];
 }; /* previously typedef'd to LZ4_stream_t */
 
 
@@ -655,11 +648,18 @@ LZ4LIB_API LZ4_stream_t* LZ4_initStream (void* buffer, size_t size);
  *  Never ever use below internal definitions directly !
  *  These definitions are not API/ABI safe, and may change in future versions.
  *  If you need static allocation, declare or allocate an LZ4_streamDecode_t object.
- */
-#define LZ4_STREAMDECODESIZE 32
+**/
+typedef struct {
+    const LZ4_byte* externalDict;
+    size_t extDictSize;
+    const LZ4_byte* prefixEnd;
+    size_t prefixSize;
+} LZ4_streamDecode_t_internal;
+
+#define LZ4_STREAMDECODE_MINSIZE 32
 union LZ4_streamDecode_u {
+    char minStateSize[LZ4_STREAMDECODE_MINSIZE];
     LZ4_streamDecode_t_internal internal_donotuse;
-    char minStateSize[LZ4_STREAMDECODESIZE];
 } ;   /* previously typedef'd to LZ4_streamDecode_t */
 
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1005,8 +1005,6 @@ int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
 LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)
 {
     LZ4_streamHC_t* const LZ4_streamHCPtr = (LZ4_streamHC_t*)buffer;
-    /* if compilation fails here, LZ4_STREAMHCSIZE must be increased */
-    LZ4_STATIC_ASSERT(sizeof(LZ4HC_CCtx_internal) <= LZ4_STREAMHCSIZE);
     DEBUGLOG(4, "LZ4_initStreamHC(%p, %u)", buffer, (unsigned)size);
     /* check conditions */
     if (buffer == NULL) return NULL;
@@ -1205,7 +1203,7 @@ int LZ4_compressHC_limitedOutput_continue (LZ4_streamHC_t* ctx, const char* src,
 
 
 /* Deprecated streaming functions */
-int LZ4_sizeofStreamStateHC(void) { return LZ4_STREAMHCSIZE; }
+int LZ4_sizeofStreamStateHC(void) { return sizeof(LZ4_streamHC_t); }
 
 /* state is presumed correctly sized, aka >= sizeof(LZ4_streamHC_t)
  * @return : 0 on success, !=0 if error */

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -198,6 +198,9 @@ LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, in
 #define LZ4HC_HASH_MASK (LZ4HC_HASHTABLESIZE - 1)
 
 
+/* Never ever use these definitions directly !
+ * Declare or allocate an LZ4_streamHC_t instead.
+**/
 typedef struct LZ4HC_CCtx_internal LZ4HC_CCtx_internal;
 struct LZ4HC_CCtx_internal
 {
@@ -216,32 +219,10 @@ struct LZ4HC_CCtx_internal
     const LZ4HC_CCtx_internal* dictCtx;
 };
 
-
-/* Never ever use these definitions directly !
- * Declare or allocate an LZ4_streamHC_t instead.
- * Note : OS400 uses 16 byte pointers and so the structure size is larger than other
- *        platforms
- *        |===========================================================
- *        |      Offset       |      Length       | Member Name
- *        |===========================================================
- *        |       0           |  131072           |  hashTable[32768]
- *        |  131072           |  131072           |  chainTable[65536]
- *        |  262144           |      16           |  end
- *        |  262160           |      16           |  base
- *        |  262176           |      16           |  dictBase
- *        |  262192           |       4           |  dictLimit
- *        |  262196           |       4           |  lowLimit
- *        |  262200           |       4           |  nextToUpdate
- *        |  262204           |       2           |  compressionLevel
- *        |  262206           |       1           |  favorDecSpeed
- *        |  262207           |       1           |  dirty
- *        |  262208           |      16           |  dictCtx
- *        ============================================================
- */
-#define LZ4_STREAMHCSIZE  262200  /* static size, for inter-version compatibility */
+#define LZ4_STREAMHC_MINSIZE  262200  /* static size, for inter-version compatibility */
 union LZ4_streamHC_u {
+    char minStateSize[LZ4_STREAMHC_MINSIZE];
     LZ4HC_CCtx_internal internal_donotuse;
-    char minStateSize[LZ4_STREAMHCSIZE];
 }; /* previously typedef'd to LZ4_streamHC_t */
 
 /* LZ4_streamHC_t :

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -217,37 +217,36 @@ struct LZ4HC_CCtx_internal
 };
 
 
-/* Do not use these definitions directly !
+/* Never ever use these definitions directly !
  * Declare or allocate an LZ4_streamHC_t instead.
  * Note : OS400 uses 16 byte pointers and so the structure size is larger than other
  *        platforms
  *        |===========================================================
- *        |      Offset       |      Length       | Member Name       
+ *        |      Offset       |      Length       | Member Name
  *        |===========================================================
- *        |       0           |  131072           |  hashTable[32768] 
+ *        |       0           |  131072           |  hashTable[32768]
  *        |  131072           |  131072           |  chainTable[65536]
- *        |  262144           |      16           |  end              
- *        |  262160           |      16           |  base             
- *        |  262176           |      16           |  dictBase         
- *        |  262192           |       4           |  dictLimit        
- *        |  262196           |       4           |  lowLimit         
- *        |  262200           |       4           |  nextToUpdate     
- *        |  262204           |       2           |  compressionLevel 
- *        |  262206           |       1           |  favorDecSpeed    
- *        |  262207           |       1           |  dirty            
- *        |  262208           |      16           |  dictCtx           
+ *        |  262144           |      16           |  end
+ *        |  262160           |      16           |  base
+ *        |  262176           |      16           |  dictBase
+ *        |  262192           |       4           |  dictLimit
+ *        |  262196           |       4           |  lowLimit
+ *        |  262200           |       4           |  nextToUpdate
+ *        |  262204           |       2           |  compressionLevel
+ *        |  262206           |       1           |  favorDecSpeed
+ *        |  262207           |       1           |  dirty
+ *        |  262208           |      16           |  dictCtx
  *        ============================================================
  */
-#define LZ4_STREAMHCSIZE       (262200 + ((sizeof(void*)==16) ? 24 : 0)) /* static size, for inter-version compatibility */
-#define LZ4_STREAMHCSIZE_VOIDP (LZ4_STREAMHCSIZE / sizeof(void*))
+#define LZ4_STREAMHCSIZE  262200  /* static size, for inter-version compatibility */
 union LZ4_streamHC_u {
-    void* table[LZ4_STREAMHCSIZE_VOIDP];
     LZ4HC_CCtx_internal internal_donotuse;
+    char minStateSize[LZ4_STREAMHCSIZE];
 }; /* previously typedef'd to LZ4_streamHC_t */
 
 /* LZ4_streamHC_t :
  * This structure allows static allocation of LZ4 HC streaming state.
- * This can be used to allocate statically, on state, or as part of a larger structure.
+ * This can be used to allocate statically on stack, or as part of a larger structure.
  *
  * Such state **must** be initialized using LZ4_initStreamHC() before first use.
  *
@@ -262,7 +261,7 @@ union LZ4_streamHC_u {
  * Required before first use of a statically allocated LZ4_streamHC_t.
  * Before v1.9.0 : use LZ4_resetStreamHC() instead
  */
-LZ4LIB_API LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size);
+LZ4LIB_API LZ4_streamHC_t* LZ4_initStreamHC(void* buffer, size_t size);
 
 
 /*-************************************

--- a/tests/abiTest.c
+++ b/tests/abiTest.c
@@ -202,6 +202,7 @@ int main(int argCount, const char** argv)
 {
     const char* const exeName = argv[0];
     int argNb = 1;
+    // Note : LZ4_VERSION_STRING requires >= v1.7.3+
     MSG("abiTest, built binary based on API %s \n", LZ4_VERSION_STRING);
     // Note : LZ4_versionString() requires >= v1.7.5+
     MSG("currently linked to dll %s \n", LZ4_versionString());


### PR DESCRIPTION
#1104 fixed an issue impacting the size of states on `OS400` specifically. This  is a relatively  niche scenario, when statically allocating on stack or as part of another structure (which is not recommended, though allowed).

To do that, @jonrumsey fixed the manual size of `LZ4_STREAMSIZE` and other equivalent constants, to fit the scenario of `OS400`, where pointers are 128-bit large.
And while the fix is correct, it should not have been necessary.

The interface design requires employing objects such as `LZ4_stream_t` to allocate statically, and never the constants nor internal definitions. `LZ4_STREAMSIZE` only exists first due to historical reasons, but also as a way to protect against mismatched library versions. In essence, it guarantees that the state preserves a "minimal size", in case it would evolve or shrink in the future, so that it remains compatible with older library versions.

The problem was that this "minimal state size", which is generally >= to the actual state size, ends up being lower that actual state size in the case `OS400`.
Still, this shouldn't be a problem, because in this case, the state occupies its actual size.

The problem came from the fact that `LZ4_STREAMSIZE` was used in other parts of the source code, and notably within static assert, resulting in compilation errors. And this wasn't a correct usage of this constant.

This PR fix the underlying issue, by making sure that all code now use `sizeof(LZ4_stream_t)`, and no longer `LZ4_STREAMSIZE`, which by the way has been renamed `LZ4_STREAM_MINSIZE`, to better reflect its role.

Such update is also easier to validate thanks to previously merged [ABI compatibility test](#1108).
