### PR TITLE
fix incorrect AND of condition check

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1085,7 +1085,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
 
         /* Catch up */
         filledIp = ip;
-        while (((ip>anchor) & (match > lowLimit)) && (unlikely(ip[-1]==match[-1]))) { ip--; match--; }
+        while (((ip>anchor) && (match > lowLimit)) && (unlikely(ip[-1]==match[-1]))) { ip--; match--; }
 
         /* Encode Literals */
         {   unsigned const litLength = (unsigned)(ip - anchor);


### PR DESCRIPTION
Missing one & in pointers check makes this a bitwise AND instead of logical AND. This was introduced in commit 3c0332600490003b1267a9f0a51a6a315b52891e.

Change-Id: Ice50d240e3f52e38e2b3456dd2c5bc5cefb70e0d