### PR TITLE
Introduce LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -189,12 +189,9 @@
 *  Memory routines
 **************************************/
 #if defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-#  undef LZ4_ALLOC
-#  undef LZ4_ALLOC_AND_ZERO
-#  undef LZ4_FREEMEM
-#  define LZ4_ALLOC(x)			lz4_error_memory_allocation_is_disabled
-#  define LZ4_ALLOC_AND_ZERO(x)	lz4_error_memory_allocation_is_disabled
-#  define LZ4_FREEMEM(x)		lz4_error_memory_allocation_is_disabled
+#  define ALLOC(s)          lz4_error_memory_allocation_is_disabled
+#  define ALLOC_AND_ZERO(s) lz4_error_memory_allocation_is_disabled
+#  define FREEMEM(p)        lz4_error_memory_allocation_is_disabled
 #elif defined(LZ4_USER_MEMORY_FUNCTIONS)
 /* memory management functions can be customized by user project.
  * Below functions must exist somewhere in the Project

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -188,7 +188,14 @@
 /*-************************************
 *  Memory routines
 **************************************/
-#ifdef LZ4_USER_MEMORY_FUNCTIONS
+#if defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  undef LZ4_ALLOC
+#  undef LZ4_ALLOC_AND_ZERO
+#  undef LZ4_FREEMEM
+#  define LZ4_ALLOC(x)			lz4_error_memory_allocation_is_disabled
+#  define LZ4_ALLOC_AND_ZERO(x)	lz4_error_memory_allocation_is_disabled
+#  define LZ4_FREEMEM(x)		lz4_error_memory_allocation_is_disabled
+#elif defined(LZ4_USER_MEMORY_FUNCTIONS)
 /* memory management functions can be customized by user project.
  * Below functions must exist somewhere in the Project
  * and be available at link time */
@@ -1440,6 +1447,7 @@ int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targe
 *  Streaming functions
 ********************************/
 
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
@@ -1449,6 +1457,7 @@ LZ4_stream_t* LZ4_createStream(void)
     LZ4_initStream(lz4s, sizeof(*lz4s));
     return lz4s;
 }
+#endif
 
 static size_t LZ4_stream_t_alignment(void)
 {
@@ -1482,6 +1491,7 @@ void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
     LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
 }
 
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
 {
     if (!LZ4_stream) return 0;   /* support free on NULL */
@@ -1489,6 +1499,7 @@ int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
     FREEMEM(LZ4_stream);
     return (0);
 }
+#endif
 
 
 #define HASH_UNIT sizeof(reg_t)
@@ -2321,6 +2332,7 @@ int LZ4_decompress_fast_doubleDict(const char* source, char* dest, int originalS
 
 /*===== streaming decompression functions =====*/
 
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 {
     LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
@@ -2333,6 +2345,7 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
     FREEMEM(LZ4_stream);
     return 0;
 }
+#endif
 
 /*! LZ4_setStreamDecode() :
  *  Use this function to instruct where to find the dictionary.
@@ -2558,11 +2571,13 @@ int LZ4_resetStreamState(void* state, char* inputBuffer)
     return 0;
 }
 
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 void* LZ4_create (char* inputBuffer)
 {
     (void)inputBuffer;
     return LZ4_createStream();
 }
+#endif
 
 char* LZ4_slideInputBuffer (void* state)
 {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -988,6 +988,7 @@ int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* s
 *  Streaming Functions
 **************************************/
 /* allocation */
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamHC_t* LZ4_createStreamHC(void)
 {
     LZ4_streamHC_t* const state =
@@ -1004,6 +1005,7 @@ int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
     FREEMEM(LZ4_streamHCPtr);
     return 0;
 }
+#endif
 
 
 LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)


### PR DESCRIPTION
Part of #1071.

This changeset introduces new compile time switch macro `LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION`
which removes the following functions when it's defined.

```
// lz4.c
LZ4_createStream
LZ4_freeStream
LZ4_createStreamDecode
LZ4_freeStreamDecode
LZ4_create              // legacy

// lz4hc.c
LZ4_createStreamHC(void)
LZ4_freeStreamHC
LZ4_createHC            // legacy
LZ4_freeHC              // legacy
```

These functions uses dynamic memory allocation functions such as malloc() and free().
It'll be useful for freestanding environment which doesn't have these allocation functions.

Since this change breaks API, this macro is only valid with lz4 as a static linked object.