### PR TITLE
Add environment check for freestanding test : resolves #1186

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -115,9 +115,6 @@ decompress-partial: lz4.o decompress-partial.c
 decompress-partial-usingDict: lz4.o decompress-partial-usingDict.c
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
-freestanding: freestanding.c
-	$(CC) -ffreestanding -nostdlib $^ -o $@$(EXT)
-
 .PHONY: clean
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
@@ -353,10 +350,44 @@ test-decompress-partial : decompress-partial decompress-partial-usingDict
 	@echo "\n ---- test decompress-partial-usingDict ----"
 	./decompress-partial-usingDict$(EXT)
 
+
+#-----------------------------------------------------------------------------
+# freestanding test only for Linux x86_64
+#-----------------------------------------------------------------------------
+ifeq ($(OS),Windows_NT)
+  UNAME_S := Windows
+else
+  UNAME_S := $(shell uname -s)
+endif
+
+ifeq ($(OS),Windows_NT)
+  UNAME_P := Unknown
+else
+  UNAME_P := $(shell uname -p)
+endif
+
+FREESTANDING_CFLAGS := -ffreestanding -nostdlib
+
+ifneq ($(UNAME_S), Linux)
+  FREESTANDING_CFLAGS :=
+endif
+
+ifneq ($(UNAME_P), x86_64)
+  FREESTANDING_CFLAGS :=
+endif
+
+freestanding: freestanding.c
+	$(CC) $(FREESTANDING_CFLAGS) $^ -o $@$(EXT)
+
 test-freestanding: freestanding
 	@echo "\n ---- test freestanding ----"
+ifeq ($(FREESTANDING_CFLAGS),)
+	@echo "\n (skip)"
+else
 	./freestanding$(EXT)
 	-strace ./freestanding$(EXT)
 	-ltrace ./freestanding$(EXT)
+endif
+
 
 endif

--- a/tests/freestanding.c
+++ b/tests/freestanding.c
@@ -30,7 +30,6 @@
 
 
 #if !defined(__x86_64__) || !defined(__linux__)
-EXTERN_C void _start(void) { }
 int main(int argc, char** argv) { return 0; }
 #else
 


### PR DESCRIPTION
Freestanding test is intended to run on only Linux x86_64 platform. Because it uses Linux x86_64 syscall directly to avoid any dependency to the standard library.

This changeset adds platform checking code to tests/Makefile to avoid unintended error in non-Linux x86_64 platforms.

This changeset resolves issue #1186