### PR TITLE
ensure make install target doesn't create files

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -85,13 +85,13 @@ default: lib-release
 $(V)$(VERBOSE).SILENT:
 
 lib-release: DEBUGFLAGS :=
-lib-release: lib
+lib-release: lib liblz4.pc
 
 .PHONY: lib
 lib: liblz4.a liblz4
 
 .PHONY: all
-all: lib
+all: lib liblz4.pc
 
 .PHONY: all32
 all32: CFLAGS+=-m32
@@ -138,6 +138,15 @@ endif
 .PHONY: liblz4
 liblz4: $(LIBLZ4)
 
+liblz4.pc: liblz4.pc.in Makefile
+	@echo creating pkgconfig
+	$(SED) -e 's|@PREFIX@|$(prefix)|' \
+           -e 's|@LIBDIR@|$(libdir)|' \
+           -e 's|@INCLUDEDIR@|$(includedir)|' \
+           -e 's|@VERSION@|$(LIBVER)|' \
+           -e 's|=${prefix}/|=$${prefix}/|' \
+           $< >$@
+
 .PHONY: clean
 clean:
 ifeq ($(WINBASED),yes)
@@ -177,15 +186,6 @@ PKGCONFIGDIR ?= $(prefix)/libdata/pkgconfig
 PKGCONFIGDIR ?= $(libdir)/pkgconfig
   endif
 pkgconfigdir ?= $(PKGCONFIGDIR)
-
-liblz4.pc: liblz4.pc.in Makefile
-	@echo creating pkgconfig
-	$(SED) -e 's|@PREFIX@|$(prefix)|' \
-         -e 's|@LIBDIR@|$(libdir)|' \
-         -e 's|@INCLUDEDIR@|$(includedir)|' \
-         -e 's|@VERSION@|$(LIBVER)|' \
-         -e 's|=${prefix}/|=$${prefix}/|' \
-          $< >$@
 
 install: lib liblz4.pc
 	$(INSTALL_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/


### PR DESCRIPTION
Following the GNU Makefile conventions : 

> If possible, write the install target rule so that it does not modify anything in the directory where the program was built, provided ‘make all’ has just been done. This is convenient for building the program under one user name and installing it under another.

(https://www.chiark.greenend.org.uk/doc/make-doc/make.html/Makefile-Conventions.html#Standard-Targets)

Extends the concept to `make`,
so that the sequence `make` + `make install` doesn't generate any new file at `make install` stage,
for the reason described (different user name for each stage, notably due to `sudo`).

To reach that goal, the only missing file was the `pkgconfig` file `liblz4.pc`.