### PR TITLE
Fix #991

### DIFF
--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -208,7 +208,7 @@ struct LZ4HC_CCtx_internal
     LZ4_u16   chainTable[LZ4HC_MAXD];
     const LZ4_byte* end;       /* next block here to continue on current prefix */
     const LZ4_byte* prefixStart;  /* Indexes relative to this position */
-    const LZ4_byte* dictBase;  /* alternate base for extDict */
+    const LZ4_byte* dictStart; /* alternate reference for extDict */
     LZ4_u32   dictLimit;       /* below that point, need extDict */
     LZ4_u32   lowLimit;        /* below that point, no more dict */
     LZ4_u32   nextToUpdate;    /* index from which to continue dictionary update */

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -207,7 +207,7 @@ struct LZ4HC_CCtx_internal
     LZ4_u32   hashTable[LZ4HC_HASHTABLESIZE];
     LZ4_u16   chainTable[LZ4HC_MAXD];
     const LZ4_byte* end;       /* next block here to continue on current prefix */
-    const LZ4_byte* base;      /* All index relative to this position */
+    const LZ4_byte* prefixStart;  /* Indexes relative to this position */
     const LZ4_byte* dictBase;  /* alternate base for extDict */
     LZ4_u32   dictLimit;       /* below that point, need extDict */
     LZ4_u32   lowLimit;        /* below that point, no more dict */


### PR DESCRIPTION
In #991, @t-mat reports an error scenario,
which happens only when using `-m32` mode, with `assert()` enabled, when employing a recent compiler (>= `clang-12`), with high optimization (`-O3`) enabled, in a scenario involving the compression of more than >2 GB, using High Compression mode.

Quite a mouthful to describe. It feels like a niche scenario (and it is), but it's actually relatively easy to trigger : just start `test-lz4c32` CI tests using a recent compiler.

The issue happens in some `assert()` statements (hence why they aren't trigger when `assert()` are disabled, i.e. in release mode), which fail, even though they should not. That's because the compiler, in high optimization mode, seems to believe it knows better, and doesn't even compute the `assert()` statement, it just considers them false. This can be circumvented by forcing the compiler to actually compute the statement, for example by printing it, in which case it will realize that the `assert()` condition is fully respected.

Taking a step back, why does the compiler act this way ?
One hypothesis is that this could be because the conditions indirectly involve the pointer `->base`, which is not a "real" pointer, merely a reference point. This does not matter, as `->base` is never dereferenced, it's only used in combination with an `index`, in which case `base + index` becomes a valid pointer.
Anyway, since `base` is not a "real" pointer, it's still technically `UB`, and the presumption here is that this is the excuse employed by the compiler to not even compute the `assert()` statement.

In an effort to avoid this situation going forward (since only very recent compilers are impacted), this PR removes `base` and `dictBase` from the `LZ4_HC` state. They are replaced by `->prefixStart` and `->dictStart`, which _are_ valid pointers, pointing to the beginning of their respective buffer.
As a consequence, calculating the position of a `match` becomes slightly more complex, requiring one more register and one more operation. But since this is `LZ4_HC`, aka the High Compression mode, speed is not critical, and the expectation is that the speed impact shall be negligible (to be confirmed).

_edit_ : 
speed measurements confirm there is no speed loss from this PR.
Strangely enough, I even measure a tiny yet consistent speed win in multiple scenarios, though this difference is within noise level, so nothing important to brag about.
