### PR TITLE
Set CMake minimum requirement to 3.5

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -10,7 +10,7 @@
 # LZ4's CMake support is maintained by Evan Nemerson; when filing
 # bugs please mention @nemequ to make sure I see it.
 
-cmake_minimum_required(VERSION 2.8.12...3.26)
+cmake_minimum_required(VERSION 3.5)
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
@@ -24,14 +24,7 @@ string(REGEX REPLACE "^#define LZ4_VERSION_RELEASE +([0-9]+) +.*$" "\\1" LZ4_VER
 set(LZ4_VERSION_STRING "${LZ4_VERSION_MAJOR}.${LZ4_VERSION_MINOR}.${LZ4_VERSION_RELEASE}")
 mark_as_advanced(LZ4_VERSION_STRING LZ4_VERSION_MAJOR LZ4_VERSION_MINOR LZ4_VERSION_RELEASE)
 
-if("${CMAKE_VERSION}" VERSION_LESS "3.0")
-  project(LZ4 C)
-else()
-  cmake_policy (SET CMP0048 NEW)
-  project(LZ4
-    VERSION ${LZ4_VERSION_STRING}
-    LANGUAGES C)
-endif()
+project(LZ4 VERSION ${LZ4_VERSION_STRING} LANGUAGES C)
 
 option(LZ4_BUILD_CLI "Build lz4 program" ON)
 option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c program with legacy argument support" ON)

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -10,7 +10,7 @@
 # LZ4's CMake support is maintained by Evan Nemerson; when filing
 # bugs please mention @nemequ to make sure I see it.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.26)
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 


### PR DESCRIPTION
`cmake_minimum_required(VERSION 2.x)` has the effect that any recent CMake runs with default settings that were considered sensible a decade ago.

Instead, use `cmake_minimum_required(VERSION 2.x...3.y)` so that newer CMake uses modern defaults for policies, without dropping CMake 2.x support.

One such policy that I need for example is CMP0042, which makes CMake output `@rpath/liblz4.dylib` as install name on macOS, so that packages linking to it register `@rpath/liblz4.dylib` as a load command, so that rpaths will be considered to locate it. Without it, dependents typically fail at runtime and cannot locate the library if it's in a non-system dir.