### PR TITLE
allocation optimization for lz4frame compression

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -264,7 +264,7 @@ typedef struct LZ4F_cctx_s
     LZ4F_CustomMem cmem;
     LZ4F_preferences_t prefs;
     U32    version;
-    U32    cStage;
+    U32    cStage;     /* 0 : compression uninitialized ; 1 : initialized, can compress */
     const LZ4F_CDict* cdict;
     size_t maxBlockSize;
     size_t maxBufferSize;
@@ -732,7 +732,7 @@ size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctxPtr,
         if (cctxPtr->maxBufferSize < requiredBuffSize) {
             cctxPtr->maxBufferSize = 0;
             LZ4F_free(cctxPtr->tmpBuff, cctxPtr->cmem);
-            cctxPtr->tmpBuff = (BYTE*)LZ4F_calloc(requiredBuffSize, cctxPtr->cmem);
+            cctxPtr->tmpBuff = (BYTE*)LZ4F_malloc(requiredBuffSize, cctxPtr->cmem);
             RETURN_ERROR_IF(cctxPtr->tmpBuff == NULL, allocation_failed);
             cctxPtr->maxBufferSize = requiredBuffSize;
     }   }
@@ -1176,7 +1176,6 @@ size_t LZ4F_compressEnd(LZ4F_cctx* cctxPtr,
     }
 
     cctxPtr->cStage = 0;   /* state is now re-usable (with identical preferences) */
-    cctxPtr->maxBufferSize = 0;  /* reuse HC context */
 
     if (cctxPtr->prefs.frameInfo.contentSize) {
         if (cctxPtr->prefs.frameInfo.contentSize != cctxPtr->totalInSize)
@@ -1722,10 +1721,10 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                     /* history management (linked blocks only)*/
                     if (dctx->frameInfo.blockMode == LZ4F_blockLinked) {
                         LZ4F_updateDict(dctx, dstPtr, sizeToCopy, dstStart, 0);
-                }   }
-
-                srcPtr += sizeToCopy;
-                dstPtr += sizeToCopy;
+                    }
+                    srcPtr += sizeToCopy;
+                    dstPtr += sizeToCopy;
+                }
                 if (sizeToCopy == dctx->tmpInTarget) {   /* all done */
                     if (dctx->frameInfo.blockChecksumFlag) {
                         dctx->tmpInSize = 0;

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -278,7 +278,7 @@ LZ4FLIB_API LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctx);
 /*! LZ4F_compressBegin() :
  *  will write the frame header into dstBuffer.
  *  dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.
- * `prefsPtr` is optional : you can provide NULL as argument, all preferences will then be set to default.
+ * `prefsPtr` is optional : NULL can be provided to set all preferences to default.
  * @return : number of bytes written into dstBuffer for the header
  *           or an error code (which can be tested using LZ4F_isError())
  */


### PR DESCRIPTION
as noted by @yixiutt in #1157, the temporary buffer managed by lz4frame compression context is being invalidated at end of compression, forcing it to be re-allocated at next compression job.

This shouldn't be necessary.
This behavior was introduced in #236, as a way to fix #232, but neither the issue is explained, nor why the patch fixes it.

This patch reverts to previous behavior,
where temporary buffer is reused between compression calls. 
This results in a net reduction of allocation workload.

Additionally, the temporary buffer should only need `malloc()`, not `calloc()`, thus saving some potential 0-initialization cost.

This diff implements both changes. It's expected to improve compression speed when repetitively compressing small data.

Performance impact on M1 laptop : 
| filename | size | cSpeed before | cSpeed after | delta |
| --- | --- | --- | --- | --- |
| enwik7 | 1000000 | 485 MB/s | 485 MB/s | +0% |
| enwik6 | 100000 | 505 MB/s | 508 MB/s  | +1% |
| enwik5 | 10000 | 862 MB/s | 1037 MB/s |  +20% |
| enwik4 | 1000 | 359 MB/s | 940 MB/s | +160% |

As expected, performance difference is only perceptible for small data, but it can matter a lot in this case.

Once this diff is merged, long fuzzer tests will be run to ensure that no sanitizer warning gets triggered.

Additionally :
- fixed a minor ubsan warning in `LZ4F_decompress()`
- added an `LZ4F_compressUpdate()` test to `fullbench`