### PR TITLE
refactor read_variable_length()

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1732,19 +1732,19 @@ typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
  * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
  * @error (output) - error code.  Must be set to 0 before call.
  */
+typedef unsigned Rvl_t;  /* note : using size_t seems to result in slowdown */
 typedef enum { loop_error = -2, initial_error = -1, ok = 0 } variable_length_error;
-LZ4_FORCE_INLINE unsigned
+LZ4_FORCE_INLINE Rvl_t
 read_variable_length(const BYTE**ip, const BYTE* ipmax,
                      int loop_check, int initial_check,
                      variable_length_error* error)
 {
-    U32 length = 0;
-    U32 s;
-    assert(ip != NULL);
-    assert(*ip != NULL);
-    assert(ipmax != NULL);
-    assert(error != NULL);
-    assert(*error == 0);
+    Rvl_t length = 0;
+    Rvl_t s;
+    assert(ip != NULL); assert(*ip != NULL);
+    if (initial_check) assert(loop_check);
+    if (loop_check) assert(ipmax != NULL);
+    assert(error != NULL); assert(*error == 0);
     if (initial_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
         *error = initial_error;
         return length;

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1755,21 +1755,20 @@ read_variable_length(const BYTE**ip, const BYTE* ipmax,
     s = **ip;
     (*ip)++;
     length += s;
-    if (s == 255) {
+    if (s < 255) return length;
+    if (loop_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
+        *error = loop_error;
+        return length;
+    }
+    do {
+        s = **ip;
+        (*ip)++;
+        length += s;
         if (loop_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
             *error = loop_error;
             return length;
         }
-        do {
-            s = **ip;
-            (*ip)++;
-            length += s;
-            if (loop_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
-                *error = loop_error;
-                return length;
-            }
-        } while (s==255);
-    }
+    } while (s==255);
     return length;
 }
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1739,36 +1739,37 @@ read_variable_length(const BYTE**ip, const BYTE* ipmax,
                      int loop_check, int initial_check,
                      variable_length_error* error)
 {
-    Rvl_t length = 0;
-    Rvl_t s;
+    Rvl_t length;
     assert(ip != NULL); assert(*ip != NULL);
     if (initial_check) assert(loop_check);
     if (loop_check) assert(ipmax != NULL);
     assert(error != NULL); assert(*error == 0);
     if (initial_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
         *error = initial_error;
-        return length;
+        return 0;
     } else {
         if (loop_check) assert(*ip < ipmax);
     }
     /* separate branch of first extra byte from rest of the loop */
-    s = **ip;
-    (*ip)++;
-    length += s;
-    if (s < 255) return length;
+    {   Rvl_t const acc = **ip;
+        (*ip)++;
+        if (acc < 255) return acc;
+        length = acc;
+    }
     if (loop_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
         *error = loop_error;
         return length;
     }
     do {
-        s = **ip;
+        Rvl_t const s = **ip;
         (*ip)++;
         length += s;
+        if (s != 255) break;
         if (loop_check && unlikely((*ip) >= ipmax)) {    /* overflow detection */
             *error = loop_error;
             return length;
         }
-    } while (s==255);
+    } while (1);
     return length;
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -407,7 +407,7 @@ test-lz4-basic: lz4 datagen unlz4 lz4cat
 	test ! -f ./-z
 	$(DIFF) -q $(FPREFIX)-hw $(FPREFIX)4
 	! $(LZ4) $(FPREFIX)2 $(FPREFIX)3 $(FPREFIX)4    # must fail: refuse to handle 3+ file names
-	$(LZ4) -f $(FPREFIX)-hw                   # create $(FPREFIX)-hw.lz4, for next tests
+	$(LZ4) -f $(FPREFIX)-hw -c > $(FPREFIX)-hw.lz4  # create $(FPREFIX)-hw.lz4, for next tests
 	$(LZ4) --list $(FPREFIX)-hw.lz4           # test --list on valid single-frame file
 	$(LZ4) --list < $(FPREFIX)-hw.lz4         # test --list from stdin (file only)
 	$(CAT) $(FPREFIX)-hw >> $(FPREFIX)-hw.lz4

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1223,7 +1223,7 @@ static void FUZ_unitTests(int compressionLevel)
         }   }
         DISPLAYLEVEL(3, "OK \n");
 
-        /* ring buffer test */
+        DISPLAYLEVEL(3, "ring buffer test : ");
         {   XXH64_state_t xxhOrig;
             XXH64_state_t xxhNewSafe, xxhNewFast;
             LZ4_streamDecode_t decodeStateSafe, decodeStateFast;
@@ -1273,6 +1273,7 @@ static void FUZ_unitTests(int compressionLevel)
                 if (rNext + messageSize > ringBufferSize) rNext = 0;
                 if (dNext + messageSize > dBufferSize) dNext = 0;
         }   }
+        DISPLAYLEVEL(3, "OK \n");
     }
 
     DISPLAYLEVEL(3, "LZ4_initStreamHC with multiple valid alignments : ");


### PR DESCRIPTION
- improved documentation
- more `assert()`
- better distinction between "end of scanning area" and "end of buffer"
- minor performance optimization, by separating first branch from the rest of the loop.

The last item is more controversial, because it's difficult to measure the benefit. While it does result in measurable performance improvement on my bench platform, the main lesson is that the LZ4 decoding loop works so close to the limits of cpu front end that performance is primarily driven by the  DSB / MITE repartition of instructions, which is itself depending on complex instruction alignments consequences, which are essentially random from a C code perspective (it's up to the compiler to decide that, and unfortunately, it's not doing a consistent job). So minor code changes can result in vast performance differences, in either direction, for any minor detail (exact compiler version, set of flags, surrounding code), making it hard to determine if a given change is globally positive or not.