### PR TITLE
remove Windows-specific `$(EXT)` suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lz4 : liblz4.a
 lz4-release : lib-release
 lz4 lz4-release :
 	$(MAKE) -C $(PRGDIR) $@
-	$(LN_SF) $(PRGDIR)/lz4$(EXT) .
+	$(LN_SF) $(PRGDIR)/lz4 .
 
 .PHONY: examples
 examples: liblz4.a
@@ -83,7 +83,7 @@ clean:
 	$(MAKE) -C $(EXDIR) $@ > $(VOID)
 	$(MAKE) -C $(FUZZDIR) $@ > $(VOID)
 	$(MAKE) -C contrib/gen_manual $@ > $(VOID)
-	$(RM) lz4$(EXT)
+	$(RM) lz4
 	$(RM) -r $(CMAKE_BUILD_DIR)
 	@echo Cleaning completed
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -57,14 +57,12 @@ WINBASED    = yes
       else
 LIBLZ4_NAME = liblz4
 WINBASED    = no
-EXT         =
       endif
     endif
   endif
 endif
 
 ifeq ($(WINBASED),yes)
-EXT        = .exe
 WINDRES ?= windres
 endif
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -102,6 +102,7 @@ build_script:
       msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v140 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       COPY build\VS2010\bin\%PLATFORM%_%CONFIGURATION%\*.exe programs\
     ) else (
+      DIR tests\ &&
       COPY tests\*.exe programs\
     )
 

--- a/contrib/gen_manual/Makefile
+++ b/contrib/gen_manual/Makefile
@@ -45,19 +45,12 @@ LIBVER_PATCH_SCRIPT:=`sed -n '/define[[:blank:]][[:blank:]]*LZ4_VERSION_RELEASE/
 LIBVER_SCRIPT:= $(LIBVER_MAJOR_SCRIPT).$(LIBVER_MINOR_SCRIPT).$(LIBVER_PATCH_SCRIPT)
 LZ4VER := $(shell echo $(LIBVER_SCRIPT))
 
-# Define *.exe as extension for Windows systems
-ifneq (,$(filter Windows%,$(OS)))
-EXT =.exe
-else
-EXT =
-endif
-
 
 .PHONY: default
 default: gen_manual
 
 gen_manual: gen_manual.cpp
-	$(CXX) $(FLAGS) $^ -o $@$(EXT)
+	$(CXX) $(FLAGS) $^ -o $@
 
 $(LZ4MANUAL) : gen_manual $(LZ4API)
 	echo "Update lz4 manual in /doc"
@@ -72,5 +65,5 @@ manuals: $(LZ4MANUAL) $(LZ4FMANUAL)
 
 .PHONY: clean
 clean:
-	@$(RM) gen_manual$(EXT)
+	@$(RM) gen_manual
 	@echo Cleaning completed

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -62,27 +62,27 @@ $(LZ4) :
 
 test : all $(LZ4)
 	@echo "\n=== Print Version ==="
-	./print_version$(EXT)
+	./print_version
 	@echo "\n=== Simple compression example ==="
-	./simple_buffer$(EXT)
+	./simple_buffer
 	@echo "\n=== Double-buffer ==="
-	./blockStreaming_doubleBuffer$(EXT) $(TESTFILE)
+	./blockStreaming_doubleBuffer $(TESTFILE)
 	@echo "\n=== Ring Buffer ==="
-	./blockStreaming_ringBuffer$(EXT)   $(TESTFILE)
+	./blockStreaming_ringBuffer   $(TESTFILE)
 	@echo "\n=== Ring Buffer + LZ4 HC ==="
-	./streamingHC_ringBuffer$(EXT) $(TESTFILE)
+	./streamingHC_ringBuffer $(TESTFILE)
 	@echo "\n=== Compress line by line ==="
-	./blockStreaming_lineByLine$(EXT) $(TESTFILE)
+	./blockStreaming_lineByLine $(TESTFILE)
 	@echo "\n=== Dictionary Random Access ==="
-	./dictionaryRandomAccess$(EXT) $(TESTFILE) $(TESTFILE) 1100 1400
+	./dictionaryRandomAccess $(TESTFILE) $(TESTFILE) 1100 1400
 	@echo "\n=== Frame compression ==="
-	./frameCompress$(EXT) $(TESTFILE)
+	./frameCompress $(TESTFILE)
 	$(LZ4) -vt $(TESTFILE).lz4
 	@echo "\n=== file compression ==="
-	./fileCompress$(EXT) $(TESTFILE)
+	./fileCompress $(TESTFILE)
 	$(LZ4) -vt $(TESTFILE).lz4
 	@echo "\n=== Q&D benchmark ==="
-	./bench_functions$(EXT) 10000
+	./bench_functions 10000
 
 .PHONY: clean
 clean:

--- a/lib/dll/example/Makefile
+++ b/lib/dll/example/Makefile
@@ -37,13 +37,6 @@ CPPFLAGS:= -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_
 FLAGS   := $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 
-# Define *.exe as extension for Windows systems
-ifneq (,$(filter Windows%,$(OS)))
-EXT =.exe
-else
-EXT =
-endif
-
 .PHONY: default fullbench-dll fullbench-lib
 
 
@@ -53,11 +46,11 @@ all: fullbench-dll fullbench-lib
 
 
 fullbench-lib: fullbench.c xxhash.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT) $(LIBDIR)/liblz4_static.lib
+	$(CC) $(FLAGS) $^ -o $@ $(LIBDIR)/liblz4_static.lib
 
 fullbench-dll: fullbench.c xxhash.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(DLLDIR)/liblz4.dll
+	$(CC) $(FLAGS) $^ -o $@ -DLZ4_DLL_IMPORT=1 $(DLLDIR)/liblz4.dll
 
 clean:
-	@$(RM) fullbench-dll$(EXT) fullbench-lib$(EXT) \
+	@$(RM) fullbench-dll fullbench-lib
 	@echo Cleaning completed

--- a/ossfuzz/Makefile
+++ b/ossfuzz/Makefile
@@ -66,7 +66,7 @@ else
   LIB_FUZZING_DEPS :=
 endif
 %_fuzzer: %_fuzzer.o lz4_helpers.o fuzz_data_producer.o $(LZ4DIR)/liblz4.a $(LIB_FUZZING_DEPS)
-	$(CXX) $(LZ4_CXXFLAGS) $(LZ4_CPPFLAGS) $(LDFLAGS) $(LIB_FUZZING_ENGINE) $^ -o $@$(EXT)
+	$(CXX) $(LZ4_CXXFLAGS) $(LZ4_CPPFLAGS) $(LDFLAGS) $(LIB_FUZZING_ENGINE) $^ -o $@
 
 %_fuzzer_clean:
 	$(RM) $*_fuzzer $*_fuzzer.o standaloneengine.o

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -84,17 +84,17 @@ lz4-exe.rc: lz4-exe.rc.in
          -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
          -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
          -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
-         -e 's|@EXT@|$(EXT)|g' \
+         -e 's|@EXT@|.exe|g' \
           $< >$@
 
 lz4-exe.o: lz4-exe.rc
 	$(WINDRES) -i lz4-exe.rc -o lz4-exe.o
 
 lz4: $(OBJFILES) lz4-exe.o
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 else
 lz4: $(OBJFILES)
-	$(CC) $(FLAGS) $(OBJFILES) -o $@$(EXT) $(LDLIBS)
+	$(CC) $(FLAGS) $(OBJFILES) -o $@ $(LDLIBS)
 endif
 
 .PHONY: lz4-release
@@ -107,18 +107,18 @@ lz4-wlib: LDFLAGS += -L $(LZ4DIR)
 lz4-wlib: LDLIBS   = -llz4
 lz4-wlib: liblz4 $(OBJFILES)
 	@echo WARNING: $@ must link to an extended variant of the dynamic library which also exposes unstable symbols
-	$(CC) $(FLAGS) $(OBJFILES) -o $@$(EXT) $(LDLIBS)
+	$(CC) $(FLAGS) $(OBJFILES) -o $@ $(LDLIBS)
 
 .PHONY:liblz4
 liblz4:
 	CPPFLAGS="-DLZ4F_PUBLISH_STATIC_FUNCTIONS -DLZ4_PUBLISH_STATIC_FUNCTIONS" $(MAKE) -C $(LZ4DIR) liblz4
 
 lz4c: lz4
-	$(LN_SF) lz4$(EXT) lz4c$(EXT)
+	$(LN_SF) lz4 lz4c
 
 lz4c32: CFLAGS += -m32
 lz4c32 : $(SRCFILES)
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 lz4.1: lz4.1.md $(LIBVER_SRC)
 	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | $(SED) -n '/^\.\\\".*/!p' > $@
@@ -137,8 +137,8 @@ ifeq ($(WINBASED),yes)
 endif
 	$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	$(RM) core *.o *.test tmp* \
-           lz4$(EXT) lz4c$(EXT) lz4c32$(EXT) lz4-wlib$(EXT) \
-           unlz4$(EXT) lz4cat$(EXT)
+           lz4 lz4c lz4c32 lz4-wlib \
+           unlz4 lz4cat
 	@echo Cleaning completed
 
 
@@ -148,10 +148,10 @@ endif
 ifeq ($(POSIX_ENV),Yes)
 
 unlz4: lz4
-	$(LN_SF) lz4$(EXT) unlz4$(EXT)
+	$(LN_SF) lz4 unlz4
 
 lz4cat: lz4
-	$(LN_SF) lz4$(EXT) lz4cat$(EXT)
+	$(LN_SF) lz4 lz4cat
 
 DESTDIR     ?=
 # directory variables : GNU conventions prefer lowercase
@@ -173,10 +173,10 @@ man1dir     ?= $(MAN1DIR)
 install: lz4
 	@echo Installing binaries in $(DESTDIR)$(bindir)
 	$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
-	$(INSTALL_PROGRAM) lz4$(EXT) $(DESTDIR)$(bindir)/lz4$(EXT)
-	$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
-	$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)
-	$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/unlz4$(EXT)
+	$(INSTALL_PROGRAM) lz4 $(DESTDIR)$(bindir)/lz4
+	$(LN_SF) lz4 $(DESTDIR)$(bindir)/lz4c
+	$(LN_SF) lz4 $(DESTDIR)$(bindir)/lz4cat
+	$(LN_SF) lz4 $(DESTDIR)$(bindir)/unlz4
 	@echo Installing man pages in $(DESTDIR)$(man1dir)
 	$(INSTALL_DATA) lz4.1 $(DESTDIR)$(man1dir)/lz4.1
 	$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/lz4c.1
@@ -185,10 +185,10 @@ install: lz4
 	@echo lz4 installation completed
 
 uninstall:
-	$(RM) $(DESTDIR)$(bindir)/lz4cat$(EXT)
-	$(RM) $(DESTDIR)$(bindir)/unlz4$(EXT)
-	$(RM) $(DESTDIR)$(bindir)/lz4$(EXT)
-	$(RM) $(DESTDIR)$(bindir)/lz4c$(EXT)
+	$(RM) $(DESTDIR)$(bindir)/lz4cat
+	$(RM) $(DESTDIR)$(bindir)/unlz4
+	$(RM) $(DESTDIR)$(bindir)/lz4
+	$(RM) $(DESTDIR)$(bindir)/lz4c
 	$(RM) $(DESTDIR)$(man1dir)/lz4.1
 	$(RM) $(DESTDIR)$(man1dir)/lz4c.1
 	$(RM) $(DESTDIR)$(man1dir)/lz4cat.1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,7 +45,7 @@ FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 include ../Makefile.inc
 
-LZ4 := $(PRGDIR)/lz4$(EXT)
+LZ4 := $(PRGDIR)/lz4
 
 
 # Default test parameters
@@ -78,57 +78,57 @@ lz4c32:   # create a 32-bits version for 32/64 interop tests
 
 fullbench : DEBUGLEVEL=0
 fullbench : lz4.o lz4hc.o lz4frame.o xxhash.o fullbench.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 $(LZ4DIR)/liblz4.a:
 	$(MAKE) -C $(LZ4DIR) liblz4.a
 
 fullbench-lib: fullbench.c $(LZ4DIR)/liblz4.a
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 fullbench-dll: fullbench.c $(LZ4DIR)/xxhash.c
 	$(MAKE) -C $(LZ4DIR) liblz4
-	$(CC) $(FLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
+	$(CC) $(FLAGS) $^ -o $@ -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
 
 # test LZ4_USER_MEMORY_FUNCTIONS
 fullbench-wmalloc: CPPFLAGS += -DLZ4_USER_MEMORY_FUNCTIONS
 fullbench-wmalloc: fullbench
 
 fuzzer  : lz4.o lz4hc.o xxhash.o fuzzer.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 frametest: lz4frame.o lz4.o lz4hc.o xxhash.o frametest.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 roundTripTest : lz4.o lz4hc.o xxhash.o roundTripTest.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 datagen : $(PRGDIR)/datagen.c datagencli.c
-	$(CC) $(FLAGS) -I$(PRGDIR) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) -I$(PRGDIR) $^ -o $@
 
 checkFrame : lz4frame.o lz4.o lz4hc.o xxhash.o checkFrame.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 decompress-partial: lz4.o decompress-partial.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 decompress-partial-usingDict: lz4.o decompress-partial-usingDict.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(FLAGS) $^ -o $@
 
 .PHONY: clean
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
 	@$(RM) -rf core *.o *.test tmp* \
-        fullbench-dll$(EXT) fullbench-lib$(EXT) \
-        fullbench$(EXT) fullbench32$(EXT) \
-        fuzzer$(EXT) fuzzer32$(EXT) \
-        frametest$(EXT) frametest32$(EXT) \
-        fasttest$(EXT) roundTripTest$(EXT) \
-        datagen$(EXT) checkTag$(EXT) \
-        frameTest$(EXT) decompress-partial$(EXT) \
-        abiTest$(EXT) freestanding$(EXT) \
-        checkFrame$(EXT) \
+        fullbench-dll fullbench-lib \
+        fullbench fullbench32 \
+        fuzzer fuzzer32 \
+        frametest frametest32 \
+        fasttest roundTripTest \
+        datagen checkTag \
+        frameTest decompress-partial \
+        abiTest freestanding \
+        checkFrame \
         lz4_all.c
 	@$(RM) -rf $(TESTDIR)
 	@echo Cleaning completed
@@ -148,7 +148,7 @@ abiTests:
 	$(PYTHON) test-lz4-abi.py
 
 checkTag: checkTag.c $(LZ4DIR)/lz4.h
-	$(CC) $(FLAGS) $< -o $@$(EXT)
+	$(CC) $(FLAGS) $< -o $@
 
 #-----------------------------------------------------------------------------
 # validated only for Linux, OSX, BSD, Hurd and Solaris targets
@@ -347,9 +347,9 @@ test-mem32: lz4c32 datagen
 
 test-decompress-partial : decompress-partial decompress-partial-usingDict
 	@echo "\n ---- test decompress-partial ----"
-	./decompress-partial$(EXT)
+	./decompress-partial
 	@echo "\n ---- test decompress-partial-usingDict ----"
-	./decompress-partial-usingDict$(EXT)
+	./decompress-partial-usingDict
 
 
 #-----------------------------------------------------------------------------
@@ -378,16 +378,16 @@ ifneq ($(UNAME_P), x86_64)
 endif
 
 freestanding: freestanding.c
-	$(CC) $(FREESTANDING_CFLAGS) $^ -o $@$(EXT)
+	$(CC) $(FREESTANDING_CFLAGS) $^ -o $@
 
 test-freestanding: freestanding
 	@echo "\n ---- test freestanding ----"
 ifeq ($(FREESTANDING_CFLAGS),)
 	@echo "\n (skip)"
 else
-	./freestanding$(EXT)
-	-strace ./freestanding$(EXT)
-	-ltrace ./freestanding$(EXT)
+	./freestanding
+	-strace ./freestanding
+	-ltrace ./freestanding
 endif
 
 


### PR DESCRIPTION
`Makefile` is only understood and therefore useful for a few specific environments under Windows.

When tested within supported environments (`mingw64`, `msys2` and `cygwin`), the current `Makefile` is able to produce Windows executable binaries with the expected `*.exe` suffix without any need to add this suffix manually in the recipe.
This works even for extended command such as `$(RM)`, which will correctly remove `target.exe` even if only the name `target` appears in the list.

This makes it possible to consume a regular `Makefile` under these environments, simplifying the redaction, clarity and maintenance of these files.

This approach is proposed as an alternative to #1243.