### PR TITLE
Enable basic support for riscv64

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -49,6 +49,7 @@ extern "C" {
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
   || defined __loongarch64                                                                                      /* LoongArch 64-bit */  \
+  || defined __riscv64 || defined __riscv64__ || defined riscv64                                                    /* Riscv 64-bit */  \
   || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \
   || (defined __SIZEOF_POINTER__ && __SIZEOF_POINTER__ == 8) /* gcc */
 #  if !defined(__64BIT__)

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -48,9 +48,9 @@ extern "C" {
   || defined __x86_64__s || defined _M_X64                                                                          /* x86 64-bit */    \
   || defined __arm64__ || defined __aarch64__ || defined __ARM64_ARCH_8__                                           /* ARM 64-bit */    \
   || (defined __mips  && (__mips == 64 || __mips == 4 || __mips == 3))                                              /* MIPS 64-bit */   \
-  || defined __loongarch64                                                                                      /* LoongArch 64-bit */  \
-  || defined __riscv64 || defined __riscv64__ || defined riscv64                                                    /* Riscv 64-bit */  \
-  || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64 /* Cray */               \
+  || defined __loongarch64                                                                                          /* LoongArch 64-bit */  \
+  || (defined __riscv && defined __riscv_xlen && (__riscv_xlen == 64))                                              /* Riscv 64-bit */  \
+  || defined _LP64 || defined __LP64__ /* NetBSD, OpenBSD */ || defined __64BIT__ /* AIX */ || defined _ADDR64      /* Cray */               \
   || (defined __SIZEOF_POINTER__ && __SIZEOF_POINTER__ == 8) /* gcc */
 #  if !defined(__64BIT__)
 #    define __64BIT__  1


### PR DESCRIPTION
Hi,
( I'm new to lz4, please kindly let me know if I need to follow some process for this pr. )
Can you take a look at this simple patch to try to bring basic riscv64 support to lz4?

Thanks!

( github CI support riscv64 is added in https://github.com/lz4/lz4/pull/1299 )

## Test
I have run the test via QEMU by following command:
```
CC=riscv64-linux-gnu-gcc make test
```
There are lots of output, seems there is no error, and the bottom lines of output are:
```
All done, ran 10000 iterations per test.
make[1]: Leaving directory '/home/hamlin/workspace/repos/github/misc/lz4/examples'
```