### PR TITLE
Improve decompression speed

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2122,7 +2122,6 @@ LZ4_decompress_generic(
 
             assert((op <= oend) && (oend-op >= 32));
             if (unlikely(offset<16)) {
-                assert(op + length >= dstPtr + MINMATCH);
                 LZ4_memcpy_using_offset(op, match, length, offset);
             } else {
                 LZ4_wildCopy32(op, match, op + length);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -375,6 +375,7 @@ static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; 
 
 static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
 static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+static void LZ4_write_ARCH(void* memPtr, reg_t value) { *(reg_t*)memPtr = value; }
 
 #elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
 
@@ -390,6 +391,7 @@ static reg_t LZ4_read_ARCH(const void* ptr) { return ((const LZ4_unalignST*)ptr)
 
 static void LZ4_write16(void* memPtr, U16 value) { ((LZ4_unalign16*)memPtr)->u16 = value; }
 static void LZ4_write32(void* memPtr, U32 value) { ((LZ4_unalign32*)memPtr)->u32 = value; }
+static void LZ4_write_ARCH(void* memPtr, reg_t value) { ((LZ4_unalignST*)memPtr)->uArch = value; }
 
 #else  /* safe and portable access using memcpy() */
 
@@ -414,6 +416,11 @@ static void LZ4_write16(void* memPtr, U16 value)
 }
 
 static void LZ4_write32(void* memPtr, U32 value)
+{
+    LZ4_memcpy(memPtr, &value, sizeof(value));
+}
+
+static void LZ4_write_ARCH(void* memPtr, reg_t value)
 {
     LZ4_memcpy(memPtr, &value, sizeof(value));
 }
@@ -475,7 +482,7 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #if LZ4_FAST_DEC_LOOP
 
 LZ4_FORCE_INLINE void
-LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const size_t offset)
 {
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
@@ -487,14 +494,17 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
         srcPtr += inc32table[offset];
         LZ4_memcpy(dstPtr+4, srcPtr, 4);
         srcPtr -= dec64table[offset];
-        dstPtr += 8;
     } else {
         LZ4_memcpy(dstPtr, srcPtr, 8);
-        dstPtr += 8;
         srcPtr += 8;
     }
 
-    LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);
+    while (length > 8) {
+        dstPtr += 8;
+        LZ4_memcpy(dstPtr, srcPtr, 8);
+        srcPtr += 8;
+        length -= 8;
+    }
 }
 
 /* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
@@ -514,42 +524,37 @@ LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
  * - dstEnd >= dstPtr + MINMATCH
  * - there is at least 8 bytes available to write after dstEnd */
 LZ4_FORCE_INLINE void
-LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const size_t offset)
 {
-    BYTE v[8];
+    reg_t r;
 
     assert(dstEnd >= dstPtr + MINMATCH);
 
     switch(offset) {
     case 1:
-        MEM_INIT(v, *srcPtr, 8);
+        r = *srcPtr * ((reg_t)0x0101010101010101ULL);
         break;
     case 2:
-        LZ4_memcpy(v, srcPtr, 2);
-        LZ4_memcpy(&v[2], srcPtr, 2);
-#if defined(_MSC_VER) && (_MSC_VER <= 1933) /* MSVC 2022 ver 17.3 or earlier */
-#  pragma warning(push)
-#  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
-#endif
-        LZ4_memcpy(&v[4], v, 4);
-#if defined(_MSC_VER) && (_MSC_VER <= 1933) /* MSVC 2022 ver 17.3 or earlier */
-#  pragma warning(pop)
-#endif
+        r = LZ4_read16(srcPtr) * ((reg_t)0x0001000100010001ULL);
         break;
     case 4:
-        LZ4_memcpy(v, srcPtr, 4);
-        LZ4_memcpy(&v[4], srcPtr, 4);
+        r = LZ4_read32(srcPtr) * ((reg_t)0x0000000100000001ULL);
         break;
+    case 8:
+        if (sizeof(reg_t) == 8) {
+            r = LZ4_read_ARCH(srcPtr);
+            break;
+        }
     default:
-        LZ4_memcpy_using_offset_base(dstPtr, srcPtr, dstEnd, offset);
+        LZ4_memcpy_using_offset_base(dstPtr, srcPtr, length, offset);
         return;
     }
 
-    LZ4_memcpy(dstPtr, v, 8);
-    dstPtr += 8;
-    while (dstPtr < dstEnd) {
-        LZ4_memcpy(dstPtr, v, 8);
-        dstPtr += 8;
+    LZ4_write_ARCH(dstPtr, r);
+    while (length > sizeof(reg_t)) {
+        dstPtr += sizeof(reg_t);
+        LZ4_write_ARCH(dstPtr, r);
+        length -= sizeof(reg_t);
     }
 }
 #endif
@@ -1911,7 +1916,7 @@ LZ4_decompress_unsafe_generic(
  * @error (output) - error code.  Must be set to 0 before call.
 **/
 typedef size_t Rvl_t;
-static const Rvl_t rvl_error = (Rvl_t)(-1);
+static const Rvl_t rvl_error = LZ4_MAX_INPUT_SIZE + 1;
 LZ4_FORCE_INLINE Rvl_t
 read_variable_length(const BYTE** ip, const BYTE* ilimit,
                      int initial_check)
@@ -2015,12 +2020,11 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) {
+                length += read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (length > LZ4_MAX_INPUT_SIZE) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
                 }
-                length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
 
@@ -2047,26 +2051,20 @@ LZ4_decompress_generic(
             assert(match <= op);  /* overflow check */
 
             /* get matchlength */
-            length = token & ML_MASK;
+            length = (token & ML_MASK) + MINMATCH;
 
-            if (length == ML_MASK) {
+            if (length == (ML_MASK + MINMATCH)) {
                 size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long match length");
                     goto _output_error;
                 }
                 length += addl;
-                length += MINMATCH;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
-                if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) {
-                    DEBUGLOG(6, "Error : offset outside buffers");
-                    goto _output_error;
-                }
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
             } else {
-                length += MINMATCH;
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
@@ -2123,16 +2121,15 @@ LZ4_decompress_generic(
             }
 
             /* copy match within block */
-            cpy = op + length;
 
             assert((op <= oend) && (oend-op >= 32));
             if (unlikely(offset<16)) {
-                LZ4_memcpy_using_offset(op, match, cpy, offset);
+                LZ4_memcpy_using_offset(op, match, length, offset);
             } else {
-                LZ4_wildCopy32(op, match, cpy);
+                LZ4_wildCopy32(op, match, op + length);
             }
 
-            op = cpy;   /* wildcopy correction */
+            op += length;   /* wildcopy correction */
         }
     safe_decode:
 #endif
@@ -2162,20 +2159,20 @@ LZ4_decompress_generic(
 
                 /* The second stage: prepare for match copying, decode full info.
                  * If it doesn't work out, the info won't be wasted. */
-                length = token & ML_MASK; /* match length */
+                length = (token & ML_MASK) + MINMATCH; /* match length */
                 offset = LZ4_readLE16(ip); ip += 2;
                 match = op - offset;
                 assert(match <= op); /* check overflow */
 
                 /* Do not deal with overlapping matches. */
-                if ( (length != ML_MASK)
+                if ( (length != (ML_MASK + MINMATCH))
                   && (offset >= 8)
                   && (dict==withPrefix64k || match >= lowPrefix) ) {
                     /* Copy the match. */
                     LZ4_memcpy(op + 0, match + 0, 8);
                     LZ4_memcpy(op + 8, match + 8, 8);
                     LZ4_memcpy(op +16, match +16, 2);
-                    op += length + MINMATCH;
+                    op += length;
                     /* Both stages worked, load the next token. */
                     continue;
                 }
@@ -2187,9 +2184,8 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) { goto _output_error; }
-                length += addl;
+                length += read_variable_length(&ip, iend-RUN_MASK, 1);
+                if (length > LZ4_MAX_INPUT_SIZE) { goto _output_error; }
                 if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
             }
@@ -2261,16 +2257,14 @@ LZ4_decompress_generic(
             match = op - offset;
 
             /* get matchlength */
-            length = token & ML_MASK;
+            length = (token & ML_MASK) + MINMATCH;
 
     _copy_match:
-            if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
-                if (addl == rvl_error) { goto _output_error; }
-                length += addl;
+            if (length == (ML_MASK + MINMATCH)) {
+                length += read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (length > LZ4_MAX_INPUT_SIZE) { goto _output_error; }
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
             }
-            length += MINMATCH;
 
 #if LZ4_FAST_DEC_LOOP
         safe_match_copy:

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -528,8 +528,6 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const s
 {
     reg_t r;
 
-    assert(dstEnd >= dstPtr + MINMATCH);
-
     switch(offset) {
     case 1:
         r = *srcPtr * ((reg_t)0x0101010101010101ULL);
@@ -2124,6 +2122,7 @@ LZ4_decompress_generic(
 
             assert((op <= oend) && (oend-op >= 32));
             if (unlikely(offset<16)) {
+                assert(op + length >= dstPtr + MINMATCH);
                 LZ4_memcpy_using_offset(op, match, length, offset);
             } else {
                 LZ4_wildCopy32(op, match, op + length);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -543,6 +543,7 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const s
             r = LZ4_read_ARCH(srcPtr);
             break;
         }
+        /* fallthrough */
     default:
         LZ4_memcpy_using_offset_base(dstPtr, srcPtr, length, offset);
         return;


### PR DESCRIPTION
Hello, I hope you are doing well,

I wanted to propose three changes which yield decompression speed improvements.

1. Optimizing LZ4_memcpy_using_offset

When the offset is a power of 2 lower or equal than sizeof(reg_t), instead of loading sizeof(reg_t) bytes onto the stack and doing memcpy, a variable of type reg_t is filled using only 1 multiplication. Then, the variable is written onto the output on a memset style.

The third parameter BYTE* dstEnd was changed to size_t length. This has two advantages: In copying loops stop conditions, the source pointer is compared against an immediate numbers instead of another variable; On LZ4_decompress_generic, at the end of the unsafe decode loop (lines ~2130 through ~2135), it is not needed to set and maintain the variable cpy while doing the copy onto the output.

2. Optimizing reading length variables

MINMATCH is added at the time the copy operation's length token is read. This reduces the size of the following code branches, which should help CPU's branch predictors.

rvl_error value has been changed to LZ4_MAX_INPUT_SIZE + 1. This one is controversial but yielded noticeable performance improvements. Now read_variable_length returns LZ4_MAX_INPUT_SIZE + 1 on error, and its result is directly added to the length variable, without needing to maintain the additional addl variable. Then, if length is greater than LZ4_MAX_INPUT_SIZE, the decompression routine follows the error path.

The deletion of the additional addl variable reduced the need to use the stack, which yielded the noticed performance improvements. Maybe rvl_error can be refactored in a more descriptive way to preserve code readability while keeping the performance gains.

3. Removing a redundant code branch

Within LZ4_decompress_generic, on line ~2061, the following error condition is checked:
(checkOffset) && (unlikely(match + dictSize < lowPrefix))
Any of the two code branches that follow also check such condition, so it should be safe to remove it.



With these three changes, I was able to get about 4% decompression speed improvement when processing the silesia corpus. On other workloads, the gains went up to about 10%.

I hope you find these changes useful,
Nicolas

