### PR TITLE
fix minor conversion warnings

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -494,7 +494,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                 DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.3f),%6.1f MB/s\r",
                         marks[markNb], displayName,
                         (U32)totalRSize, (U32)cSize, ratio,
-                        ((double)totalRSize / fastestC) * 1000 );
+                        ((double)totalRSize / (double)fastestC) * 1000 );
             }
             (void)fastestD; (void)crcOrig;   /*  unused when decompression disabled */
 #if 1
@@ -557,8 +557,8 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
             DISPLAYLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.3f),%6.1f MB/s, %6.1f MB/s\r",
                     marks[markNb], displayName,
                     (U32)totalRSize, (U32)cSize, ratio,
-                    ((double)totalRSize / fastestC) * 1000,
-                    ((double)totalRSize / fastestD) * 1000);
+                    ((double)totalRSize / (double)fastestC) * 1000,
+                    ((double)totalRSize / (double)fastestD) * 1000);
 
             /* CRC Checking (not possible in decode-only mode)*/
             if (!g_decodeOnly) {
@@ -590,8 +590,8 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
         }   /* for (testNb = 1; testNb <= (g_nbSeconds + !g_nbSeconds); testNb++) */
 
         if (g_displayLevel == 1) {
-            double const cSpeed = ((double)srcSize / fastestC) * 1000;
-            double const dSpeed = ((double)srcSize / fastestD) * 1000;
+            double const cSpeed = ((double)srcSize / (double)fastestC) * 1000;
+            double const dSpeed = ((double)srcSize / (double)fastestD) * 1000;
             if (g_additionalParam)
                 DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, g_additionalParam);
             else

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -466,7 +466,7 @@ int LZ4IO_compressFilename_Legacy(const char* input_filename,
         assert(outSize >= 0);
         compressedfilesize += (unsigned long long)outSize+4;
         DISPLAYUPDATE(2, "\rRead : %i MiB  ==> %.2f%%   ",
-                (int)(filesize>>20), (double)compressedfilesize/filesize*100);
+                (int)(filesize>>20), (double)compressedfilesize/(double)filesize*100);
 
         /* Write Block */
         assert(outSize > 0);
@@ -483,7 +483,7 @@ int LZ4IO_compressFilename_Legacy(const char* input_filename,
     filesize += !filesize;   /* avoid division by zero (ratio) */
     DISPLAYLEVEL(2, "\r%79s\r", "");   /* blank line */
     DISPLAYLEVEL(2,"Compressed %llu bytes into %llu bytes ==> %.2f%%\n",
-        filesize, compressedfilesize, (double)compressedfilesize / filesize * 100);
+        filesize, compressedfilesize, (double)compressedfilesize / (double)filesize * 100);
     {   double const seconds = (double)(clockEnd - clockStart) / CLOCKS_PER_SEC;
         DISPLAYLEVEL(4,"Done in %.2f s ==> %.2f MiB/s\n", seconds,
                         (double)filesize / seconds / 1024 / 1024);
@@ -719,7 +719,7 @@ LZ4IO_compressFilename_extRess(cRess_t ress,
             END_PROCESS(41, "Compression failed : %s", LZ4F_getErrorName(cSize));
         compressedfilesize = cSize;
         DISPLAYUPDATE(2, "\rRead : %u MiB   ==> %.2f%%   ",
-                      (unsigned)(filesize>>20), (double)compressedfilesize/(filesize+!filesize)*100);   /* avoid division by zero */
+                      (unsigned)(filesize>>20), (double)compressedfilesize/(double)(filesize+!filesize)*100);   /* avoid division by zero */
 
         /* Write Block */
         if (fwrite(dstBuffer, 1, cSize, dstFile) != cSize) {
@@ -744,7 +744,7 @@ LZ4IO_compressFilename_extRess(cRess_t ress,
                 END_PROCESS(45, "Compression failed : %s", LZ4F_getErrorName(outSize));
             compressedfilesize += outSize;
             DISPLAYUPDATE(2, "\rRead : %u MiB   ==> %.2f%%   ",
-                        (unsigned)(filesize>>20), (double)compressedfilesize/filesize*100);
+                        (unsigned)(filesize>>20), (double)compressedfilesize/(double)filesize*100);
 
             /* Write Block */
             if (fwrite(dstBuffer, 1, outSize, dstFile) != outSize)
@@ -787,7 +787,7 @@ LZ4IO_compressFilename_extRess(cRess_t ress,
     DISPLAYLEVEL(2, "\r%79s\r", "");
     DISPLAYLEVEL(2, "Compressed %llu bytes into %llu bytes ==> %.2f%%\n",
                     filesize, compressedfilesize,
-                    (double)compressedfilesize / (filesize + !filesize /* avoid division by zero */ ) * 100);
+                    (double)compressedfilesize / (double)(filesize + !filesize /* avoid division by zero */ ) * 100);
 
     return 0;
 }
@@ -1636,7 +1636,7 @@ LZ4IO_getCompressedFileInfo(LZ4IO_cFileInfo_t* cfinfo, const char* input_filenam
                                              bTypeBuffer,
                                              frameInfo.lz4FrameInfo.contentChecksumFlag ? "XXH32" : "-");
                                 if (frameInfo.lz4FrameInfo.contentSize) {
-                                    {   double const ratio = (double)(totalBlocksSize + hSize) / frameInfo.lz4FrameInfo.contentSize * 100;
+                                    {   double const ratio = (double)(totalBlocksSize + hSize) / (double)frameInfo.lz4FrameInfo.contentSize * 100;
                                         DISPLAYLEVEL(3, " %20llu %20llu %9.2f%%\n",
                                                      totalBlocksSize + hSize,
                                                      frameInfo.lz4FrameInfo.contentSize,
@@ -1750,7 +1750,7 @@ int LZ4IO_displayCompressedFilesInfo(const char** inFileNames, size_t ifnIdx)
                         LZ4IO_toHuman((long double)cfinfo.fileSize, buffers[1]),
                         cfinfo.allContentSize ? LZ4IO_toHuman((long double)cfinfo.frameSummary.lz4FrameInfo.contentSize, buffers[2]) : "-");
                 if (cfinfo.allContentSize) {
-                    double const ratio = (double)cfinfo.fileSize / cfinfo.frameSummary.lz4FrameInfo.contentSize * 100;
+                    double const ratio = (double)cfinfo.fileSize / (double)cfinfo.frameSummary.lz4FrameInfo.contentSize * 100;
                     DISPLAYOUT("%9.2f%%  %s \n", ratio, cfinfo.fileName);
                 } else {
                     DISPLAYOUT("%9s   %s\n",

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1042,9 +1042,9 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
     bytes += !bytes;   /* avoid division by 0 */
     printf("\r%7u /%7u   - ", cycleNb, nbCycles);
     printf("all tests completed successfully \n");
-    printf("compression ratio: %0.3f%%\n", (double)cbytes/bytes*100);
-    printf("HC compression ratio: %0.3f%%\n", (double)hcbytes/bytes*100);
-    printf("ratio with dict: %0.3f%%\n", (double)ccbytes/bytes*100);
+    printf("compression ratio: %0.3f%%\n", (double)cbytes/(double)bytes*100);
+    printf("HC compression ratio: %0.3f%%\n", (double)hcbytes/(double)bytes*100);
+    printf("ratio with dict: %0.3f%%\n", (double)ccbytes/(double)bytes*100);
 
     /* release memory */
     free(CNBuffer);


### PR DESCRIPTION
with newer `clang-17`