### PR TITLE
Cancel in-progress CI if a new commit workflow supplants it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+
 jobs:
   lz4-c-compilers:
     name: CC=${{ matrix.cc }}, ${{ matrix.os }}


### PR DESCRIPTION
This is useful when repushing to a PR very quickly and when merging to
dev very quickly.