### PR TITLE
Optimize LZ4_memcpy_using_offset

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -485,7 +485,6 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 
 
 
-
 #if LZ4_FAST_DEC_LOOP
 
 LZ4_FORCE_INLINE void

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -535,6 +535,11 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const s
 {
     reg_t r;
 
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4310) /* warning C4310: cast truncates constant value. */
+#endif
+
     switch(offset) {
     case 1:
         r = *srcPtr * ((reg_t)0x0101010101010101ULL);
@@ -556,12 +561,17 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, size_t length, const s
         return;
     }
 
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
     LZ4_write_ARCH(dstPtr, r);
     while (length > sizeof(reg_t)) {
         dstPtr += sizeof(reg_t);
         LZ4_write_ARCH(dstPtr, r);
         length -= sizeof(reg_t);
     }
+
 }
 #endif
 


### PR DESCRIPTION
LZ4_memcpy_using_offset is modified, as follows:

When the offset is a power of 2 lower or equal than sizeof(reg_t), instead of loading sizeof(reg_t) bytes onto the stack and doing memcpy, a variable of type reg_t is filled using only 1 multiplication. Then, the variable is written onto the output on a memset style.

The third parameter BYTE* dstEnd was changed to size_t length. This has two advantages: In copying loops stop conditions, the source pointer is compared against an immediate numbers instead of another variable; On LZ4_decompress_generic, at the end of the unsafe decode loop (lines ~2130 through ~2135), it is not needed to set and maintain the variable cpy while doing the copy onto the output.