### PR TITLE
LZ4 HC match finder and parsers use direct offset values

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -366,7 +366,7 @@ LZ4HC_InsertAndGetWiderMatch (
                 if ( (repeat == rep_confirmed) && (matchCandidateIdx >= lowestMatchIndex)
                   && LZ4HC_protectDictEnd(prefixIdx, matchCandidateIdx) ) {
                     const int extDict = matchCandidateIdx < prefixIdx;
-                    const BYTE* const matchPtr = (extDict ? dictStart - dictIdx : prefixPtr - prefixIdx) + matchCandidateIdx;
+                    const BYTE* const matchPtr = extDict ? dictStart + (matchCandidateIdx - dictIdx) : prefixPtr + (matchCandidateIdx - prefixIdx);
                     if (LZ4_read32(matchPtr) == pattern) {  /* good candidate */
                         const BYTE* const iLimit = extDict ? dictEnd : iHighLimit;
                         size_t forwardPatternLength = LZ4HC_countPattern(matchPtr+sizeof(pattern), iLimit, pattern) + sizeof(pattern);


### PR DESCRIPTION
Direct offset values replace the former method of "virtual pointers", which could lead to UB in some complex scenarios involving a combination of HC compression, external dictionaries and low memory addresses.

As importantly, it also makes the code a bit easier to read.

The produced compressed data remains strictly bit-identical.
Performance is unchanged on M1+`clang`,
but it's unfortunately slightly slower on Skylake (both `gcc` & `clang`).

Even in latter case, the performance difference remains small (<5%), confined to fastest levels (3-5), and quickly unmeasurable at higher levels.

I'm tempted to favor correctness and readability over the small speed difference, given that these HC levels are not speed-sensitive (as long as performance differences remain within a few %).