### PR TITLE
Implement decoder-only benchmark

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -417,7 +417,10 @@ LZ4LIB_API int LZ4_decoderRingBufferSize(int maxBlockSize);
  *  save the last 64KB of decoded data into a safe buffer where it can't be modified during decompression,
  *  then indicate where this data is saved using LZ4_setStreamDecode(), before decompressing next block.
 */
-LZ4LIB_API int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int srcSize, int dstCapacity);
+LZ4LIB_API int
+LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
+                        const char* src, char* dst,
+                        int srcSize, int dstCapacity);
 
 
 /*! LZ4_decompress_*_usingDict() :
@@ -428,9 +431,17 @@ LZ4LIB_API int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecod
  *  Performance tip : Decompression speed can be substantially increased
  *                    when dst == dictStart + dictSize.
  */
-LZ4LIB_API int LZ4_decompress_safe_usingDict (const char* src, char* dst, int srcSize, int dstCapcity, const char* dictStart, int dictSize);
+LZ4LIB_API int
+LZ4_decompress_safe_usingDict(const char* src, char* dst,
+                              int srcSize, int dstCapcity,
+                              const char* dictStart, int dictSize);
 
-LZ4LIB_API int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int maxOutputSize, const char* dictStart, int dictSize);
+LZ4LIB_API int
+LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
+                                      int compressedSize,
+                                      int targetOutputSize, int maxOutputSize,
+                                      const char* dictStart, int dictSize);
+
 #endif /* LZ4_H_2983827168210 */
 
 
@@ -508,7 +519,9 @@ LZ4LIB_STATIC_API int LZ4_compress_fast_extState_fastReset (void* state, const c
  *  stream (and source buffer) must remain in-place / accessible / unchanged
  *  through the completion of the first compression call on the stream.
  */
-LZ4LIB_STATIC_API void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream);
+LZ4LIB_STATIC_API void
+LZ4_attach_dictionary(LZ4_stream_t* workingStream,
+                const LZ4_stream_t* dictionaryStream);
 
 
 /*! In-place compression and decompression

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -433,7 +433,7 @@ LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
  */
 LZ4LIB_API int
 LZ4_decompress_safe_usingDict(const char* src, char* dst,
-                              int srcSize, int dstCapcity,
+                              int srcSize, int dstCapacity,
                               const char* dictStart, int dictSize);
 
 LZ4LIB_API int

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -56,9 +56,9 @@ extern "C" {
 /**
   Introduction
 
-  lz4frame.h implements LZ4 frame specification (doc/lz4_Frame_format.md).
-  lz4frame.h provides frame compression functions that take care
-  of encoding standard metadata alongside LZ4-compressed blocks.
+  lz4frame.h implements LZ4 frame specification: see doc/lz4_Frame_format.md .
+  LZ4 Frames are interoperable on any systems.
+  The are compatible with `lz4` CLI.
 */
 
 /*-***************************************************************
@@ -397,7 +397,7 @@ LZ4FLIB_API size_t LZ4F_headerSize(const void* src, size_t srcSize);
 
 /*! LZ4F_getFrameInfo() :
  *  This function extracts frame parameters (max blockSize, dictID, etc.).
- *  Its usage is optional: user can call LZ4F_decompress() directly.
+ *  Its usage is optional: user can also invoke LZ4F_decompress() directly.
  *
  *  Extracted information will fill an existing LZ4F_frameInfo_t structure.
  *  This can be useful for allocation and dictionary identification purposes.
@@ -438,9 +438,10 @@ LZ4FLIB_API size_t LZ4F_headerSize(const void* src, size_t srcSize);
  *  note 1 : in case of error, dctx is not modified. Decoding operation can resume from beginning safely.
  *  note 2 : frame parameters are *copied into* an already allocated LZ4F_frameInfo_t structure.
  */
-LZ4FLIB_API size_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
-                                     LZ4F_frameInfo_t* frameInfoPtr,
-                                     const void* srcBuffer, size_t* srcSizePtr);
+LZ4FLIB_API size_t
+LZ4F_getFrameInfo(LZ4F_dctx* dctx,
+                  LZ4F_frameInfo_t* frameInfoPtr,
+            const void* srcBuffer, size_t* srcSizePtr);
 
 /*! LZ4F_decompress() :
  *  Call this function repetitively to regenerate data compressed in `srcBuffer`.
@@ -473,10 +474,11 @@ LZ4FLIB_API size_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
  *
  *  After a frame is fully decoded, dctx can be used again to decompress another frame.
  */
-LZ4FLIB_API size_t LZ4F_decompress(LZ4F_dctx* dctx,
-                                   void* dstBuffer, size_t* dstSizePtr,
-                                   const void* srcBuffer, size_t* srcSizePtr,
-                                   const LZ4F_decompressOptions_t* dOptPtr);
+LZ4FLIB_API size_t
+LZ4F_decompress(LZ4F_dctx* dctx,
+                void* dstBuffer, size_t* dstSizePtr,
+          const void* srcBuffer, size_t* srcSizePtr,
+          const LZ4F_decompressOptions_t* dOptPtr);
 
 
 /*! LZ4F_resetDecompressionContext() : added in v1.8.0
@@ -572,10 +574,11 @@ LZ4FLIB_STATIC_API size_t LZ4F_getBlockSize(LZ4F_blockSizeID_t blockSizeID);
  * @return : number of bytes written into `dstBuffer` (it can be zero, meaning input data was just buffered).
  *           or an error code if it fails (which can be tested using LZ4F_isError())
  */
-LZ4FLIB_STATIC_API size_t LZ4F_uncompressedUpdate(LZ4F_cctx* cctx,
-                                                  void* dstBuffer, size_t dstCapacity,
-                                                  const void* srcBuffer, size_t srcSize,
-                                                  const LZ4F_compressOptions_t* cOptPtr);
+LZ4FLIB_STATIC_API size_t
+LZ4F_uncompressedUpdate(LZ4F_cctx* cctx,
+                        void* dstBuffer, size_t dstCapacity,
+                  const void* srcBuffer, size_t srcSize,
+                  const LZ4F_compressOptions_t* cOptPtr);
 
 /**********************************
  *  Bulk processing dictionary API
@@ -619,12 +622,12 @@ LZ4FLIB_STATIC_API void        LZ4F_freeCDict(LZ4F_CDict* CDict);
  *  but it's not recommended, as it's the only way to provide dictID in the frame header.
  * @return : number of bytes written into dstBuffer.
  *           or an error code if it fails (can be tested using LZ4F_isError()) */
-LZ4FLIB_STATIC_API size_t LZ4F_compressFrame_usingCDict(
-    LZ4F_cctx* cctx,
-    void* dst, size_t dstCapacity,
-    const void* src, size_t srcSize,
-    const LZ4F_CDict* cdict,
-    const LZ4F_preferences_t* preferencesPtr);
+LZ4FLIB_STATIC_API size_t
+LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
+                              void* dst, size_t dstCapacity,
+                        const void* src, size_t srcSize,
+                        const LZ4F_CDict* cdict,
+                        const LZ4F_preferences_t* preferencesPtr);
 
 
 /*! LZ4F_compressBegin_usingCDict() :
@@ -634,23 +637,23 @@ LZ4FLIB_STATIC_API size_t LZ4F_compressFrame_usingCDict(
  *  however, it's the only way to provide dictID in the frame header.
  * @return : number of bytes written into dstBuffer for the header,
  *           or an error code (which can be tested using LZ4F_isError()) */
-LZ4FLIB_STATIC_API size_t LZ4F_compressBegin_usingCDict(
-    LZ4F_cctx* cctx,
-    void* dstBuffer, size_t dstCapacity,
-    const LZ4F_CDict* cdict,
-    const LZ4F_preferences_t* prefsPtr);
+LZ4FLIB_STATIC_API size_t
+LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctx,
+                              void* dstBuffer, size_t dstCapacity,
+                        const LZ4F_CDict* cdict,
+                        const LZ4F_preferences_t* prefsPtr);
 
 
 /*! LZ4F_decompress_usingDict() :
  *  Same as LZ4F_decompress(), using a predefined dictionary.
  *  Dictionary is used "in place", without any preprocessing.
- *  It must remain accessible throughout the entire frame decoding. */
-LZ4FLIB_STATIC_API size_t LZ4F_decompress_usingDict(
-    LZ4F_dctx* dctxPtr,
-    void* dstBuffer, size_t* dstSizePtr,
-    const void* srcBuffer, size_t* srcSizePtr,
-    const void* dict, size_t dictSize,
-    const LZ4F_decompressOptions_t* decompressOptionsPtr);
+**  It must remain accessible throughout the entire frame decoding. */
+LZ4FLIB_STATIC_API size_t
+LZ4F_decompress_usingDict(LZ4F_dctx* dctxPtr,
+                          void* dstBuffer, size_t* dstSizePtr,
+                    const void* srcBuffer, size_t* srcSizePtr,
+                    const void* dict, size_t dictSize,
+                    const LZ4F_decompressOptions_t* decompressOptionsPtr);
 
 
 /*! Custom memory allocation :

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -54,12 +54,12 @@ extern "C" {
 
 
 /**
-  Introduction
-
-  lz4frame.h implements LZ4 frame specification: see doc/lz4_Frame_format.md .
-  LZ4 Frames are interoperable on any systems.
-  The are compatible with `lz4` CLI.
-*/
+ * Introduction
+ *
+ * lz4frame.h implements LZ4 frame specification: see doc/lz4_Frame_format.md .
+ * LZ4 Frames are compatible with `lz4` CLI,
+ * and designed to be interoperable with any system.
+**/
 
 /*-***************************************************************
  *  Compiler specifics

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -677,7 +677,8 @@ static void BMK_syntheticTest(int cLevel, int cLevelLast, double compressibility
 }
 
 
-int BMK_benchFilesSeparately(const char** fileNamesTable, unsigned nbFiles,
+static int
+BMK_benchFilesSeparately(const char** fileNamesTable, unsigned nbFiles,
                    int cLevel, int cLevelLast,
                    const char* dictBuf, int dictSize)
 {
@@ -685,7 +686,6 @@ int BMK_benchFilesSeparately(const char** fileNamesTable, unsigned nbFiles,
     if (cLevel > LZ4HC_CLEVEL_MAX) cLevel = LZ4HC_CLEVEL_MAX;
     if (cLevelLast > LZ4HC_CLEVEL_MAX) cLevelLast = LZ4HC_CLEVEL_MAX;
     if (cLevelLast < cLevel) cLevelLast = cLevel;
-    if (cLevelLast > cLevel) DISPLAYLEVEL(2, "Benchmarking levels from %d to %d\n", cLevel, cLevelLast);
 
     for (fileNb=0; fileNb<nbFiles; fileNb++)
         BMK_benchFileTable(fileNamesTable+fileNb, 1, cLevel, cLevelLast, dictBuf, dictSize);

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -25,15 +25,28 @@
 
 #include <stddef.h>
 
+/* BMK_benchFiles() :
+ * Benchmark all files provided through array @fileNamesTable.
+ * All files must be valid, otherwise benchmark fails.
+ * Roundtrip measurements are done for each file individually, but
+ * unless BMK_setBenchSeparately() is set, all results are agglomerated.
+ * The method benchmarks all compression levels from @cLevelStart to @cLevelLast,
+ * both inclusive, providing one result per compression level.
+ * If @cLevelLast <= @cLevelStart, BMK_benchFiles() benchmarks @cLevelStart only.
+ * @dictFileName is optional, it's possible to provide NULL.
+ * When provided, compression and decompression use the specified file as dictionary.
+ * Only one dictionary can be provided, in which case it's applied to all benchmarked files.
+**/
 int BMK_benchFiles(const char** fileNamesTable, unsigned nbFiles,
-                   int cLevel, int cLevelLast,
+                   int cLevelStart, int cLevelLast,
                    const char* dictFileName);
 
 /* Set Parameters */
-void BMK_setNbSeconds(unsigned nbLoops);
-void BMK_setBlockSize(size_t blockSize);
-void BMK_setAdditionalParam(int additionalParam);
-void BMK_setNotificationLevel(unsigned level);
-void BMK_setBenchSeparately(int separate);
+void BMK_setNbSeconds(unsigned nbSeconds);  /* minimum benchmark duration, in seconds, for both compression and decompression */
+void BMK_setBlockSize(size_t blockSize);    /* Internally cut input file(s) into independent blocks of specified size */
+void BMK_setNotificationLevel(unsigned level);  /* Influence verbosity level */
+void BMK_setBenchSeparately(int separate);  /* When providing multiple files, output one result per file */
+
+void BMK_setAdditionalParam(int additionalParam); /* hidden param, influence output format, for python parsing */
 
 #endif   /* BENCH_H_125623623633 */

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -46,6 +46,7 @@ void BMK_setNbSeconds(unsigned nbSeconds);  /* minimum benchmark duration, in se
 void BMK_setBlockSize(size_t blockSize);    /* Internally cut input file(s) into independent blocks of specified size */
 void BMK_setNotificationLevel(unsigned level);  /* Influence verbosity level */
 void BMK_setBenchSeparately(int separate);  /* When providing multiple files, output one result per file */
+void BMK_setDecodeOnlyMode(int set);        /* v1.9.4+: set benchmark mode to decode only */
 
 void BMK_setAdditionalParam(int additionalParam); /* hidden param, influence output format, for python parsing */
 

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -377,8 +377,12 @@ int main(int argc, const char** argv)
             if (argument[1]=='-') {
                 if (!strcmp(argument,  "--")) { all_arguments_are_files = 1; continue; }
                 if (!strcmp(argument,  "--compress")) { mode = om_compress; continue; }
-                if ((!strcmp(argument, "--decompress"))
-                    || (!strcmp(argument, "--uncompress"))) { mode = om_decompress; continue; }
+                if ( (!strcmp(argument, "--decompress"))
+                  || (!strcmp(argument, "--uncompress"))) {
+                      if (mode != om_bench) mode = om_decompress;
+                      BMK_setDecodeOnlyMode(1);
+                      continue;
+                 }
                 if (!strcmp(argument,  "--multiple")) { multiple_inputs = 1; continue; }
                 if (!strcmp(argument,  "--test")) { mode = om_test; continue; }
                 if (!strcmp(argument,  "--force")) { LZ4IO_setOverwrite(prefs, 1); continue; }
@@ -478,7 +482,10 @@ int main(int argc, const char** argv)
                 case 'l': legacy_format = 1; blockSize = 8 MB; break;
 
                     /* Decoding */
-                case 'd': mode = om_decompress; break;
+                case 'd':
+                    if (mode != om_bench) mode = om_decompress;
+                    BMK_setDecodeOnlyMode(1);
+                    break;
 
                     /* Force stdout, even if stdout==console */
                 case 'c':

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -476,6 +476,9 @@ test-lz4-testmode: FPREFIX = tmp-ltm
 test-lz4-testmode: lz4 datagen
 	@echo "\n ---- bench mode ----"
 	$(LZ4) -bi0
+	$(DATAGEN) > $(FPREFIX)
+	$(LZ4) -f $(FPREFIX) -c > $(FPREFIX).lz4
+	$(LZ4) -bdi0 $(FPREFIX).lz4 # test benchmark decode-only mode
 	@echo "\n ---- test mode ----"
 	! $(DATAGEN) | $(LZ4) -t
 	! $(DATAGEN) | $(LZ4) -tf

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -397,7 +397,8 @@ static int local_LZ4F_decompress_followHint(const char* src, char* dst, int srcS
     size_t outRemaining = maxOutSize - outPos;
 
     for (;;) {
-        size_t const sizeHint = LZ4F_decompress(g_dCtx, dst+outPos, &outRemaining, src+inPos, &inSize, NULL);
+        size_t const sizeHint =
+            LZ4F_decompress(g_dCtx, dst+outPos, &outRemaining, src+inPos, &inSize, NULL);
         assert(!LZ4F_isError(sizeHint));
 
         inPos += inSize;


### PR DESCRIPTION
`lz4 -b` is  pretty  convenient when benchmarking the outcome of code modifications on speed.
The  way it works, it requires round-tripping the input : compress it first, then  decompress. Repeat a few times to get stable results.
Waiting for compression is a nuisance when the goal is only to measure  decompression speed. 
It's generally not a problem in "default" mode, (`-1`), since compression is fast enough to not wait. But, when  considering benchmarking on the product of `-9` of `-12`, and on larger samples, compression becomes a non-negligible wait time. This is a concern for development  velocity.

This PR introduces decoder-only benchmark mode.
Invocation is pretty simple : instead of `-b`, which keeps the usual round-tripping mode, use `-bd`, or any  equivalent which  combines "benchmark" and "decompression".

A few considerations : 
- Input must be a  valid LZ4  Frame.  That's the  only format that  the decode-only benchmark mode can support.
    - Note that the regular round-tripping benchmark employs the block mode. So results are slightly different.
- As a side effect of combining both modes into a single benchmark routine, there is a hard input size limit, at `LZ4_MAX_INPUT_SIZE` bytes (aka a bit less than 2 GB). Frames larger than this size won't be accepted.
- More importantly, the LZ4 Frame decoding speed is highly dependent on the presence of a checksum. When checksum is present, it's calculated and validated. This can cost up to 40% of CPU just for this stage, measuring a combined speed much slower than decompression alone.

For all these reasons, I consider this feature still  "fragile", and intend to keep this mode a "developer only" capability, and therefore not document it. It's going to be useful  in upcoming investigations on the decoder code base.
