### PR TITLE
decomp: refine read_variable_length codegen layout

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1931,6 +1931,17 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
     if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
         return rvl_error;
     }
+    s = **ip;
+    (*ip)++;
+    length += s;
+    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+        return rvl_error;
+    }
+    /* accumulator overflow detection (32-bit mode only) */
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        return rvl_error;
+    }
+    if (likely(s != 255)) return length;
     do {
         s = **ip;
         (*ip)++;
@@ -1939,10 +1950,10 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
             return rvl_error;
         }
         /* accumulator overflow detection (32-bit mode only) */
-        if ((sizeof(length)<8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
             return rvl_error;
         }
-    } while (s==255);
+    } while (s == 255);
 
     return length;
 }


### PR DESCRIPTION
The probability of multiple-bytes length is low.
Split the first byte extraction from the loop,
add hint of comparison to get more pipeline friendly code, and move the reset of loop to a seperate cold path. See: https://godbolt.org/z/z4jd5z7z9

Change-Id: Ic93ae717954574435357fdb84624d00b0c280331