### PR TITLE
fix: missing LZ4F_freeDecompressionContext

### DIFF
--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -79,6 +79,7 @@ LZ4F_errorCode_t LZ4F_readOpen(LZ4_readFile_t** lz4fRead, FILE* fp)
   (*lz4fRead)->fp = fp;
   consumedSize = fread(buf, 1, sizeof(buf), (*lz4fRead)->fp);
   if (consumedSize != sizeof(buf)) {
+    LZ4F_freeDecompressionContext((*lz4fRead)->dctxPtr);
     free(*lz4fRead);
     return -LZ4F_ERROR_GENERIC;
   }


### PR DESCRIPTION
Reported by @BojackMa as issue #1249.

When file size is less than `LZ4F_HEADER_SIZE_MAX` (19), `LZ4F_readOpen()` misses to free memory.  
Therefore, memory leak happens.

We may also need:

- Tests for lz4file
  - or run examples/fileCompress with malicious file
- Run them with valgrind.
