### PR TITLE
Add `freestanding` to `all` and `test` of `tests/Makefile`

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,7 +56,7 @@ NB_LOOPS     ?= -i1
 .PHONY: default
 default: all
 
-all: fullbench fuzzer frametest roundTripTest datagen checkFrame decompress-partial
+all: fullbench fuzzer frametest roundTripTest datagen checkFrame decompress-partial freestanding
 
 all32: CFLAGS+=-m32
 all32: all
@@ -180,7 +180,7 @@ list:
 check: test-lz4-essentials
 
 .PHONY: test
-test: test-lz4 test-lz4c test-frametest test-fullbench test-fuzzer test-amalgamation listTest test-decompress-partial
+test: test-lz4 test-lz4c test-frametest test-fullbench test-fuzzer test-amalgamation listTest test-decompress-partial test-freestanding
 
 .PHONY: test32
 test32: CFLAGS+=-m32
@@ -373,6 +373,10 @@ ifneq ($(UNAME_S), Linux)
 endif
 
 ifneq ($(UNAME_P), x86_64)
+  FREESTANDING_CFLAGS :=
+endif
+
+ifneq (,$(findstring -m32,$(CFLAGS)))
   FREESTANDING_CFLAGS :=
 endif
 


### PR DESCRIPTION
Follow up of #1184 and #1187

Now `tests/Makefile` contains

- `freestanding` as a member of `all`.
- `test-freestanding` as a member of `test`.

Note that as for `all32` (`-m32`) builds, `test-freestanding` skips its actual test.

----
```
cd /path/to/lz4
cd tests

make all
# cc -ffreestanding -nostdlib freestanding.c -o freestanding

make test
#  ---- test freestanding ----
# ./freestanding
# strace ./freestanding
# ...
# +++ exited with 0 +++
# ltrace ./freestanding
# +++ exited (status 0) +++
```
