### PR TITLE
fix #1246

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ _codelite_lz4/
 bin/
 *.zip
 *.swp
+compile_flags.txt
 
 # analyzers
 infer-out

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -339,7 +339,8 @@ int main(int argc, const char** argv)
     /* Init */
     if (inFileNames==NULL) {
         DISPLAY("Allocation error : not enough memory \n");
-        return 1;
+        operationResult = 1;
+        goto _cleanup;
     }
     inFileNames[0] = stdinmark;
     LZ4IO_setOverwrite(prefs, 0);


### PR DESCRIPTION
The resource is being freed anyway, since this is an exit point from `main()`, but it's proper to release the resource manually first, and avoids triggering an automated detection tool.

fix #1246