### PR TITLE
Remove redundant null pointer checks before `free()`

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1545,7 +1545,6 @@ void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
 #if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
 {
-    if (!LZ4_stream) return 0;   /* support free on NULL */
     DEBUGLOG(5, "LZ4_freeStream %p", LZ4_stream);
     FREEMEM(LZ4_stream);
     return (0);
@@ -2497,7 +2496,6 @@ LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 
 int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
 {
-    if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
     FREEMEM(LZ4_stream);
     return 0;
 }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1058,7 +1058,6 @@ LZ4_streamHC_t* LZ4_createStreamHC(void)
 int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
 {
     DEBUGLOG(4, "LZ4_freeStreamHC(%p)", LZ4_streamHCPtr);
-    if (!LZ4_streamHCPtr) return 0;  /* support free on NULL */
     FREEMEM(LZ4_streamHCPtr);
     return 0;
 }
@@ -1293,7 +1292,6 @@ void* LZ4_createHC (const char* inputBuffer)
 
 int LZ4_freeHC (void* LZ4HC_Data)
 {
-    if (!LZ4HC_Data) return 0;  /* support free on NULL */
     FREEMEM(LZ4HC_Data);
     return 0;
 }


### PR DESCRIPTION
`free()` [already checks if it was given a null pointer](https://en.cppreference.com/w/c/memory/free#Notes), and therefore a user-defined `LZ4_free()` should too, so we don't need to check for null pointers ourselves.