### PR TITLE
Move GNUInstallDirs include before it is referenced first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,12 +677,10 @@ jobs:
 
     - name: cmake
       run: |
-        cd build/cmake
-        mkdir build
-        cd build
-        cmake ..
-        CFLAGS=-Werror make VERBOSE=1
-
+        CFLAGS=-Werror cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
+        VERBOSE=1 cmake --build build --target install
+        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
+        VERBOSE=1 cmake --build build_test
 
   # Invoke cmake via Makefile
   lz4-build-make-cmake:

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -93,6 +93,7 @@ set(LZ4_CLI_SOURCES
 option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ON)
 
 # liblz4
+include(GNUInstallDirs)
 set(LZ4_LIBRARIES_BUILT)
 if(BUILD_SHARED_LIBS)
   add_library(lz4_shared SHARED ${LZ4_SOURCES})
@@ -192,8 +193,6 @@ foreach (flag
 endforeach (flag)
 
 if(NOT LZ4_BUNDLED_MODE)
-  include(GNUInstallDirs)
-
   install(TARGETS ${LZ4_PROGRAMS_BUILT}
     BUNDLE	DESTINATION "${CMAKE_INSTALL_BINDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -19,5 +19,5 @@ endif()
 
 # Add a test that builds against the installation
 set(LZ4_TESTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
-add_executable(frametest "${LZ4_TESTS_SOURCE_DIR}/frametest.c")
-target_link_libraries(frametest LZ4::lz4_shared)
+add_executable(decompress-partial "${LZ4_TESTS_SOURCE_DIR}/decompress-partial.c")
+target_link_libraries(decompress-partial LZ4::lz4_shared)

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmake_install_test LANGUAGES C)
+
+# Find LZ4 installation in Config mode
+find_package(lz4 CONFIG REQUIRED)
+
+# Verify that the location property is set
+get_property(LZ4_LOCATION TARGET LZ4::lz4_shared PROPERTY LOCATION)
+if (NOT LZ4_LOCATION)
+  message(FATAL_ERROR "Missing LOCATION property for LZ4::lz4_shared!")
+endif()
+
+# Verify that the include directory property is set
+get_property(LZ4_SHARED_INCLUDE_DIRECTORIES TARGET LZ4::lz4_shared PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+if (NOT LZ4_SHARED_INCLUDE_DIRECTORIES)
+  message(FATAL_ERROR "Missing INTERFACE_INCLUDE_DIRECTORIES property for LZ4::lz4_shared!")
+endif()
+
+# Add a test that builds against the installation
+set(LZ4_TESTS_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+add_executable(frametest "${LZ4_TESTS_SOURCE_DIR}/frametest.c")
+target_link_libraries(frametest LZ4::lz4_shared)


### PR DESCRIPTION
The lz4_shared and lz4_static targets specify their install include directories with the CMAKE_INSTALL_INCLUDEDIR variable that should be coming from include(GNUInstallDirs), however that file is only included later.

I think this results in an empty/missing INTERFACE_INCLUDE_DIRECTORIES property in the installed configuration files, making CMake not pick up the correct include directories for the installation.

This becomes an issue for example when cross compiling with a sysroot that does not has lz4 headers in standard include paths and the explicitly installed headers are not found either due to the empty INTERFACE_INCLUDE_DIRECTORIES property.

Please let me know if I'm missing something or you need more details

@nemequ