### PR TITLE
Improve LZ4F_decompress() docs

### DIFF
--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -473,6 +473,11 @@ LZ4F_getFrameInfo(LZ4F_dctx* dctx,
  * `dstBuffer` can freely change between each consecutive function invocation.
  * `dstBuffer` content will be overwritten.
  *
+ *  Note: if `LZ4F_getFrameInfo()` is called before `LZ4F_decompress()`, srcBuffer must be updated to reflect
+ *  the number of bytes consumed after reading the frame header. Failure to update srcBuffer before calling
+ *  `LZ4F_decompress()` will cause decompression failure or, even worse, successful but incorrect decompression.
+ *  See the `LZ4F_getFrameInfo()` docs for details.
+ *
  * @return : an hint of how many `srcSize` bytes LZ4F_decompress() expects for next call.
  *  Schematically, it's the size of the current (or remaining) compressed block + header of next block.
  *  Respecting the hint provides some small speed benefit, because it skips intermediate buffers.


### PR DESCRIPTION
zstd requires users to pass the frame header along with the frame content, while lz4 separates the header and the content. This PR adds an explicit warning for users coming from zstd who are used to passing in the header and content together.