### PR TITLE
Introduce ability to save cpu cycles by disabling checksum validation

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1959,11 +1959,11 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 (void)readCRC;
                 (void)resultCRC;
 #endif
-                nextSrcSizeHint = 0;
-                LZ4F_resetDecompressionContext(dctx);
-                doAnotherStage = 0;
-                break;
             }
+            nextSrcSizeHint = 0;
+            LZ4F_resetDecompressionContext(dctx);
+            doAnotherStage = 0;
+            break;
 
         case dstage_getSFrameSize:
             if ((srcEnd - srcPtr) >= 4) {

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -355,8 +355,12 @@ typedef struct LZ4F_dctx_s LZ4F_dctx;   /* incomplete type */
 typedef LZ4F_dctx* LZ4F_decompressionContext_t;   /* compatibility with previous API versions */
 
 typedef struct {
-  unsigned stableDst;    /* pledges that last 64KB decompressed data will remain available unmodified. This optimization skips storage operations in tmp buffers. */
-  unsigned reserved[3];  /* must be set to zero for forward compatibility */
+  unsigned stableDst;     /* pledges that last 64KB decompressed data will remain available unmodified between invocations.
+                           * This optimization skips storage operations in tmp buffers. */
+  unsigned skipChecksums; /* disable checksum calculation and verification, even when one is present in frame, to save CPU time.
+                           * Setting this option to 1 once disables all checksums for the rest of the frame. */
+  unsigned reserved1;     /* must be set to zero for forward compatibility */
+  unsigned reserved0;     /* idem */
 } LZ4F_decompressOptions_t;
 
 

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -321,8 +321,10 @@ LZ4F_decompress_binding(const char* src, char* dst,
 {
     size_t dstSize = (size_t)dstCapacity;
     size_t readSize = (size_t)srcSize;
-    LZ4F_decompressOptions_t const dOpt = { 1, g_skipChecksums, 0, 0 };
-    size_t const decStatus = LZ4F_decompress(g_dctx,
+    LZ4F_decompressOptions_t dOpt = { 1, 0, 0, 0 };
+    size_t decStatus;
+    dOpt.skipChecksums = g_skipChecksums;
+    decStatus = LZ4F_decompress(g_dctx,
                     dst, &dstSize,
                     src, &readSize,
                     &dOpt);

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -47,6 +47,7 @@ void BMK_setBlockSize(size_t blockSize);    /* Internally cut input file(s) into
 void BMK_setNotificationLevel(unsigned level);  /* Influence verbosity level */
 void BMK_setBenchSeparately(int separate);  /* When providing multiple files, output one result per file */
 void BMK_setDecodeOnlyMode(int set);        /* v1.9.4+: set benchmark mode to decode only */
+void BMK_skipChecksums(int skip);           /* v1.9.4+: only useful for DecodeOnlyMode; do not calculate checksum when present, to save CPU time */
 
 void BMK_setAdditionalParam(int additionalParam); /* hidden param, influence output format, for python parsing */
 

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -188,6 +188,9 @@ only the latest one will be applied.
 * `--[no-]frame-crc`:
   Select frame checksum (default:enabled)
 
+* `--no-crc`:
+  Disable both frame and block checksums
+
 * `--[no-]content-size`:
   Header includes original size (default:not present)<br/>
   Note : this option can only be activated when the original size can be

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -391,6 +391,7 @@ int main(int argc, const char** argv)
                     || (!strcmp(argument, "--to-stdout"))) { forceStdout=1; output_filename=stdoutmark; continue; }
                 if (!strcmp(argument,  "--frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 1); BMK_skipChecksums(0); continue; }
                 if (!strcmp(argument,  "--no-frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 0); BMK_skipChecksums(1); continue; }
+                if (!strcmp(argument,  "--no-crc")) { LZ4IO_setStreamChecksumMode(prefs, 0); LZ4IO_setBlockChecksumMode(prefs, 0); BMK_skipChecksums(1); continue; }
                 if (!strcmp(argument,  "--content-size")) { LZ4IO_setContentSize(prefs, 1); continue; }
                 if (!strcmp(argument,  "--no-content-size")) { LZ4IO_setContentSize(prefs, 0); continue; }
                 if (!strcmp(argument,  "--list")) { mode = om_list; continue; }

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -389,8 +389,8 @@ int main(int argc, const char** argv)
                 if (!strcmp(argument,  "--no-force")) { LZ4IO_setOverwrite(prefs, 0); continue; }
                 if ((!strcmp(argument, "--stdout"))
                     || (!strcmp(argument, "--to-stdout"))) { forceStdout=1; output_filename=stdoutmark; continue; }
-                if (!strcmp(argument,  "--frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 1); continue; }
-                if (!strcmp(argument,  "--no-frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 0); continue; }
+                if (!strcmp(argument,  "--frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 1); BMK_skipChecksums(0); continue; }
+                if (!strcmp(argument,  "--no-frame-crc")) { LZ4IO_setStreamChecksumMode(prefs, 0); BMK_skipChecksums(1); continue; }
                 if (!strcmp(argument,  "--content-size")) { LZ4IO_setContentSize(prefs, 1); continue; }
                 if (!strcmp(argument,  "--no-content-size")) { LZ4IO_setContentSize(prefs, 0); continue; }
                 if (!strcmp(argument,  "--list")) { mode = om_list; continue; }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -380,7 +380,7 @@ test-lz4-basic: lz4 datagen unlz4 lz4cat
 	$(DATAGEN) -g6M -P99 | $(LZ4) -9BD   | $(LZ4) -t
 	$(DATAGEN) -g17M     | $(LZ4) -9v    | $(LZ4) -qt
 	$(DATAGEN) -g33M     | $(LZ4) --no-frame-crc | $(LZ4) -t
-	$(DATAGEN) -g256MB   | $(LZ4) -vqB4D | $(LZ4) -t
+	$(DATAGEN) -g256MB   | $(LZ4) -vqB4D | $(LZ4) -t --no-crc
 	@echo "hello world" > $(FPREFIX)-hw
 	$(LZ4) --rm -f $(FPREFIX)-hw $(FPREFIX)-hw.lz4
 	test ! -f $(FPREFIX)-hw                      # must fail (--rm)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -376,6 +376,7 @@ test-lz4-basic: lz4 datagen unlz4 lz4cat
 	$(LZ4) --no-frame-crc < $(FPREFIX)-dg20k | $(LZ4) -d > $(FPREFIX)-dec
 	$(DIFF) -q $(FPREFIX)-dg20k $(FPREFIX)-dec
 	$(DATAGEN)           | $(LZ4) -BI    | $(LZ4) -t
+	$(DATAGEN)           | $(LZ4) --no-crc | $(LZ4) -t
 	$(DATAGEN) -g6M -P99 | $(LZ4) -9BD   | $(LZ4) -t
 	$(DATAGEN) -g17M     | $(LZ4) -9v    | $(LZ4) -qt
 	$(DATAGEN) -g33M     | $(LZ4) --no-frame-crc | $(LZ4) -t
@@ -479,6 +480,7 @@ test-lz4-testmode: lz4 datagen
 	$(DATAGEN) > $(FPREFIX)
 	$(LZ4) -f $(FPREFIX) -c > $(FPREFIX).lz4
 	$(LZ4) -bdi0 $(FPREFIX).lz4 # test benchmark decode-only mode
+	$(LZ4) -bdi0 --no-crc $(FPREFIX).lz4 # test benchmark decode-only mode
 	@echo "\n ---- test mode ----"
 	! $(DATAGEN) | $(LZ4) -t
 	! $(DATAGEN) | $(LZ4) -tf

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -906,6 +906,7 @@ size_t test_lz4f_decompression_wBuffers(
         memset(&dOptions, 0, sizeof(dOptions));
         dOptions.stableDst = FUZ_rand(randState) & 1;
         if (o_scenario == o_overwrite) dOptions.stableDst = 0;  /* overwrite mode */
+        dOptions.skipChecksums = FUZ_rand(randState) & 127;
         if (sentinelTest) op[oSizeMax] = mark;
 
         DISPLAYLEVEL(7, "dstCapacity=%u,  presentedInput=%u \n", (unsigned)oSize, (unsigned)iSize);


### PR DESCRIPTION
This new capability only applies to LZ4 Frames, which can optionally embed a Frame Content checksum, and even block checksums.
When this situation happens for a received  frame, corresponding flags will be set in the header, and the `lz4frame.c` library will automatically compute the required checksum(s) in the background, and compare it to the transmitted one, to validate the content.
The checksum is computed using `XXH32()`, which is pretty fast. Yet, LZ4 decoder is also really fast. Consequently, **up to 40% cpu time** can employed just to compute the checksum.
While the final combined speed remains decently fast, there might be situations where some users would prefer to save cpu instead, to achieve better decoding speed, simply by disabling checksum validation.

This is what this PR allows. It introduces a new parameter, within the optional `LZ4F_decompressOptions_t` parameter structure,  called `skipChecksums`. As the name implies, once selected, this parameter will make the decoder skip all checksum validations for the rest of the frame, with the goal to save cpu cycles.

Obviously, when received frame do not contain any checksum, this parameter will not impact performance in any way. And note that checksums are disabled by default when employing the `lz4frame.h` API. That being said, frame content checksum is enabled by default when employing the `lz4` CLI.

This capability  can be triggered from the command line, by using  the new `--no-crc` long command, which will disable checksum validation for compression (as usual), decompression and benchmark modes.