### PR TITLE
chore: suppress warning C6385 for MSVC 17.7

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -532,12 +532,12 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
     case 2:
         LZ4_memcpy(v, srcPtr, 2);
         LZ4_memcpy(&v[2], srcPtr, 2);
-#if defined(_MSC_VER) && (_MSC_VER <= 1936) /* MSVC 2022 ver 17.6 or earlier */
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
 #  pragma warning(push)
 #  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
 #endif
         LZ4_memcpy(&v[4], v, 4);
-#if defined(_MSC_VER) && (_MSC_VER <= 1936) /* MSVC 2022 ver 17.6 or earlier */
+#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
 #  pragma warning(pop)
 #endif
         break;


### PR DESCRIPTION
MSVC 17.7 has been released [1].  Their new `_MSC_VER` is `1937`.
But we're still hitting same false positive warnings.

[1]: https://devblogs.microsoft.com/visualstudio/visual-studio-2022-17-7-now-available/
