### PR TITLE
fixed usan32 tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ usan: clean
 	CC=$(CC) CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' $(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
 
 .PHONY: usan32
-usan32: CFLAGS = -m32 -O3 -g -fsanitize=undefined
+usan32: CFLAGS = -m32 -O3 -g -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-recover=pointer-overflow
 usan32: LDFLAGS = $(CFLAGS)
 usan32: clean
-	$(MAKE) test FUZZER_TIME="-T30s" NB_LOOPS=-i1
+	CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' $(MAKE) V=1 test FUZZER_TIME="-T30s" NB_LOOPS=-i1
 
 SCANBUILD ?= scan-build
 SCANBUILD_FLAGS += --status-bugs -v --force-analyze-debug-code

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -257,7 +257,7 @@ LZ4HC_InsertAndGetWiderMatch (
         const HCfavor_e favorDecSpeed)
 {
     U16* const chainTable = hc4->chainTable;
-    U32* const HashTable = hc4->hashTable;
+    U32* const hashTable = hc4->hashTable;
     const LZ4HC_CCtx_internal * const dictCtx = hc4->dictCtx;
     const BYTE* const prefixPtr = hc4->prefixStart;
     const U32 prefixIdx = hc4->dictLimit;
@@ -280,8 +280,8 @@ LZ4HC_InsertAndGetWiderMatch (
     assert(startpos != NULL);
     *startpos = ip;  /* in case there is no solution */
     /* First Match */
-    LZ4HC_Insert(hc4, ip);
-    matchIndex = HashTable[LZ4HC_hashPtr(ip)];
+    LZ4HC_Insert(hc4, ip);  /* insert all prior positions up to ip (excluded) */
+    matchIndex = hashTable[LZ4HC_hashPtr(ip)];
     DEBUGLOG(7, "First candidate match for pos %u found at index %u / %u (lowestMatchIndex)",
                 ipIndex, matchIndex, lowestMatchIndex);
 
@@ -293,7 +293,7 @@ LZ4HC_InsertAndGetWiderMatch (
             /* do nothing:
              * favorDecSpeed intentionally skips matches with offset < 8 */
         } else if (matchIndex >= prefixIdx) {   /* within current Prefix */
-            const BYTE* const matchPtr = prefixPtr + matchIndex - prefixIdx;
+            const BYTE* const matchPtr = prefixPtr + (matchIndex - prefixIdx);
             assert(matchPtr < ip);
             assert(longest >= 1);
             if (LZ4_read16(iLowLimit + longest - 1) == LZ4_read16(matchPtr - lookBackLength + longest - 1)) {


### PR DESCRIPTION
the sanitizer was not enabled,
due to environment variables not being passed to second level `make`.