### PR TITLE
updated code documentation

### DIFF
--- a/doc/lz4_manual.html
+++ b/doc/lz4_manual.html
@@ -1,16 +1,16 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>1.9.4 Manual</title>
+<title>1.9.5 Manual</title>
 </head>
 <body>
-<h1>1.9.4 Manual</h1>
+<h1>1.9.5 Manual</h1>
 <hr>
 <a name="Contents"></a><h2>Contents</h2>
 <ol>
 <li><a href="#Chapter1">Introduction</a></li>
 <li><a href="#Chapter2">Version</a></li>
-<li><a href="#Chapter3">Tuning parameter</a></li>
+<li><a href="#Chapter3">Tuning memory usage</a></li>
 <li><a href="#Chapter4">Simple Functions</a></li>
 <li><a href="#Chapter5">Advanced Functions</a></li>
 <li><a href="#Chapter6">Streaming Compression Functions</a></li>
@@ -83,15 +83,15 @@
 </b></pre><BR>
 <pre><b>const char* LZ4_versionString (void);   </b>/**< library version string; useful to check dll version; requires v1.7.5+ */<b>
 </b></pre><BR>
-<a name="Chapter3"></a><h2>Tuning parameter</h2><pre></pre>
+<a name="Chapter3"></a><h2>Tuning memory usage</h2><pre></pre>
 
 <pre><b>#ifndef LZ4_MEMORY_USAGE
 # define LZ4_MEMORY_USAGE LZ4_MEMORY_USAGE_DEFAULT
 #endif
-</b><p> Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB; )
- Increasing memory usage improves compression ratio, at the cost of speed.
+</b><p> Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB)
+ Increasing memory usage improves compression ratio, generally at the cost of speed.
  Reduced memory usage may improve speed at the cost of ratio, thanks to better cache locality.
- Default value is 14, for 16KB, which nicely fits into Intel x86 L1 cache
+ Default value is 14, for 16KB, which nicely fits into most L1 caches.
  
 </p></pre><BR>
 
@@ -114,8 +114,9 @@
 </p></pre><BR>
 
 <pre><b>int LZ4_decompress_safe (const char* src, char* dst, int compressedSize, int dstCapacity);
-</b><p>  compressedSize : is the exact complete size of the compressed block.
-  dstCapacity : is the size of destination buffer (which must be already allocated), presumed an upper bound of decompressed size.
+</b><p> @compressedSize : is the exact complete size of the compressed block.
+ @dstCapacity : is the size of destination buffer (which must be already allocated),
+                presumed an upper bound of decompressed size.
  @return : the number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
            If destination buffer is not large enough, decoding will stop and output an error code (negative value).
            If the source stream is detected malformed, the function will stop decoding and return a negative result.
@@ -171,7 +172,7 @@ int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int src
  @return : Nb bytes written into 'dst' (necessarily <= targetDestSize)
            or 0 if compression fails.
 
- Note : from v1.8.2 to v1.9.1, this function had a bug (fixed un v1.9.2+):
+ Note : from v1.8.2 to v1.9.1, this function had a bug (fixed in v1.9.2+):
         the produced compressed content could, in specific circumstances,
         require to be decompressed into a destination buffer larger
         by at least 1 byte than the content to decompress.
@@ -221,6 +222,24 @@ int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int src
 </p></pre><BR>
 
 <a name="Chapter6"></a><h2>Streaming Compression Functions</h2><pre></pre>
+
+<pre><b>#if !defined(RC_INVOKED) </b>/* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */<b>
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+LZ4_stream_t* LZ4_createStream(void);
+int           LZ4_freeStream (LZ4_stream_t* streamPtr);
+#endif </b>/* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */<b>
+#endif
+</b><p>
+ - RC_INVOKED is predefined symbol of rc.exe (the resource compiler which is part of MSVC/Visual Studio).
+   https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros
+
+ - Since rc.exe is a legacy compiler, it truncates long symbol (> 30 chars)
+   and reports warning "RC4011: identifier truncated".
+
+ - To eliminate the warning, we surround long preprocessor symbol with
+   "#if !defined(RC_INVOKED) ... #endif" block that means
+   "skip this block when rc.exe is trying to read it".
+</p></pre><BR>
 
 <pre><b>void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
 </b><p>  Use this to prepare an LZ4_stream_t for a new chain of dependent blocks
@@ -296,10 +315,12 @@ int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int src
 <a name="Chapter7"></a><h2>Streaming Decompression Functions</h2><pre>  Bufferless synchronous API
 <BR></pre>
 
-<pre><b>#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+<pre><b>#if !defined(RC_INVOKED) </b>/* https://docs.microsoft.com/en-us/windows/win32/menurc/predefined-macros */<b>
+#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamDecode_t* LZ4_createStreamDecode(void);
 int                 LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream);
 #endif </b>/* !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION) */<b>
+#endif
 </b><p>  creation / destruction of streaming decompression tracking context.
   A tracking context can be re-used multiple times.
  
@@ -332,10 +353,23 @@ int                 LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream);
 LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
                         const char* src, char* dst,
                         int srcSize, int dstCapacity);
-</b><p>  These decoding functions allow decompression of consecutive blocks in "streaming" mode.
-  A block is an unsplittable entity, it must be presented entirely to a decompression function.
-  Decompression functions only accepts one block at a time.
-  The last 64KB of previously decoded data *must* remain available and unmodified at the memory position where they were decoded.
+</b><p>  This decoding function allows decompression of consecutive blocks in "streaming" mode.
+  The difference with the usual independent blocks is that
+  new blocks are allowed to find references into former blocks.
+  A block is an unsplittable entity, and must be presented entirely to the decompression function.
+  LZ4_decompress_safe_continue() only accepts one block at a time.
+  It's modeled after `LZ4_decompress_safe()` and behaves similarly.
+
+ @LZ4_streamDecode : decompression state, tracking the position in memory of past data
+ @compressedSize : exact complete size of one compressed block.
+ @dstCapacity : size of destination buffer (which must be already allocated),
+                must be an upper bound of decompressed size.
+ @return : number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
+           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
+           If the source stream is detected malformed, the function will stop decoding and return a negative result.
+
+  The last 64KB of previously decoded data *must* remain available and unmodified
+  at the memory position where they were previously decoded.
   If less than 64KB of data has been decoded, all the data must be present.
 
   Special : if decompression side sets a ring buffer, it must respect one of the following conditions :
@@ -361,10 +395,22 @@ LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode,
 LZ4_decompress_safe_usingDict(const char* src, char* dst,
                               int srcSize, int dstCapacity,
                               const char* dictStart, int dictSize);
-</b><p>  These decoding functions work the same as
-  a combination of LZ4_setStreamDecode() followed by LZ4_decompress_*_continue()
-  They are stand-alone, and don't need an LZ4_streamDecode_t structure.
+</b><p>  Works the same as
+  a combination of LZ4_setStreamDecode() followed by LZ4_decompress_safe_continue()
+  However, it's stateless: it doesn't need any LZ4_streamDecode_t state.
   Dictionary is presumed stable : it must remain accessible and unmodified during decompression.
+  Performance tip : Decompression speed can be substantially increased
+                    when dst == dictStart + dictSize.
+ 
+</p></pre><BR>
+
+<pre><b>int
+LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
+                                      int compressedSize,
+                                      int targetOutputSize, int maxOutputSize,
+                                      const char* dictStart, int dictSize);
+</b><p>  Behaves the same as LZ4_decompress_safe_partial()
+  with the added ability to specify a memory segment for past data.
   Performance tip : Decompression speed can be substantially increased
                     when dst == dictStart + dictSize.
  
@@ -568,11 +614,12 @@ LZ4_DEPRECATED("use LZ4_decompress_safe() instead") LZ4LIB_API int LZ4_uncompres
 LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4_decompress_fast_withPrefix64k (const char* src, char* dst, int originalSize);
 </b><p></p></pre><BR>
 
-<pre><b>LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe() instead")
+<pre><b>LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial() instead")
 int LZ4_decompress_fast (const char* src, char* dst, int originalSize);
-LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_continue() instead")
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider migrating towards LZ4_decompress_safe_continue() instead. "
+               "Note that the contract will change (requires block's compressed size, instead of decompressed size)")
 int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
-LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_usingDict() instead")
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial_usingDict() instead")
 int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
 </b><p>  These functions used to be faster than LZ4_decompress_safe(),
   but this is no longer the case. They are now slower.

--- a/doc/lz4frame_manual.html
+++ b/doc/lz4frame_manual.html
@@ -1,10 +1,10 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
-<title>1.9.4 Manual</title>
+<title>1.9.5 Manual</title>
 </head>
 <body>
-<h1>1.9.4 Manual</h1>
+<h1>1.9.5 Manual</h1>
 <hr>
 <a name="Contents"></a><h2>Contents</h2>
 <ol>
@@ -116,9 +116,19 @@
 <pre><b>size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
                                 const void* srcBuffer, size_t srcSize,
                                 const LZ4F_preferences_t* preferencesPtr);
-</b><p>  Compress an entire srcBuffer into a valid LZ4 frame.
-  dstCapacity MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
-  The LZ4F_preferences_t structure is optional : you can provide NULL as argument. All preferences will be set to default.
+</b><p>  Compress srcBuffer content into an LZ4-compressed frame.
+  It's a one shot operation, all input content is consumed, and all output is generated.
+
+  Note : it's a stateless operation (no LZ4F_cctx state needed).
+  In order to reduce load on the allocator, LZ4F_compressFrame(), by default,
+  uses the stack to allocate space for the compression state and some table.
+  If this usage of the stack is too much for your application,
+  consider compiling `lz4frame.c` with compile-time macro LZ4F_HEAPMODE set to 1 instead.
+  All state allocations will use the Heap.
+  It also means each invocation of LZ4F_compressFrame() will trigger several internal alloc/free invocations.
+
+ @dstCapacity MUST be >= LZ4F_compressFrameBound(srcSize, preferencesPtr).
+ @preferencesPtr is optional : one can provide NULL, in which case all preferences are set to default.
  @return : number of bytes written into dstBuffer.
            or an error code if it fails (can be tested using LZ4F_isError())
  
@@ -157,7 +167,7 @@ LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctx);
                                       const LZ4F_preferences_t* prefsPtr);
 </b><p>  will write the frame header into dstBuffer.
   dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.
- `prefsPtr` is optional : you can provide NULL as argument, all preferences will then be set to default.
+ `prefsPtr` is optional : NULL can be provided to set all preferences to default.
  @return : number of bytes written into dstBuffer for the header
            or an error code (which can be tested using LZ4F_isError())
  
@@ -227,8 +237,9 @@ LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctx);
 <a name="Chapter9"></a><h2>Decompression functions</h2><pre></pre>
 
 <pre><b>typedef struct {
-  unsigned stableDst;     /* pledges that last 64KB decompressed data will remain available unmodified between invocations.
-                           * This optimization skips storage operations in tmp buffers. */
+  unsigned stableDst;     /* pledges that last 64KB decompressed data is present right before @dstBuffer pointer.
+                           * This optimization skips internal storage operations.
+                           * Once set, this pledge must remain valid up to the end of current frame. */
   unsigned skipChecksums; /* disable checksum calculation and verification, even when one is present in frame, to save CPU time.
                            * Setting this option to 1 once disables all checksums for the rest of the frame. */
   unsigned reserved1;     </b>/* must be set to zero for forward compatibility */<b>
@@ -328,6 +339,11 @@ LZ4F_decompress(LZ4F_dctx* dctx,
 
  `dstBuffer` can freely change between each consecutive function invocation.
  `dstBuffer` content will be overwritten.
+
+  Note: if `LZ4F_getFrameInfo()` is called before `LZ4F_decompress()`, srcBuffer must be updated to reflect
+  the number of bytes consumed after reading the frame header. Failure to update srcBuffer before calling
+  `LZ4F_decompress()` will cause decompression failure or, even worse, successful but incorrect decompression.
+  See the `LZ4F_getFrameInfo()` docs for details.
 
  @return : an hint of how many `srcSize` bytes LZ4F_decompress() expects for next call.
   Schematically, it's the size of the current (or remaining) compressed block + header of next block.

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -144,22 +144,22 @@ LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; 
 
 
 /*-************************************
-*  Tuning parameter
+*  Tuning memory usage
 **************************************/
-#define LZ4_MEMORY_USAGE_MIN 10
-#define LZ4_MEMORY_USAGE_DEFAULT 14
-#define LZ4_MEMORY_USAGE_MAX 20
-
 /*!
  * LZ4_MEMORY_USAGE :
- * Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB; )
- * Increasing memory usage improves compression ratio, at the cost of speed.
+ * Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB)
+ * Increasing memory usage improves compression ratio, generally at the cost of speed.
  * Reduced memory usage may improve speed at the cost of ratio, thanks to better cache locality.
- * Default value is 14, for 16KB, which nicely fits into Intel x86 L1 cache
+ * Default value is 14, for 16KB, which nicely fits into most L1 caches.
  */
 #ifndef LZ4_MEMORY_USAGE
 # define LZ4_MEMORY_USAGE LZ4_MEMORY_USAGE_DEFAULT
 #endif
+
+#define LZ4_MEMORY_USAGE_MIN 10
+#define LZ4_MEMORY_USAGE_DEFAULT 14
+#define LZ4_MEMORY_USAGE_MAX 20
 
 #if (LZ4_MEMORY_USAGE < LZ4_MEMORY_USAGE_MIN)
 #  error "LZ4_MEMORY_USAGE is too small !"
@@ -191,7 +191,7 @@ LZ4LIB_API int LZ4_compress_default(const char* src, char* dst, int srcSize, int
 /*! LZ4_decompress_safe() :
  * @compressedSize : is the exact complete size of the compressed block.
  * @dstCapacity : is the size of destination buffer (which must be already allocated),
- *                is an upper bound of decompressed size.
+ *                presumed an upper bound of decompressed size.
  * @return : the number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
  *           If destination buffer is not large enough, decoding will stop and output an error code (negative value).
  *           If the source stream is detected malformed, the function will stop decoding and return a negative result.
@@ -312,7 +312,7 @@ LZ4LIB_API int LZ4_decompress_safe_partial (const char* src, char* dst, int srcS
 ***********************************************/
 typedef union LZ4_stream_u LZ4_stream_t;  /* incomplete type (defined later) */
 
-/**
+/*!
  Note about RC_INVOKED
 
  - RC_INVOKED is predefined symbol of rc.exe (the resource compiler which is part of MSVC/Visual Studio).
@@ -546,9 +546,9 @@ LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
 #define LZ4_STATIC_3504398509
 
 #ifdef LZ4_PUBLISH_STATIC_FUNCTIONS
-#define LZ4LIB_STATIC_API LZ4LIB_API
+# define LZ4LIB_STATIC_API LZ4LIB_API
 #else
-#define LZ4LIB_STATIC_API
+# define LZ4LIB_STATIC_API
 #endif
 
 
@@ -705,7 +705,7 @@ struct LZ4_stream_t_internal {
     /* Implicit padding to ensure structure is aligned */
 };
 
-#define LZ4_STREAM_MINSIZE  ((1UL << LZ4_MEMORY_USAGE) + 32)  /* static size, for inter-version compatibility */
+#define LZ4_STREAM_MINSIZE  ((1UL << (LZ4_MEMORY_USAGE)) + 32)  /* static size, for inter-version compatibility */
 union LZ4_stream_u {
     char minStateSize[LZ4_STREAM_MINSIZE];
     LZ4_stream_t_internal internal_donotuse;
@@ -838,11 +838,12 @@ LZ4_DEPRECATED("use LZ4_decompress_fast_usingDict() instead") LZ4LIB_API int LZ4
  *         But they may happen if input data is invalid (error or intentional tampering).
  *         As a consequence, use these functions in trusted environments with trusted data **only**.
  */
-LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe() instead")
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial() instead")
 LZ4LIB_API int LZ4_decompress_fast (const char* src, char* dst, int originalSize);
-LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_continue() instead")
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider migrating towards LZ4_decompress_safe_continue() instead. "
+               "Note that the contract will change (requires block's compressed size, instead of decompressed size)")
 LZ4LIB_API int LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* src, char* dst, int originalSize);
-LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_usingDict() instead")
+LZ4_DEPRECATED("This function is deprecated and unsafe. Consider using LZ4_decompress_safe_partial_usingDict() instead")
 LZ4LIB_API int LZ4_decompress_fast_usingDict (const char* src, char* dst, int originalSize, const char* dictStart, int dictSize);
 
 /*! LZ4_resetStream() :


### PR DESCRIPTION
notably around migration advice from deprecated `_fast`  functions.

fix #1310.