### PR TITLE
fix: fix PR #1286

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
     - name: cmake (static lib)
       run: |
         CFLAGS=-Werror cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
-        VERBOSE=1 cmake --build build
+        VERBOSE=1 cmake --build build --target install
         cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
         VERBOSE=1 cmake --build build_test
 


### PR DESCRIPTION
This is a follow-up/fix of PR #1286.

Add missing `--target install`.
Without this parameter, following cmake tests fail to find cmake configuration files.

Here's actual `cmake static` log : https://github.com/lz4/lz4/actions/runs/6494405289/job/17637268190?pr=1292
