### PR TITLE
cmake static lib test (ci.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,6 +679,24 @@ jobs:
         cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
         VERBOSE=1 cmake --build build_test
 
+  lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
+    name: cmake (static lib)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # https://github.com/actions/checkout v4.1.0
+
+    - name: Environment info
+      run: |
+        echo && type cmake && which cmake && cmake --version
+        echo && type make && which make && make -v
+
+    - name: cmake (static lib)
+      run: |
+        CFLAGS=-Werror cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
+        VERBOSE=1 cmake --build build
+        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
+        VERBOSE=1 cmake --build build_test
+
   # Invoke cmake via Makefile
   lz4-build-make-cmake:
     name: make cmake


### PR DESCRIPTION
This PR is follow-up for #1281.
To check #1269, this PR adds actual static library build test for cmake.

note: before merging #1281, this PR fails to build the static library.

https://github.com/t-mat/lz4/actions/runs/6453785476/job/17518007581#step:4:106

```
/usr/bin/ld: CMakeFiles/lz4cli.dir/home/runner/work/lz4/lz4/programs/bench.c.o: in function `BMK_benchMem':
bench.c:(.text+0x1c66): undefined reference to `XXH64'
/usr/bin/ld: bench.c:(.text+0x298a): undefined reference to `XXH64'
collect2: error: ld returned 1 exit status
```
