### PR TITLE
contrib/gen_manual: Allow caller to set CXX_FOR_BUILD for gen_manual.

### DIFF
--- a/contrib/gen_manual/Makefile
+++ b/contrib/gen_manual/Makefile
@@ -56,8 +56,9 @@ endif
 .PHONY: default
 default: gen_manual
 
+CXX_FOR_BUILD = $(CXX)
 gen_manual: gen_manual.cpp
-	$(CXX) $(FLAGS) $^ -o $@$(EXT)
+	$(CXX_FOR_BUILD) $(FLAGS) $^ -o $@$(EXT)
 
 $(LZ4MANUAL) : gen_manual $(LZ4API)
 	echo "Update lz4 manual in /doc"


### PR DESCRIPTION
This way, in a cross-build of lz4, you can set CXX_FOR_BUILD to a native compiler that can produce a gen_manual executable to run at build-time.

fix https://github.com/lz4/lz4/issues/1240