### PR TITLE
Introduce the `.clang-format` rule file 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,132 @@
+# This is the configuration file for clang-format, an automatic code formatter.
+# Introduction: https://clang.llvm.org/docs/ClangFormat.html
+# Supported options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+Language: Cpp
+Standard: Latest
+
+ColumnLimit: 110
+
+UseTab: Never
+IndentWidth: 4
+PPIndentWidth: 2
+ContinuationIndentWidth: 4
+
+LineEnding: LF
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentWrappedFunctionNames: false
+
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Right
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignConsecutiveAssignments:
+    Enabled:          true
+    AcrossEmptyLines: false
+    AcrossComments:   false
+    AlignCompound:    false
+    PadOperators:     false
+AlignConsecutiveBitFields:
+    Enabled:          true
+    AcrossEmptyLines: false
+    AcrossComments:   false
+AlignConsecutiveDeclarations:
+    Enabled:          true
+    AcrossEmptyLines: false
+    AcrossComments:   false
+AlignConsecutiveMacros:
+    Enabled:          true
+    AcrossEmptyLines: false
+    AcrossComments:   false
+AlignTrailingComments:
+    Kind:           Leave
+    OverEmptyLines: 0
+
+BinPackArguments: true
+BinPackParameters: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BraceWrapping:
+    AfterCaseLabel:        false
+    AfterControlStatement: Never
+    AfterEnum:             false
+    AfterExternBlock:      false
+    AfterFunction:         true
+    AfterStruct:           false
+    AfterUnion:            false
+    BeforeElse:            false
+    BeforeWhile:           false
+    IndentBraces:          false
+    SplitEmptyFunction:    false
+    SplitEmptyRecord:      false
+BreakAfterAttributes: Never
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+QualifierAlignment: Custom
+QualifierOrder: ["inline", "static", "volatile", "restrict", "const", "type"]
+
+ReflowComments: false
+BreakStringLiterals: false
+RemoveSemicolon: true
+RemoveParentheses: ReturnStatement
+InsertBraces: false
+SeparateDefinitionBlocks: Always
+
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+BitFieldColonSpacing: Both
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInSquareBrackets: false
+SpacesInLineCommentPrefix:
+    Minimum: 1
+    Maximum: -1
+
+SortIncludes: Never
+IncludeBlocks: Preserve
+IncludeIsMainRegex: ""
+IncludeCategories:
+    - {Regex: "<.*>",   Priority: -2, CaseSensitive: true}
+    - {Regex: "\".*\"", Priority: -1, CaseSensitive: true}
+
+AttributeMacros: ["__capability"]
+StatementAttributeLikeMacros: []
+StatementMacros: []
+
+PenaltyBreakAssignment: 200
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 10
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60


### PR DESCRIPTION
This PR introduces [clang-format](https://clang.llvm.org/docs/ClangFormat.html) into the codebase.

## Motivation

Currently, the codebase is, to put it lightly, inconsistent. There is variation even in such basic things as the number of spaces with which we indent. Consistent code is easier to read and understand, and with clang-format we can ensure consistency across the whole codebase. It makes contributing to the project easier too; people don't need to read any style guide or try and figure out the conventions we use; they can write code however they want and run clang-format on it before they submit a PR.

## Key changes

My starting settings are quite aggressive. I'm happy to make the formatter more lenient or discuss specific settings. I strongly believe that even a very lenient formatter is better than no formatter at all.

- A for loop, while loop, or case label and block on one line is disallowed:

```c
// before
while (true) bar();
for (int i = 0; i < 5; ++i) { baz(); fiz(); }
case 1: biz();

// after
while (true) {
    bar();
}
for (int i = 0; i < 5; ++i) { 
    baz(); 
    fiz(); 
}
case 1: 
    biz();
```

- Consecutive declarations are always aligned:

```c
// before
LZ4_stream_t* const lz4Stream = LZ4_createStream();
const size_t cmpBufBytes = LZ4_COMPRESSBOUND(messageMaxBytes);
char* const cmpBuf = (char*) malloc(cmpBufBytes);
char* const inpBuf = (char*) malloc(ringBufferBytes);
int inpOffset = 0;

// after
LZ4_stream_t* const lz4Stream   = LZ4_createStream();
const size_t        cmpBufBytes = LZ4_COMPRESSBOUND(messageMaxBytes);
char* const         cmpBuf      = (char*)malloc(cmpBufBytes);
char* const         inpBuf      = (char*)malloc(ringBufferBytes);
int                 inpOffset   = 0;
```
- Consistent handling of functions with long argument/parameter lists (clang-format calls this "binpacking"):
```c
// before
static void roundTripTest(void* resultBuff, size_t resultBuffCapacity,
                          void* compressedBuff, size_t compressedBuffCapacity,
                    const void* srcBuff, size_t srcSize)

// after
static void roundTripTest(void*       resultBuff,
                          size_t      resultBuffCapacity,
                          void*       compressedBuff,
                          size_t      compressedBuffCapacity,
                          const void* srcBuff,
                          size_t      srcSize)
```

## Possible improvements

- Integrate clang-format with GitHub (I'm not familiar with that so it's not part of this PR).

---

I realize this may be an overwhelming PR. Please keep in mind that these are changes to *style*, not functionality, and so not every single line deserves close scrutiny. Thank you very much for your time.