### PR TITLE
Make hashes identical between LE and BE platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lz4
 
 # IDE / editors files
 .clang_complete
+.vscode
 _codelite/
 _codelite_lz4/
 bin/

--- a/build/meson/meson/meson.build
+++ b/build/meson/meson/meson.build
@@ -81,6 +81,15 @@ if get_option('memory-usage') > 0
   compile_args += '-DLZ4_MEMORY_USAGE=@0@'.format(get_option('memory-usage'))
 endif
 
+if get_option('endianness-independent-output')
+  if get_option('default_library') != 'static'
+    error('Endianness-independent output can only be enabled in static builds')
+  endif
+
+  add_project_arguments('-DLZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT')
+  compile_args += '-DLZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT'
+endif
+
 if get_option('unstable')
   add_project_arguments('-DLZ4_STATIC_LINKING_ONLY', language: 'c')
   compile_args += '-DLZ4_STATIC_LINKING_ONLY'

--- a/build/meson/meson_options.txt
+++ b/build/meson/meson_options.txt
@@ -18,6 +18,8 @@ option('disable-memory-allocation', type: 'boolean', value: false,
   description: 'See LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION. Static builds only')
 option('distance-max', type: 'integer', min: 0, max: 65535, value: 65535,
   description: 'See LZ4_DISTANCE_MAX')
+option('endianness-independent-output', type: 'boolean', value: false,
+  description: 'See LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT. Static builds only')
 option('examples', type: 'boolean', value: false,
   description: 'Enable examples')
 option('fast-dec-loop', type: 'feature', value: 'auto',

--- a/lib/README.md
+++ b/lib/README.md
@@ -111,7 +111,8 @@ The following build macro can be selected to adjust source code behavior at comp
 - `LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT` : experimental feature aimed at producing the same
   compressed output on platforms of different endianness (i.e. little-endian and big-endian).
   Output on little-endian platforms shall remain unchanged, while big-endian platforms will start producing
-  the same output as little-endian. This isn't expected to impact backward- and forward-compatibility in any way.
+  the same output as little-endian ones. This isn't expected to impact backward- and forward-compatibility
+  in any way.
 
 - `LZ4_FREESTANDING` : by setting this build macro to 1,
   LZ4/HC removes dependencies on the C standard library,

--- a/lib/README.md
+++ b/lib/README.md
@@ -108,6 +108,11 @@ The following build macro can be selected to adjust source code behavior at comp
   Remove support of dynamic memory allocation.
   For more details, see description of this macro in `lib/lz4.c`.
 
+- `LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT` : experimental feature aimed at producing the same
+  compressed output on platforms of different endianness (i.e. little-endian and big-endian).
+  Output on little-endian platforms shall remain unchanged, while big-endian platforms will start producing
+  the same output as little-endian. This isn't expected to impact backward- and forward-compatibility in any way.
+
 - `LZ4_FREESTANDING` : by setting this build macro to 1,
   LZ4/HC removes dependencies on the C standard library,
   including allocation functions and `memmove()`, `memcpy()`, and `memset()`.

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -431,6 +431,16 @@ static U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
+static U32 LZ4_readLE32(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read32(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        return (U32)p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24);
+    }
+}
+
 static void LZ4_writeLE16(void* memPtr, U16 value)
 {
     if (LZ4_isLittleEndian()) {
@@ -779,7 +789,7 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
 LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
 {
     if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
-    return LZ4_hash4(LZ4_read32(p), tableType);
+    return LZ4_hash4(LZ4_readLE32(p), tableType);
 }
 
 LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -431,6 +431,7 @@ static U16 LZ4_readLE16(const void* memPtr)
     }
 }
 
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
 static U32 LZ4_readLE32(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
@@ -440,6 +441,7 @@ static U32 LZ4_readLE32(const void* memPtr)
         return (U32)p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24);
     }
 }
+#endif
 
 static void LZ4_writeLE16(void* memPtr, U16 value)
 {
@@ -789,7 +791,12 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
 LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
 {
     if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+
+#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
     return LZ4_hash4(LZ4_readLE32(p), tableType);
+#else
+    return LZ4_hash4(LZ4_read32(p), tableType);
+#endif
 }
 
 LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)


### PR DESCRIPTION
My changes aim to resolve a difference in coding between little-endian and big-endian platforms in certain cases.

When invoked on the same data but on platforms of different endianness the `LZ4_hash4` function would produce different results owing to the multiplication performed in its body. I aim to resolve this by reading the contents of the binary as if they were represented in little-endian - which of course doesn't constrain the input data in any way; it's just for the sake of consistency with the ultimate goal of the aforementioned arithmetic operation producing the same numeric result and thus the same hash in the end.