### PR TITLE
minor: lz4file API provides more accurate error codes

### DIFF
--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -222,7 +222,7 @@ LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4
   if (fp == NULL || lz4fWrite == NULL)
     RETURN_ERROR(parameter_null);
 
-  *lz4fWrite = (LZ4_writeFile_t*)malloc(sizeof(LZ4_writeFile_t));
+  *lz4fWrite = (LZ4_writeFile_t*)calloc(1, sizeof(LZ4_writeFile_t));
   if (*lz4fWrite == NULL) {
     RETURN_ERROR(allocation_failed);
   }

--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -31,7 +31,7 @@
  * - LZ4 homepage : http://www.lz4.org
  * - LZ4 source repository : https://github.com/lz4/lz4
  */
-#include <stdlib.h>  // malloc, free
+#include <stdlib.h>  /* malloc, free */
 #include <string.h>
 #include <assert.h>
 #include "lz4.h"

--- a/lib/lz4file.h
+++ b/lib/lz4file.h
@@ -38,7 +38,7 @@ extern "C" {
 #ifndef LZ4FILE_H
 #define LZ4FILE_H
 
-#include <stdio.h>  // FILE*
+#include <stdio.h>  /* FILE* */
 #include "lz4frame_static.h"
 
 typedef struct LZ4_readFile_s LZ4_readFile_t;

--- a/lib/lz4file.h
+++ b/lib/lz4file.h
@@ -38,7 +38,7 @@ extern "C" {
 #ifndef LZ4FILE_H
 #define LZ4FILE_H
 
-#include <stdio.h>
+#include <stdio.h>  // FILE*
 #include "lz4frame_static.h"
 
 typedef struct LZ4_readFile_s LZ4_readFile_t;

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -564,6 +564,8 @@ extern "C" {
         ITEM(ERROR_frameDecoding_alreadyStarted) \
         ITEM(ERROR_compressionState_uninitialized) \
         ITEM(ERROR_parameter_null) \
+        ITEM(ERROR_io_write) \
+        ITEM(ERROR_io_read) \
         ITEM(ERROR_maxCode)
 
 #define LZ4F_GENERATE_ENUM(ENUM) LZ4F_##ENUM,


### PR DESCRIPTION
removed all instances of error `GENERIC`, and replaced them with more accurate error descriptions.
2 more error codes are created for this purpose, `io_write` and `io_read`.