### PR TITLE
Adding XXH_NAMESPACE to CMake builds

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -131,6 +131,16 @@ if(BUILD_STATIC_LIBS)
   list(APPEND LZ4_LIBRARIES_BUILT lz4_static)
 endif()
 
+# xxhash namesapce
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(lz4_shared PRIVATE 
+    XXH_NAMESPACE=LZ4_)
+endif()
+if(BUILD_STATIC_LIBS)
+  target_compile_definitions(lz4_static PRIVATE 
+    XXH_NAMESPACE=LZ4_)
+endif()
+
 if(BUILD_STATIC_LIBS)
   set(LZ4_LINK_LIBRARY lz4_static)
 else()


### PR DESCRIPTION
When building with CMake, lz4 compiles its own version of xxHash. This is not ideal since it disallows the simultaneous use of xxHash and lz4 in the same project without modifications in the build.

I'm using Conan as a package manager, and as soon as I use xxHash and lz4, I get linker issues because of multiple defined symbols (xxHash functions in lz4 and xxHash). Originally, I tried fixing this in #1254, but as stated by @t-mat it is better to use the preprocessor define `XXH_NAMESPACE`. I have added the namespace definition by default to static and dynamic library builds when using CMake.