### PR TITLE
refactor appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: 1.0.{build}
 environment:
   matrix:
+  - COMPILER: "clang"
+    PLATFORM: "mingw64"
   - COMPILER: "gcc"
     PLATFORM: "mingw64"
   - COMPILER: "gcc"
@@ -17,48 +19,48 @@ environment:
   - COMPILER: "visual"
     CONFIGURATION: "Release"
     PLATFORM: "Win32"
-  - COMPILER: "gcc"
-    PLATFORM: "clang"
 
 install:
   - ECHO Installing %COMPILER% %PLATFORM% %CONFIGURATION%
   - MKDIR bin
-  - if [%COMPILER%]==[gcc] SET PATH_ORIGINAL=%PATH%
-  - if [%COMPILER%]==[gcc] (
+  - if [%COMPILER%]==[visual] (
+      if [%PLATFORM%]==[x64] (
+        SET ADDITIONALPARAM=/p:LibraryPath="C:\Program Files\Microsoft SDKs\Windows\v7.1\lib\x64;c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\lib\amd64;C:\Program Files (x86)\Microsoft Visual Studio 10.0\;C:\Program Files (x86)\Microsoft Visual Studio 10.0\lib\amd64;"
+      )
+    ) else (
       SET "PATH_MINGW32=c:\MinGW\bin;c:\MinGW\usr\bin" &&
       SET "PATH_MINGW64=c:\msys64\mingw64\bin;c:\msys64\usr\bin" &&
       COPY C:\MinGW\bin\mingw32-make.exe C:\MinGW\bin\make.exe &&
       COPY C:\MinGW\bin\gcc.exe C:\MinGW\bin\cc.exe
-    ) else (
-      IF [%PLATFORM%]==[x64] (SET ADDITIONALPARAM=/p:LibraryPath="C:\Program Files\Microsoft SDKs\Windows\v7.1\lib\x64;c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\lib\amd64;C:\Program Files (x86)\Microsoft Visual Studio 10.0\;C:\Program Files (x86)\Microsoft Visual Studio 10.0\lib\amd64;")
     )
 
 build_script:
-  - if [%PLATFORM%]==[mingw32] SET PATH=%PATH_MINGW32%;%PATH_ORIGINAL%
-  - if [%PLATFORM%]==[mingw64] SET PATH=%PATH_MINGW64%;%PATH_ORIGINAL%
-  - if [%PLATFORM%]==[clang] SET PATH=%PATH_MINGW64%;%PATH_ORIGINAL%
+  - if [%PLATFORM%]==[mingw32] SET PATH=%PATH_MINGW32%;%PATH%
+  - if [%PLATFORM%]==[mingw64] SET PATH=%PATH_MINGW64%;%PATH%
   - ECHO *** &&
       ECHO Building %COMPILER% %PLATFORM% %CONFIGURATION% &&
       ECHO ***
-  - if [%PLATFORM%]==[clang] (clang -v)
-  - if [%COMPILER%]==[gcc] (gcc -v)
   - if [%COMPILER%]==[gcc] (
       echo ----- &&
+      gcc -v &&
       make -v &&
       echo ----- &&
-      if not [%PLATFORM%]==[clang] (
-        make -C programs lz4 &&
-        make -C tests fullbench &&
-        make -C tests fuzzer &&
-        make -C lib lib V=1
-      ) ELSE (
-        make -C programs lz4 CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-        make -C tests fullbench CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-        make -C tests fuzzer CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-        make -C lib lib CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
-      )
+      make -C programs lz4 &&
+      make -C tests fullbench &&
+      make -C tests fuzzer &&
+      make -C lib lib V=1
     )
-  - if [%COMPILER%]==[gcc] if not [%PLATFORM%]==[clang] (
+  - if [%COMPILER%]==[clang] (
+      echo ----- &&
+      clang -v &&
+      make -v &&
+      echo ----- &&
+      make -C programs lz4 CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C tests fullbench CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C tests fuzzer CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C lib lib CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
+    )
+  - if [%COMPILER%]==[gcc] (
       MKDIR bin\dll bin\static bin\example bin\include &&
       COPY tests\fullbench.c bin\example\ &&
       COPY lib\xxhash.c bin\example\ &&
@@ -81,7 +83,6 @@ build_script:
       7z.exe a -bb1 bin\lz4_x86.zip NEWS .\bin\lz4.exe .\bin\README.md .\bin\example .\bin\dll .\bin\static .\bin\include &&
       appveyor PushArtifact bin\lz4_x86.zip
     )
-  - if [%COMPILER%]==[gcc] (COPY tests\*.exe programs\)
   - if [%COMPILER%]==[visual] (
       ECHO *** &&
       ECHO *** Building Visual Studio 2010 %PLATFORM%\%CONFIGURATION% &&
@@ -100,6 +101,8 @@ build_script:
       ECHO *** &&
       msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v140 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       COPY build\VS2010\bin\%PLATFORM%_%CONFIGURATION%\*.exe programs\
+    ) else (
+      COPY tests\*.exe programs\
     )
 
 test_script:


### PR DESCRIPTION
The clang test definition was really weird (`COMPILER: "gcc", PLATFORM: "clang"` ??).
Make it more logical (`COMPILER: "clang", PLATFORM: "mingw64"`) and fix the rest of the script accordingly.

Tests definition and execution should remain identical.