### PR TITLE
Optimize reading of length variables

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1911,7 +1911,7 @@ LZ4_decompress_unsafe_generic(
  * @error (output) - error code.  Must be set to 0 before call.
 **/
 typedef size_t Rvl_t;
-static const Rvl_t rvl_error = (Rvl_t)(-1);
+static const Rvl_t rvl_error = LZ4_MAX_INPUT_SIZE + 1;
 LZ4_FORCE_INLINE Rvl_t
 read_variable_length(const BYTE** ip, const BYTE* ilimit,
                      int initial_check)
@@ -2015,12 +2015,11 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) {
+                length += read_variable_length(&ip, iend - RUN_MASK, 1);
+                if (length > LZ4_MAX_INPUT_SIZE) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
                 }
-                length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
 
@@ -2046,16 +2045,15 @@ LZ4_decompress_generic(
             assert(match <= op);  /* overflow check */
 
             /* get matchlength */
-            length = token & ML_MASK;
+            length = (token & ML_MASK) + MINMATCH;
 
-            if (length == ML_MASK) {
+            if (length == (ML_MASK + MINMATCH)) {
                 size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long match length");
                     goto _output_error;
                 }
                 length += addl;
-                length += MINMATCH;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
                 if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) {
                     DEBUGLOG(6, "Error : offset outside buffers");
@@ -2065,7 +2063,6 @@ LZ4_decompress_generic(
                     goto safe_match_copy;
                 }
             } else {
-                length += MINMATCH;
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
@@ -2161,20 +2158,20 @@ LZ4_decompress_generic(
 
                 /* The second stage: prepare for match copying, decode full info.
                  * If it doesn't work out, the info won't be wasted. */
-                length = token & ML_MASK; /* match length */
+                length = (token & ML_MASK) + MINMATCH; /* match length */
                 offset = LZ4_readLE16(ip); ip += 2;
                 match = op - offset;
                 assert(match <= op); /* check overflow */
 
                 /* Do not deal with overlapping matches. */
-                if ( (length != ML_MASK)
+                if ((length != (ML_MASK + MINMATCH))
                   && (offset >= 8)
                   && (dict==withPrefix64k || match >= lowPrefix) ) {
                     /* Copy the match. */
                     LZ4_memcpy(op + 0, match + 0, 8);
                     LZ4_memcpy(op + 8, match + 8, 8);
                     LZ4_memcpy(op +16, match +16, 2);
-                    op += length + MINMATCH;
+                    op += length;
                     /* Both stages worked, load the next token. */
                     continue;
                 }
@@ -2186,9 +2183,8 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) { goto _output_error; }
-                length += addl;
+                length += read_variable_length(&ip, iend - RUN_MASK, 1);
+                if (length > LZ4_MAX_INPUT_SIZE) { goto _output_error; }
                 if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
             }
@@ -2261,16 +2257,14 @@ LZ4_decompress_generic(
             match = op - offset;
 
             /* get matchlength */
-            length = token & ML_MASK;
+            length = (token & ML_MASK) + MINMATCH;
 
     _copy_match:
-            if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
-                if (addl == rvl_error) { goto _output_error; }
-                length += addl;
+            if (length == (ML_MASK + MINMATCH)) {
+                length += read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (length > LZ4_MAX_INPUT_SIZE) { goto _output_error; }
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
             }
-            length += MINMATCH;
 
 #if LZ4_FAST_DEC_LOOP
         safe_match_copy:


### PR DESCRIPTION
The code that reads the stream of bytes representing a length is modified as follows:

MINMATCH is added at the time the copy operation's length token is read. This reduces the size of the following code branches, which should help CPU's branch predictors.

rvl_error value has been changed to LZ4_MAX_INPUT_SIZE + 1. This one is controversial but yielded noticeable performance improvements. Now read_variable_length returns LZ4_MAX_INPUT_SIZE + 1 on error, and its result is directly added to the length variable, without needing to maintain the additional addl variable. Then, if length is greater than LZ4_MAX_INPUT_SIZE, the decompression routine follows the error path.

The deletion of the additional addl variable reduced the need to use the stack, which yielded the noticed performance improvements. Maybe rvl_error can be refactored in a more descriptive way to preserve code readability while keeping the performance gains.