### PR TITLE
Don't conflate the shared library name with the shared library filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ ld.exe*
 # test artifacts
 *.lz4
 tmp*
+
+# generated Windows resource files
+lib/*.rc
+programs/*.rc

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -38,26 +38,26 @@ ifeq ($(TARGET_OS),)
 endif
 
 ifneq (,$(filter Windows%,$(TARGET_OS)))
-LIBLZ4 = liblz4-$(LIBVER_MAJOR)
-LIBLZ4_EXP = liblz4.lib
-WINBASED   = yes
+LIBLZ4_NAME = liblz4-$(LIBVER_MAJOR)
+LIBLZ4_EXP  = liblz4.lib
+WINBASED    = yes
 else
-LIBLZ4_EXP = liblz4.dll.a
+LIBLZ4_EXP  = liblz4.dll.a
   ifneq (,$(filter MINGW%,$(TARGET_OS)))
-LIBLZ4     = liblz4
-WINBASED   = yes
+LIBLZ4_NAME = liblz4
+WINBASED    = yes
   else
     ifneq (,$(filter MSYS%,$(TARGET_OS)))
-LIBLZ4     = msys-lz4-$(LIBVER_MAJOR)
-WINBASED   = yes
+LIBLZ4_NAME = msys-lz4-$(LIBVER_MAJOR)
+WINBASED    = yes
     else
       ifneq (,$(filter CYGWIN%,$(TARGET_OS)))
-LIBLZ4     = cyglz4-$(LIBVER_MAJOR)
-WINBASED   = yes
+LIBLZ4_NAME = cyglz4-$(LIBVER_MAJOR)
+WINBASED    = yes
       else
-LIBLZ4     = liblz4.$(SHARED_EXT_VER)
-WINBASED   = no
-EXT        =
+LIBLZ4_NAME = liblz4
+WINBASED    = no
+EXT         =
       endif
     endif
   endif
@@ -67,6 +67,8 @@ ifeq ($(WINBASED),yes)
 EXT        = .exe
 WINDRES    = windres
 endif
+
+LIBLZ4      = $(LIBLZ4_NAME).$(SHARED_EXT_VER)
 
 #determine if dev/nul based on host environment
 ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(shell $(UNAME))))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ build_script:
       COPY lib\lz4hc.h bin\include\ &&
       COPY lib\lz4frame.h bin\include\ &&
       COPY lib\liblz4.a bin\static\liblz4_static.lib &&
-      COPY lib\dll\* bin\dll\ &&
+      COPY lib\liblz4.dll* bin\dll\ &&
       COPY lib\dll\example\Makefile bin\example\ &&
       COPY lib\dll\example\fullbench-dll.* bin\example\ &&
       COPY lib\dll\example\README.md bin\ &&

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -212,7 +212,7 @@ install: lib liblz4.pc
 
 uninstall:
 	$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
-  ifeq (WINBASED,1)
+  ifeq (WINBASED,yes)
 	$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4).dll
 	$(RM) $(DESTDIR)$(libdir)/$(LIBLZ4_EXP)
   else

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -67,10 +67,15 @@ ifeq ($(TARGET_OS), Darwin)
 	SHARED_EXT_VER = $(LIBVER).$(SHARED_EXT)
 	SONAME_FLAGS = -install_name $(libdir)/liblz4.$(SHARED_EXT_MAJOR) -compatibility_version $(LIBVER_MAJOR) -current_version $(LIBVER)
 else
-	SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR)
-	SHARED_EXT = so
-	SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR)
-	SHARED_EXT_VER = $(SHARED_EXT).$(LIBVER)
+	ifeq ($(WINBASED),yes)
+		SHARED_EXT = dll
+		SHARED_EXT_VER = $(SHARED_EXT)
+	else
+		SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR)
+		SHARED_EXT = so
+		SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR)
+		SHARED_EXT_VER = $(SHARED_EXT).$(LIBVER)
+	endif
 endif
 
 .PHONY: default
@@ -102,7 +107,7 @@ endif
 ifeq ($(WINBASED),yes)
 liblz4-dll.rc: liblz4-dll.rc.in
 	@echo creating library resource
-	$(SED) -e 's|@LIBLZ4@|$(LIBLZ4)|' \
+	$(SED) -e 's|@LIBLZ4@|$(LIBLZ4_NAME)|' \
          -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
          -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
          -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
@@ -114,7 +119,7 @@ liblz4-dll.o: liblz4-dll.rc
 $(LIBLZ4): $(SRCFILES) liblz4-dll.o
 ifeq ($(BUILD_SHARED),yes)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll -Wl,--out-implib,dll/$(LIBLZ4_EXP)
+	$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o $@ -Wl,--out-implib,$(LIBLZ4_EXP)
 endif
 
 else   # not windows
@@ -138,7 +143,7 @@ clean:
 ifeq ($(WINBASED),yes)
 	$(RM) *.rc
 endif
-	$(RM) core *.o liblz4.pc dll/$(LIBLZ4).dll dll/$(LIBLZ4_EXP)
+	$(RM) core *.o liblz4.pc $(LIBLZ4) $(LIBLZ4_EXP)
 	$(RM) *.a *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
 	@echo Cleaning library completed
 
@@ -196,8 +201,8 @@ install: lib liblz4.pc
 # search them first in their directory. This allows to not pollute system
 # directories (like c:/windows/system32), nor modify the PATH variable.
     ifeq ($(WINBASED),yes)
-	$(INSTALL_PROGRAM) dll/$(LIBLZ4).dll $(DESTDIR)$(bindir)
-	$(INSTALL_PROGRAM) dll/$(LIBLZ4_EXP) $(DESTDIR)$(libdir)
+	$(INSTALL_PROGRAM) $(LIBLZ4) $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) $(LIBLZ4_EXP) $(DESTDIR)$(libdir)
     else
 	$(INSTALL_PROGRAM) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)
 	$(LN_SF) liblz4.$(SHARED_EXT_VER) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT_MAJOR)
@@ -213,7 +218,7 @@ install: lib liblz4.pc
 uninstall:
 	$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
   ifeq (WINBASED,yes)
-	$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4).dll
+	$(RM) $(DESTDIR)$(bindir)/$(LIBLZ4)
 	$(RM) $(DESTDIR)$(libdir)/$(LIBLZ4_EXP)
   else
 	$(RM) $(DESTDIR)$(libdir)/liblz4.$(SHARED_EXT)


### PR DESCRIPTION
Currently, when building with MinGW, `$(LIBLZ4)` is `liblz4`. This is the correct _name_ for the library, but not the correct _filename_ for the DLL, which is `liblz4.dll`. This causes a problem with the following Makefile target:
```
 $(LIBLZ4): $(SRCFILES) liblz4-dll.o
 ifeq ($(BUILD_SHARED),yes)
        @echo compiling dynamic library $(LIBVER)
       $(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o dll/$@.dll -Wl,--out-implib,dll/$(LIBLZ4_EXP)
 endif
```
The recipe writes `dll/liblz4.dll` (and also `dll/liblz4.dll.a`), but does not write `liblz4`---which is the target. As a result, make cannot see that after running `make` that it has a fresh `dll/liblz4.dll` and thus will relink the library on runing `make` again (or `make install`).

Additionally, this target ends up being circular, due to `$(LIBLZ4)` being `liblz4`:
```
liblz4: $(LIBLZ4)
```

The cause of these problems is that current usage treats `LIBLZ4` as both the name of the shared library and the path of the shared library file, which for Windows builds are not the same thing. This PR fixes the problem by separating the name of the shared library out to `LIBLZ4_NAME`.