### PR TITLE
Don't clobber default WINDRES in MinGW environments

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -65,11 +65,7 @@ endif
 
 ifeq ($(WINBASED),yes)
 EXT        = .exe
-  ifneq (,$(filter MINGW%,$(TARGET_OS)))
-# WINDRES should already be set correctly for MinGW
-  else
-WINDRES    = windres
-  endif
+WINDRES ?= windres
 endif
 
 #determine if dev/nul based on host environment

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -65,7 +65,11 @@ endif
 
 ifeq ($(WINBASED),yes)
 EXT        = .exe
+  ifneq (,$(filter MINGW%,$(TARGET_OS)))
+# WINDRES should already be set correctly for MinGW
+  else
 WINDRES    = windres
+  endif
 endif
 
 #determine if dev/nul based on host environment


### PR DESCRIPTION
`WINDRES` is already set when building with MinGW; setting it unconditionally to `windres` prevents the MinGW version of `windres` from being called.

This patch skips setting `WINDRES` for MinGW builds.