### PR TITLE
lz4: remove unnecessary check of ip

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1085,7 +1085,10 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
 
         /* Catch up */
         filledIp = ip;
-        while (((ip>anchor) & (match > lowLimit)) && (unlikely(ip[-1]==match[-1]))) { ip--; match--; }
+        assert(ip > anchor); /* this is always true as ip has been advanced before entering the main loop */
+        if ((match > lowLimit) && unlikely(ip[-1] == match[-1])) {
+            do { ip--; match--; } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
+        }
 
         /* Encode Literals */
         {   unsigned const litLength = (unsigned)(ip - anchor);


### PR DESCRIPTION
ip has been advanced before the match finder loop, so (ip>anchor) will be always true before entering the loop.
This change generates better codegen with clang.

Change-Id: I2567cb7f4a16cc28496fc88c07dcd99601bc97b3