### PR TITLE
Remove redundant error check

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2058,10 +2058,6 @@ LZ4_decompress_generic(
                 length += addl;
                 length += MINMATCH;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
-                if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) {
-                    DEBUGLOG(6, "Error : offset outside buffers");
-                    goto _output_error;
-                }
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }


### PR DESCRIPTION
Within LZ4_decompress_generic, on line 2061, the following error condition is checked:

(checkOffset) && (unlikely(match + dictSize < lowPrefix))

Any of the two code branches that follow also check such condition, so it should be safe to remove it.