### PR TITLE
Add arm64 assembly decoder

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,7 @@ Consequently, they are not interoperable with LZ4 command line utility, nor (gen
 |__WASM__             | Raymond Hill        | https://github.com/gorhill/lz4-wasm
 |__C__ decoder (tiny) | Justine Tunney      | https://github.com/jart/cosmopolitan/blob/467504308a103865c058f9a0ac858cc22e72240e/libc/nexgen32e/lz4cpy.c
 |__ARM Cortex assembly__ decoder | Jens Bauer | https://community.arm.com/developer/ip-products/processors/b/processors-ip-blog/posts/lz4-decompression-routine-for-cortex-m0-and-later
+|__arm64 assembly__ decoder | Siguza        | https://github.com/Siguza/lz4dec
 |__Risc-V assembly__ decoder | Martin Wendt | https://github.com/enthusi/lz4_rv32i_decode
 |__8088 assembly__ decoder | Jim Leonard    | http://www.oldskool.org/pc/lz4_8088
 |__6502 & 65C02 assembly__ decoder | Peter Ferrie | https://github.com/pararaum/lz4-6502


### PR DESCRIPTION
I wrote a tiny LZ4 block decoder in arm64 assembly for use in freestanding environments.   
Figured it would be nice to link it here, since you have a 32-bit ARM one already. :)