### PR TITLE
refactor test ensuring that make test does not depend on console status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,10 +581,9 @@ jobs:
     - name: make test
       run: make V=1 clean test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion'
 
-    - name: make test | tee
-      # test scenario where `stdout` is not the console
-      run: make V=1 clean test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion' | tee
-
+    - name: Ensure `make test` doesn't depend on the status of the console
+      # see issue #990 for detailed explanations
+      run: make test > /dev/null
 
 
 ###############################################################


### PR DESCRIPTION
Fix #990