### PR TITLE
Recognize and decompress files created by Mozilla

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1041,7 +1041,7 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
         if (fstat(fileno(finput), &sb) != 0) END_PROCESS(74, "Stat error: %s", strerror(errno));
         if (sb.st_size >= INT_MAX) END_PROCESS(74, "Input file too large - %llu bytes",
             (unsigned long long)sb.st_size);
-        inputSize = sb.st_size - 12;
+        inputSize = (U32)sb.st_size - 12;
     }
 
 #ifdef __unix__

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1038,7 +1038,7 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
         outputSize = LZ4IO_readLE32(&outputSize);
     }
     {   struct stat sb;
-        if (fstat(fileno(finput), &sb) != 0) END_PROCESS(74, "Stat error: %s", strerror(errno));
+        if (fstat(UTIL_fileno(finput), &sb) != 0) END_PROCESS(74, "Stat error: %s", strerror(errno));
         if (sb.st_size >= INT_MAX) END_PROCESS(74, "Input file too large - %llu bytes",
             (unsigned long long)sb.st_size);
         inputSize = (U32)sb.st_size - 12;
@@ -1049,7 +1049,7 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
      * On Unix we try to mmap the input -- to save memory -- falling back
      * to stdio, if mmap fails. Output is always written "normally".
      */
-    in_buff = (char *)mmap(NULL, inputSize, PROT_READ, MAP_SHARED, fileno(finput), 12);
+    in_buff = (char *)mmap(NULL, inputSize, PROT_READ, MAP_SHARED, UTIL_fileno(finput), 12);
     if (in_buff == MAP_FAILED) {
         DISPLAYLEVEL(1, "mmap-ing input failed (%s), falling back to stdio\n", strerror(errno));
         in_buff  = (char *)malloc(inputSize);

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1053,7 +1053,7 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
      * to stdio, if mmap fails. Output is always written "normally".
      */
     if (inputSize == 0) {
-        in_buff = malloc(LEGACY_BLOCKSIZE);
+        in_buff = (char *)malloc(LEGACY_BLOCKSIZE);
         inputSize = LEGACY_BLOCKSIZE;
         mmapped = 0;
     } else if ((in_buff = (char *)mmap(NULL, inputSize, PROT_READ, MAP_SHARED,

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1039,7 +1039,8 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
     }
     {   struct stat sb;
         if (fstat(fileno(finput), &sb) != 0) END_PROCESS(74, "Stat error: %s", strerror(errno));
-        if (sb.st_size >= INT_MAX) END_PROCESS(74, "Input file too large - %jd bytes", sb.st_size);
+        if (sb.st_size >= INT_MAX) END_PROCESS(74, "Input file too large - %llu bytes",
+            (unsigned long long)sb.st_size);
         inputSize = sb.st_size - 12;
     }
 
@@ -1048,10 +1049,10 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
      * On Unix we try to mmap the input -- to save memory -- falling back
      * to stdio, if mmap fails. Output is always written "normally".
      */
-    in_buff = mmap(NULL, inputSize, PROT_READ, MAP_SHARED, fileno(finput), 12);
+    in_buff = (char *)mmap(NULL, inputSize, PROT_READ, MAP_SHARED, fileno(finput), 12);
     if (in_buff == MAP_FAILED) {
         DISPLAYLEVEL(1, "mmap-ing input failed (%s), falling back to stdio\n", strerror(errno));
-        in_buff  = malloc(inputSize);
+        in_buff  = (char *)malloc(inputSize);
         mmapped = 0;
     } else {
         DISPLAYLEVEL(2, "Using mmap for input\n");
@@ -1059,9 +1060,9 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
         mmapped = 1;
     }
 #else
-    in_buff  = malloc(inputSize);
+    in_buff  = (char *)malloc(inputSize);
 #endif
-    out_buff = malloc(outputSize);
+    out_buff = (char *)malloc(outputSize);
     if (!in_buff || !out_buff) END_PROCESS(75, "Allocation error : not enough memory");
 
 #ifdef __unix__
@@ -1074,7 +1075,8 @@ LZ4IO_decodeMozilla(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
     /* Decode Block */
     {   int const decodeSize = LZ4_decompress_safe(in_buff, out_buff, inputSize, outputSize);
         if (decodeSize < 0) END_PROCESS(77, "Decoding Failed ! Corrupted input detected !");
-        if (decodeSize != (int)outputSize) DISPLAYLEVEL(2, "Suspect: decoded size %d differs from the expected %zd", decodeSize, (size_t)outputSize);
+        if (decodeSize != (int)outputSize) DISPLAYLEVEL(2, "Suspect: decoded size %d differs from the expected %u",
+            decodeSize, (unsigned)outputSize);
         /* Write Block */
         storedSkips = LZ4IO_fwriteSparse(foutput, out_buff, decodeSize, prefs->sparseFileSupport, 0); /* success or die */
     }


### PR DESCRIPTION
This aims to address the decompression part of the lz4/lz4#880.

The compression part -- _creation_ of files usable by Mozilla -- may be more contentious, given the reluctance to support the proliferation of the bogus formats.

(Personally, I need to be able to (sometimes) decompress Mozilla files, modify them, and then compress the modified data back for Firefox and/or Thunderbird to process.)