### PR TITLE
Test support of Standard Makefile Variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,16 @@ jobs:
       run: make V=1 -C tests test-fuzzer32
 
 
+  lz4-standard-makefile-variables:
+    name: LZ4 Makefile - support for standard variables
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # https://github.com/actions/checkout
+
+    - name: make standard_variables
+      run: make V=1 standard_variables
+
+
   lz4-versions:
     name: LZ4 versions test
     runs-on: ubuntu-latest


### PR DESCRIPTION
The goal of this  test is to detect issues such as #958, which managed to silently slip into `v1.9.3` release. It's relatively easy for any future contribution to introduce changes in the `Makefile` that would partially break support of some Standard Variables through environment. So let's have a way to detect that.

The downside is that the current test is a bit brittle, because it could fail for other unrelated reasons. For example, adding more files in the `programs/` to be compiled as part of `lz4` CLI would require to change the quantities to detect.

Well, at least that's a start, there is now a test for this topic. We'll see through experience if and how it needs to be improved.