### PR TITLE
fix: issue #1269

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -86,6 +86,7 @@ set(LZ4_CLI_SOURCES
   "${LZ4_PROG_SOURCE_DIR}/lz4cli.c"
   "${LZ4_PROG_SOURCE_DIR}/lz4io.c"
   "${LZ4_PROG_SOURCE_DIR}/datagen.c")
+list(APPEND LZ4_CLI_SOURCES ${LZ4_SOURCES}) # LZ4_CLI always use liblz4 sources directly.
 
 # Whether to use position independent code for the static library.  If
 # we're building a shared library this is ignored and PIC is always
@@ -135,20 +136,11 @@ if(BUILD_STATIC_LIBS)
     XXH_NAMESPACE=LZ4_)
 endif()
 
-if(BUILD_STATIC_LIBS)
-  set(LZ4_LINK_LIBRARY lz4_static)
-else()
-  list(APPEND LZ4_CLI_SOURCES ${LZ4_SOURCES})
-endif()
-
 # lz4
 if (LZ4_BUILD_CLI)
   set(LZ4_PROGRAMS_BUILT lz4cli)
   add_executable(lz4cli ${LZ4_CLI_SOURCES})
   set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
-  if (BUILD_STATIC_LIBS)
-    target_link_libraries(lz4cli ${LZ4_LINK_LIBRARY})
-  endif()
 endif()
 
 # lz4c
@@ -156,9 +148,6 @@ if (LZ4_BUILD_LEGACY_LZ4C)
   list(APPEND LZ4_PROGRAMS_BUILT lz4c)
   add_executable(lz4c ${LZ4_CLI_SOURCES})
   set_target_properties(lz4c PROPERTIES COMPILE_DEFINITIONS "ENABLE_LZ4C_LEGACY_OPTIONS")
-  if (BUILD_STATIC_LIBS)
-    target_link_libraries(lz4c ${LZ4_LINK_LIBRARY})
-  endif()
 endif()
 
 # Extra warning flags


### PR DESCRIPTION
This PR fixes #1269.

Since `lz4/programs/Makefile:SRCFILES` explicitly contains source code of `lz4` CLI and `liblz4`, `CMakeLists.txt` must follow this settings.

It also means, `lz4` CLI and legacy `lz4c` must avoid to link with `liblz4`.

This PR supports the following two expected scenarios: shared and static lib.

```
cd
git clone -b fix/issue-1269 https://github.com/t-mat/lz4.git lz4-issue-1269
cd lz4-issue-1269
cd build/cmake

# default (shared lib, cli and legacy lz4c)
rm -rf build
mkdir  build
pushd  build
cmake ..
make -j
readelf -h ./liblz4.so
readelf -h ./liblz4.a   # must be failed: No such file
popd

# static (static lib, cli and legacy lz4c)
rm -rf build
mkdir  build
pushd  build
cmake -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF ..
make -j
readelf -h ./liblz4.so  # must be failed: No such file
readelf -h ./liblz4.a
popd
```

I'll add these scenarios to the CI as a follow up PR.
