### PR TITLE
build: Support BUILD_SHARED=no

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -112,17 +112,21 @@ liblz4-dll.o: liblz4-dll.rc
 	$(WINDRES) -i liblz4-dll.rc -o liblz4-dll.o
 
 $(LIBLZ4): $(SRCFILES) liblz4-dll.o
+ifeq ($(BUILD_SHARED),yes)
 	@echo compiling dynamic library $(LIBVER)
 	$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll -Wl,--out-implib,dll/$(LIBLZ4_EXP)
+endif
 
 else   # not windows
 
 $(LIBLZ4): $(SRCFILES)
+ifeq ($(BUILD_SHARED),yes)
 	@echo compiling dynamic library $(LIBVER)
 	$(CC) $(FLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
 	@echo creating versioned links
 	$(LN_SF) $@ liblz4.$(SHARED_EXT_MAJOR)
 	$(LN_SF) $@ liblz4.$(SHARED_EXT)
+endif
 
 endif
 


### PR DESCRIPTION
Since e585a438c714652e866a59371b287f52aa4d2dc3, the BUILD_SHARED Makefile variable only takes effect for the install target (i.e. the shared libraries always built). This restores the original behaviour.