### PR TITLE
Makefile refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
     # This is based on your 1.0 configuration file or project settings
     - run: CFLAGS= make clangtest && make clean
     - run: g++ -v; make cxxtest   && make clean
-    - run: gcc -v; g++ -v; make ctocpptest && make clean
+    - run: gcc -v; g++ -v; make ctocxxtest && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -Werror" make check && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
     - run: gcc-6 -v; CC=gcc-6 CFLAGS="-O2 -Werror" make check  && make clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,21 +48,21 @@ jobs:
     - run: gcc -v; g++ -v; make ctocpptest && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -Werror" make check && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
-    - run: gcc-6 -v; CC=gcc-6 MOREFLAGS="-O2 -Werror" make check  && make clean
+    - run: gcc-6 -v; CC=gcc-6 CFLAGS="-O2 -Werror" make check  && make clean
     - run: make cmake                && make clean
     - run: make -C tests test-lz4
     - run: make -C tests test-lz4c
     - run: make -C tests test-frametest
     - run: make -C tests test-fuzzer && make clean
     - run: make -C lib all           && make clean
-    - run: pyenv global 3.4.4; make versionsTest MOREFLAGS=-I/usr/include/x86_64-linux-gnu && make clean
+    - run: pyenv global 3.4.4; CPPFLAGS=-I/usr/include/x86_64-linux-gnu make versionsTest && make clean
     - run: make test-install         && make clean
     - run: gcc -v; CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
     - run: clang -v; make staticAnalyze && make clean
-    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static                   && make clean
-    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static MOREFLAGS=-m64  && make clean
-    - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static                   && make clean
-    - run: make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static               && make clean
+    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static                && make clean
+    - run: CFLAGS=-m64 make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static  && make clean
+    - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static                && make clean
+    - run: make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static            && make clean
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
     # Test
     #   This would typically be a build job when using workflows, possibly combined with build
     # This is based on your 1.0 configuration file or project settings
-    - run: CFLAGS= make clangtest && make clean
-    - run: g++ -v; make cxxtest   && make clean
-    - run: gcc -v; g++ -v; make ctocxxtest && make clean
+    - run: CFLAGS=-O0 make clangtest && make clean
+    - run: c++ -v; make cxxtest      && make clean
+    - run: cc -v; c++ -v; make ctocxxtest && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -Werror" make check && make clean
     - run: gcc-5 -v; CC=gcc-5 CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
     - run: gcc-6 -v; CC=gcc-6 CFLAGS="-O2 -Werror" make check  && make clean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ jobs:
     - run: make test-install         && make clean
     - run: gcc -v; CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
     - run: clang -v; make staticAnalyze && make clean
-    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static                && make clean
-    - run: CFLAGS=-m64 make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static  && make clean
-    - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static                && make clean
-    - run: make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static            && make clean
+    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static V=1       && make clean
+    - run: CFLAGS=-m64 LDFLAGS=-m64 make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static V=1 && make clean
+    - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static V=1      && make clean
+    - run: make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static V=1  && make clean
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
     - name: examples
       run: make V=1 clean examples
 
-  # lasts ~20mn
+  # lasts ~8mn
   oss-fuzz:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,19 +130,19 @@ jobs:
 
     - name: make -C tests test-lz4
       if: always()
-      run: make clean; MOREFLAGS='-Werror' make -j V=1 -C tests test-lz4
+      run: make clean; CFLAGS='-Werror -O1' make -j V=1 -C tests test-lz4
 
     - name: make clangtest (clang only)
       if: ${{ startsWith( matrix.cc , 'clang' ) }}
       run: make V=1 clean clangtest
 
-    - name: make -C tests test MOREFLAGS='-mx32'
+    - name: make -C tests test CFLAGS='-mx32'
       if: ${{ matrix.x32 == 'true' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' MOREFLAGS='-mx32' make -j V=1 -C tests test
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32' make -j V=1 -C tests test
 
     - name: make -C tests test-lz4c32
       if: ${{ matrix.x86 == 'true' }}
-      run: LDFLAGS='-Wl,--verbose' MOREFLAGS='-Werror' make V=1 -C tests clean test-lz4c32
+      run: LDFLAGS='-Wl,--verbose' CFLAGS='-Werror -O1' make V=1 -C tests clean test-lz4c32
 
 
     ###############################################################
@@ -150,13 +150,13 @@ jobs:
     #      Remove this block when we stabilize the tests.         #
     #                                                             #
 
-    - name: make -C tests test MOREFLAGS='-mx32' || echo Ignore failure for now.
+    - name: make -C tests test CFLAGS='-mx32' || echo Ignore failure for now.
       if: ${{ matrix.x32 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' MOREFLAGS='-mx32' make -j V=1 -C tests test || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32 -O1' make -j V=1 -C tests test || $FIXME__LZ4_CI_IGNORE
 
     - name: make -C tests test-lz4c32 || echo Ignore failure for now.
       if: ${{ matrix.x86 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' MOREFLAGS='-Werror' make V=1 -C tests test-lz4c32 || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror -O1' make V=1 -C tests test-lz4c32 || $FIXME__LZ4_CI_IGNORE
 
     #                                                             #
     ###############################################################
@@ -293,7 +293,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout v4.1.1
     - name: custom LZ4_DISTANCE_MAX; test LZ4_USER_MEMORY_FUNCTIONS
       run: |
-        MOREFLAGS='-DLZ4_DISTANCE_MAX=8000' make V=1 check
+        CPPFLAGS='-DLZ4_DISTANCE_MAX=8000' make V=1 check
         make V=1 clean
         make V=1 -C programs lz4-wlib
         make V=1 clean
@@ -429,10 +429,10 @@ jobs:
       run: sudo sysctl -w vm.mmap_min_addr=4096
 
     - name: frametest
-      run: CC=clang MOREFLAGS=-fsanitize=address make V=1 -C tests clean test-frametest
+      run: CC=clang CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address make V=1 -C tests clean test-frametest
 
     - name: fuzzer
-      run: CC=clang MOREFLAGS=-fsanitize=address make V=1 -C tests clean test-fuzzer
+      run: CC=clang CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address make V=1 -C tests clean test-fuzzer
 
   unicode-lint:
     name: lint unicode in ./lib/, ./tests/ and ./programs/
@@ -501,15 +501,6 @@ jobs:
   # QEMU
   # All tests use QEMU (static) and gcc cross compiler.
   #
-  # note:
-  #   We don't employ completely matrix method which provides `MOREFLAGS`
-  #   etc in the matrix.  Because some platform may need its special
-  #   compiler options and test.
-  #   For example, xxHash already has tests for scalar and SIMD version of
-  #   it.  But compiler options are quite different between platforms.
-  #
-  #   So, please keep them simple and independent.
-  #
   lz4-qemu-platforms:
     name: QEMU ${{ matrix.type }}
     strategy:
@@ -559,7 +550,7 @@ jobs:
 
     - name: PPC64LE
       if: ${{ matrix.type == 'PPC64LE' }}
-      run: make V=1 platformTest CC=$XCC QEMU_SYS=$XEMU MOREFLAGS=-m64
+      run: CFLAGS=-m64 make V=1 platformTest CC=$XCC QEMU_SYS=$XEMU
 
     - name: MIPS-M68K-RISCV
       if: ${{ matrix.type == 'MIPS' || matrix.type == 'M68K' || matrix.type == 'RISC-V' }}
@@ -581,10 +572,10 @@ jobs:
         echo && sysctl -a | grep machdep.cpu   # cpuinfo
 
     - name: make default
-      run: CFLAGS="-Werror" make V=1 clean default
+      run: CFLAGS="-Werror -O1" make V=1 clean default
 
     - name: make test
-      run: make clean; make -j V=1 test MOREFLAGS='-Werror -Wconversion -Wno-sign-conversion'
+      run: make clean; CFLAGS='-O1 -Werror -Wconversion -Wno-sign-conversion' make -j V=1 test
 
     - name: Ensure `make test` doesn't depend on the status of the console
       # see issue #990 for detailed explanations
@@ -670,7 +661,7 @@ jobs:
 
     - name: cmake
       run: |
-        CFLAGS=-Werror cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
+        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
         VERBOSE=1 cmake --build build --target install
         cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
         VERBOSE=1 cmake --build build_test
@@ -688,7 +679,7 @@ jobs:
 
     - name: cmake (static lib)
       run: |
-        CFLAGS=-Werror cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
+        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
         VERBOSE=1 cmake --build build --target install
         cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
         VERBOSE=1 cmake --build build_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,39 +90,39 @@ jobs:
 
     - name: make
       if: always()
-      run: make V=1
+      run: make -j V=1
 
     - name: install test
       if: always()
-      run: make clean; make V=1 -C tests test-install
+      run: make clean; make -C tests test-install V=1
 
     - name: make all
       if: always()
-      run: make V=1 clean all
+      run: make clean; make -j all V=1
 
     - name: make c_standards (C90)
       if: always()
-      run: make V=1 clean c_standards_c90
+      run: make clean; make -j c_standards_c90 V=1
 
     - name: make c_standards (C11)
       if: always()
-      run: make V=1 clean c_standards_c11
+      run: make clean; make -j c_standards_c11 V=1
 
     - name: make c-to-c++
-      if: always()
-      run: make clean; make ctocxxtest V=1
+      if: ${{ matrix.cxxtest == 'true' }}
+      run: make clean; make -j ctocxxtest V=1
 
     - name: make cxxtest
       if: ${{ matrix.cxxtest == 'true' }}
-      run: make clean; make cxxtest V=1
+      run: make clean; make -j cxxtest V=1
 
     - name: make test-freestanding
       if: ${{ matrix.freestanding == 'true' }}
-      run: make V=1 clean test-freestanding
+      run: make clean; make test-freestanding V=1
 
     - name: make -C programs default
       if: always()
-      run: make V=1 -C programs clean default
+      run: make clean; make -j -C programs default V=1
 
     - name: make -C programs default -D_FORTIFY_SOURCE=2
       if: always()
@@ -134,15 +134,15 @@ jobs:
 
     - name: make clangtest (clang only)
       if: ${{ startsWith( matrix.cc , 'clang' ) }}
-      run: make V=1 clean clangtest
+      run: make clean; make clangtest V=1
 
     - name: make -C tests test CFLAGS='-mx32'
       if: ${{ matrix.x32 == 'true' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32' make -j V=1 -C tests test
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32 -O1' make -j -C tests test V=1
 
     - name: make -C tests test-lz4c32
       if: ${{ matrix.x86 == 'true' }}
-      run: LDFLAGS='-Wl,--verbose' CFLAGS='-Werror' make V=1 -C tests clean test-lz4c32
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror -O1' make -j -C tests test-lz4c32 V=1
 
 
     ###############################################################
@@ -152,11 +152,11 @@ jobs:
 
     - name: make -C tests test CFLAGS='-mx32' || echo Ignore failure for now.
       if: ${{ matrix.x32 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32' make -j V=1 -C tests test || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32' make -j -C tests test V=1 || $FIXME__LZ4_CI_IGNORE
 
     - name: make -C tests test-lz4c32 || echo Ignore failure for now.
       if: ${{ matrix.x86 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror' make V=1 -C tests test-lz4c32 || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror' make -C tests test-lz4c32 V=1 || $FIXME__LZ4_CI_IGNORE
 
     #                                                             #
     ###############################################################
@@ -184,19 +184,19 @@ jobs:
         sudo apt-get install gcc-multilib
 
     - name: benchmark (-C tests test-lz4)
-      run: make -j V=1 -C tests test-lz4
+      run: make -j -C tests test-lz4 V=1
 
     - name: benchmark (-C tests test-lz4c)
-      run: make -j V=1 -C tests test-lz4c
+      run: make -j -C tests test-lz4c V=1
 
     - name: benchmark (-C tests test-lz4c32)
-      run: make V=1 -C tests test-lz4c32
+      run: make -j -C tests test-lz4c32 V=1
 
     - name: benchmark (-C tests test-fullbench)
-      run: make V=1 -C tests test-fullbench
+      run: make -j -C tests test-fullbench V=1
 
     - name: benchmark (-C tests test-fullbench32)
-      run: make V=1 -C tests test-fullbench32
+      run: make -j -C tests test-fullbench32 V=1
 
 
   lz4-fuzzer:
@@ -214,10 +214,10 @@ jobs:
       run: sudo sysctl -w vm.mmap_min_addr=4096
 
     - name: fuzzer
-      run: make V=1 -C tests test-fuzzer
+      run: make -j -C tests test-fuzzer V=1
 
     - name: fuzzer32
-      run: make V=1 -C tests test-fuzzer32
+      run: make -C tests test-fuzzer32 V=1
 
 
   lz4-standard-makefile-variables:
@@ -227,7 +227,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # https://github.com/actions/checkout v4.1.1
 
     - name: make standard_variables
-      run: make V=1 standard_variables
+      run: make -j standard_variables V=1
 
 
   lz4-versions:
@@ -242,7 +242,7 @@ jobs:
         sudo apt-get install gcc-multilib
 
     - name: make -C tests versionsTest
-      run: make V=1 -C tests versionsTest
+      run: make -j -C tests versionsTest V=1
 
 
   lz4-abi:
@@ -257,7 +257,7 @@ jobs:
         sudo apt-get install gcc-multilib
 
     - name: make -C tests abiTests
-      run: make V=1 -C tests abiTests
+      run: make -j -C tests abiTests V=1
 
 
   lz4-frame:
@@ -272,10 +272,10 @@ jobs:
         sudo apt-get install gcc-multilib
 
     - name: LZ4 frame test
-      run: make V=1 -C tests test-frametest
+      run: make -j -C tests test-frametest V=1
 
     - name: LZ4 frame test (32-bit)
-      run: make V=1 -C tests test-frametest32
+      run: make -j -C tests test-frametest32 V=1
 
   lz4-memory-usage:
     name: test different values of LZ4_MEMORY_USAGE
@@ -294,12 +294,12 @@ jobs:
     - name: custom LZ4_DISTANCE_MAX; test LZ4_USER_MEMORY_FUNCTIONS
       run: |
         CPPFLAGS='-DLZ4_DISTANCE_MAX=8000' make V=1 check
-        make V=1 clean
-        make V=1 -C programs lz4-wlib
-        make V=1 clean
-        make V=1 -C tests fullbench-wmalloc  # test LZ4_USER_MEMORY_FUNCTIONS
-        make V=1 clean
-        CC="c++ -Wno-deprecated" make V=1 -C tests fullbench-wmalloc  # stricter function signature check
+        make clean
+        make -C programs lz4-wlib V=1
+        make clean
+        make -C tests fullbench-wmalloc V=1  # test LZ4_USER_MEMORY_FUNCTIONS
+        make clean
+        CC="c++ -Wno-deprecated" make -C tests fullbench-wmalloc V=1 # stricter function signature check
 
   # test block device compression #1086
   lz4cli-block-device:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           #
           #   pkgs         : apt-get package names.  It can include multiple package names which are delimited by space.
           #   cc           : C compiler executable.
-          #   cxx          : C++ compiler executable for `make ctocxxtest`.
+          #   cxx          : C++ compiler executable for targets `cxxtest` and `ctocxxtest`.
           #   x32          : Set 'true' if compiler supports x32.  Otherwise, set 'false'.
           #                  Set 'fail' if it supports x32 but fails for now.  'fail' cases must be removed.
           #   x86          : Set 'true' if compiler supports x86 (-m32).  Otherwise, set 'false'.
@@ -110,11 +110,11 @@ jobs:
 
     - name: make c-to-c++
       if: always()
-      run: make V=1 ctocxxtest
+      run: make clean; make ctocxxtest V=1
 
     - name: make cxxtest
       if: ${{ matrix.cxxtest == 'true' }}
-      run: make V=1 clean cxxtest
+      run: make clean; make cxxtest V=1
 
     - name: make test-freestanding
       if: ${{ matrix.freestanding == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,7 +478,7 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'lz4'
-        fuzz-seconds: 600
+        fuzz-seconds: 300
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
 
     - name: make -C tests test-lz4
       if: always()
-      run: make clean; CFLAGS='-Werror -O1' make -j V=1 -C tests test-lz4
+      run: make clean; CFLAGS='-Werror' make -j V=1 -C tests test-lz4
 
     - name: make clangtest (clang only)
       if: ${{ startsWith( matrix.cc , 'clang' ) }}
@@ -142,7 +142,7 @@ jobs:
 
     - name: make -C tests test-lz4c32
       if: ${{ matrix.x86 == 'true' }}
-      run: LDFLAGS='-Wl,--verbose' CFLAGS='-Werror -O1' make V=1 -C tests clean test-lz4c32
+      run: LDFLAGS='-Wl,--verbose' CFLAGS='-Werror' make V=1 -C tests clean test-lz4c32
 
 
     ###############################################################
@@ -152,11 +152,11 @@ jobs:
 
     - name: make -C tests test CFLAGS='-mx32' || echo Ignore failure for now.
       if: ${{ matrix.x32 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32 -O1' make -j V=1 -C tests test || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-mx32' make -j V=1 -C tests test || $FIXME__LZ4_CI_IGNORE
 
     - name: make -C tests test-lz4c32 || echo Ignore failure for now.
       if: ${{ matrix.x86 == 'fail' }}
-      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror -O1' make V=1 -C tests test-lz4c32 || $FIXME__LZ4_CI_IGNORE
+      run: make clean; LDFLAGS='-Wl,--verbose' CFLAGS='-Werror' make V=1 -C tests test-lz4c32 || $FIXME__LZ4_CI_IGNORE
 
     #                                                             #
     ###############################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,10 +572,10 @@ jobs:
         echo && sysctl -a | grep machdep.cpu   # cpuinfo
 
     - name: make default
-      run: CFLAGS="-Werror -O1" make V=1 clean default
+      run: make clean; CFLAGS="-Werror -O1" make V=1 default
 
     - name: make test
-      run: make clean; CFLAGS='-O1 -Werror -Wconversion -Wno-sign-conversion' make -j V=1 test
+      run: make clean; CFLAGS="-O2 -Werror -Wconversion -Wno-sign-conversion" make -j V=1 test
 
     - name: Ensure `make test` doesn't depend on the status of the console
       # see issue #990 for detailed explanations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           #
           #   pkgs         : apt-get package names.  It can include multiple package names which are delimited by space.
           #   cc           : C compiler executable.
-          #   cxx          : C++ compiler executable for `make ctocpptest`.
+          #   cxx          : C++ compiler executable for `make ctocxxtest`.
           #   x32          : Set 'true' if compiler supports x32.  Otherwise, set 'false'.
           #                  Set 'fail' if it supports x32 but fails for now.  'fail' cases must be removed.
           #   x86          : Set 'true' if compiler supports x86 (-m32).  Otherwise, set 'false'.
@@ -110,7 +110,7 @@ jobs:
 
     - name: make c-to-c++
       if: always()
-      run: make V=1 clean ctocpptest
+      run: make V=1 ctocxxtest
 
     - name: make cxxtest
       if: ${{ matrix.cxxtest == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,9 @@ cppcheck:
 platformTest: clean
 	@echo "\n ---- test lz4 with $(CC) compiler ----"
 	$(CC) -v
-	CFLAGS="-O3 -Werror"         $(MAKE) -C $(LZ4DIR) all
-	CFLAGS="-O3 -Werror -static" $(MAKE) -C $(PRGDIR) all
-	CFLAGS="-O3 -Werror -static" $(MAKE) -C $(TESTDIR) all
+	CFLAGS="$(CFLAGS) -O3 -Werror"         $(MAKE) -C $(LZ4DIR) all
+	CFLAGS="$(CFLAGS) -O3 -Werror -static" $(MAKE) -C $(PRGDIR) all
+	CFLAGS="$(CFLAGS) -O3 -Werror -static" $(MAKE) -C $(TESTDIR) all
 	$(MAKE) -C $(TESTDIR) test-platform
 
 .PHONY: versionsTest

--- a/Makefile
+++ b/Makefile
@@ -213,11 +213,10 @@ cxx17build : clean
 	CC=$(CC) $(MAKE) -C $(PRGDIR)  all CFLAGS="$(CFLAGS)"
 	CC=$(CC) $(MAKE) -C $(TESTDIR) all CFLAGS="$(CFLAGS)"
 
-.PHONY: ctocpptest
-ctocpptest: LIBCC="$(CC)"
-ctocpptest: TESTCC="$(CXX)"
-ctocpptest: CFLAGS=
-ctocpptest: clean
+.PHONY: ctocxxtest
+ctocxxtest: LIBCC="$(CC)"
+ctocxxtest: TESTCC="$(CXX)"
+ctocxxtest: CFLAGS=
 	CC=$(LIBCC)  $(MAKE) -C $(LZ4DIR)  CFLAGS="$(CFLAGS)" all
 	CC=$(LIBCC)  $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" lz4.o lz4hc.o lz4frame.o
 	CC=$(TESTCC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" all

--- a/Makefile
+++ b/Makefile
@@ -187,18 +187,30 @@ platformTest: clean
 	$(MAKE) -C $(TESTDIR) test-platform
 
 .PHONY: versionsTest
-versionsTest: clean
+versionsTest:
+	$(MAKE) -C $(TESTDIR) clean
 	$(MAKE) -C $(TESTDIR) $@
 
 .PHONY: test-freestanding
 test-freestanding:
-	$(MAKE) -C $(TESTDIR) clean $@
+	$(MAKE) -C $(TESTDIR) clean
+	$(MAKE) -C $(TESTDIR) $@
+
+# test linking C libraries from C++ executables
+.PHONY: ctocxxtest
+ctocxxtest: LIBCC="$(CC)"
+ctocxxtest: EXECC="$(CXX) -Wno-deprecated"
+ctocxxtest: CFLAGS=-O0
+ctocxxtest:
+	CC=$(LIBCC) $(MAKE) -C $(LZ4DIR)  CFLAGS="$(CFLAGS)" all
+	CC=$(LIBCC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" lz4.o lz4hc.o lz4frame.o
+	CC=$(EXECC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" all
 
 .PHONY: cxxtest cxx32test
+cxx32test: CFLAGS += -m32
 cxxtest cxx32test: CC := "$(CXX) -Wno-deprecated"
 cxxtest cxx32test: CFLAGS = -O3 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Werror
-cxx32test: CFLAGS += -m32
-cxxtest cxx32test: clean
+cxxtest cxx32test:
 	$(CXX) -v
 	CC=$(CC) $(MAKE) -C $(LZ4DIR)  all CFLAGS="$(CFLAGS)"
 	CC=$(CC) $(MAKE) -C $(PRGDIR)  all CFLAGS="$(CFLAGS)"
@@ -212,14 +224,6 @@ cxx17build : clean
 	CC=$(CC) $(MAKE) -C $(LZ4DIR)  all CFLAGS="$(CFLAGS)"
 	CC=$(CC) $(MAKE) -C $(PRGDIR)  all CFLAGS="$(CFLAGS)"
 	CC=$(CC) $(MAKE) -C $(TESTDIR) all CFLAGS="$(CFLAGS)"
-
-.PHONY: ctocxxtest
-ctocxxtest: LIBCC="$(CC)"
-ctocxxtest: TESTCC="$(CXX)"
-ctocxxtest: CFLAGS=
-	CC=$(LIBCC)  $(MAKE) -C $(LZ4DIR)  CFLAGS="$(CFLAGS)" all
-	CC=$(LIBCC)  $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" lz4.o lz4hc.o lz4frame.o
-	CC=$(TESTCC) $(MAKE) -C $(TESTDIR) CFLAGS="$(CFLAGS)" all
 
 .PHONY: c_standards
 c_standards: clean c_standards_c11 c_standards_c99 c_standards_c90

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test:
 .PHONY: clangtest
 clangtest: CFLAGS += -Werror -Wconversion -Wno-sign-conversion
 clangtest: CC = clang
-clangtest: clean
+clangtest:
 	$(CC) -v
 	$(MAKE) -C $(LZ4DIR)  all CC=$(CC)
 	$(MAKE) -C $(PRGDIR)  all CC=$(CC)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,25 +41,25 @@ build_script:
       ECHO Building %COMPILER% %PLATFORM% %CONFIGURATION% &&
       ECHO ***
   - if [%COMPILER%]==[gcc] (
-      echo ----- &&
+      echo ----- %TIME% &&
       gcc -v &&
       make -v &&
       echo ----- &&
-      make -C programs lz4 &&
-      make -C tests fullbench &&
-      make -C tests fuzzer &&
-      make -C lib lib V=1
+      make -j -C programs lz4 V=1 &&
+      make -j -C tests fullbench V=1 &&
+      make -j -C tests fuzzer V=1 &&
+      make -j -C lib lib V=1
     )
   - if [%COMPILER%]==[clang] (
-      echo ----- &&
+      echo ----- %TIME% &&
       clang -v &&
       make -v &&
       echo ----- &&
       set CFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C programs lz4 CC=clang V=1    &&
-      make -C tests fullbench CC=clang V=1 &&
-      make -C tests fuzzer CC=clang V=1    &&
-      make -C lib lib CC=clang V=1
+      make -j -C programs lz4 CC=clang V=1    &&
+      make -j -C tests fullbench CC=clang V=1 &&
+      make -j -C tests fuzzer CC=clang V=1    &&
+      make -j -C lib lib CC=clang V=1
     )
   - if [%COMPILER%]==[gcc] (
       MKDIR bin\dll bin\static bin\example bin\include &&
@@ -85,19 +85,15 @@ build_script:
       appveyor PushArtifact bin\lz4_x86.zip
     )
   - if [%COMPILER%]==[visual] (
-      ECHO *** &&
-      ECHO *** Building Visual Studio 2010 %PLATFORM%\%CONFIGURATION% &&
-      ECHO *** &&
-      msbuild "build\VS2010\lz4.sln" %ADDITIONALPARAM% /m /verbosity:minimal /property:PlatformToolset=v100 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /p:EnableWholeProgramOptimization=true /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
-      ECHO *** &&
+      ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2012 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&
       msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v110 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
-      ECHO *** &&
+      ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2013 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&
       msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v120 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
-      ECHO *** &&
+      ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2015 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&
       msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v140 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
@@ -107,7 +103,7 @@ build_script:
     )
 
 test_script:
-  - ECHO *** &&
+  - ECHO *** %TIME% &&
       ECHO Testing %COMPILER% %PLATFORM% %CONFIGURATION% &&
       ECHO ***
   - if not [%COMPILER%]==[unknown] (
@@ -119,9 +115,10 @@ test_script:
       lz4 -i1b15 lz4.exe &&
       echo ------- lz4 tested ------- &&
       fullbench.exe -i1 fullbench.exe &&
-      echo trying to launch fuzzer.exe &&
-      fuzzer.exe -v -T30s
+      echo Launching test program fuzzer.exe &&
+      fuzzer.exe -v -T20s
     )
+  - ECHO *** %TIME%
 
 artifacts:
   - path: bin\lz4_x64.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,10 +55,11 @@ build_script:
       clang -v &&
       make -v &&
       echo ----- &&
-      make -C programs lz4 CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C tests fullbench CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C tests fuzzer CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C lib lib CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
+      set CFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C programs lz4 CC=clang  &&
+      make -C tests fullbench CC=clang  &&
+      make -C tests fuzzer CC=clang  &&
+      make -C lib lib CC=clang
     )
   - if [%COMPILER%]==[gcc] (
       MKDIR bin\dll bin\static bin\example bin\include &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,10 +56,10 @@ build_script:
       make -v &&
       echo ----- &&
       set CFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C programs lz4 CC=clang  &&
-      make -C tests fullbench CC=clang  &&
-      make -C tests fuzzer CC=clang  &&
-      make -C lib lib CC=clang
+      make -C programs lz4 CC=clang V=1    &&
+      make -C tests fullbench CC=clang V=1 &&
+      make -C tests fuzzer CC=clang V=1    &&
+      make -C lib lib CC=clang V=1
     )
   - if [%COMPILER%]==[gcc] (
       MKDIR bin\dll bin\static bin\example bin\include &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,10 +55,10 @@ build_script:
       clang -v &&
       make -v &&
       echo ----- &&
-      make -C programs lz4 CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C tests fullbench CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C tests fuzzer CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
-      make -C lib lib CC=clang MOREFLAGS="--target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
+      make -C programs lz4 CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C tests fullbench CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C tests fuzzer CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion" &&
+      make -C lib lib CC=clang CFLAGS="-O1 --target=x86_64-w64-mingw32 -Werror -Wconversion -Wno-sign-conversion"
     )
   - if [%COMPILER%]==[gcc] (
       MKDIR bin\dll bin\static bin\example bin\include &&

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,19 +27,21 @@
 # kindly provided by Takayuki Matsuoka
 # ##########################################################################
 
-CPPFLAGS += -I../lib
+LIBDIR   := ../lib
+
+CPPFLAGS += -I$(LIBDIR)
 CFLAGS   ?= -O2
 CFLAGS   += -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes -Wc++-compat
 
 TESTFILE  = Makefile
-LZ4DIR   := ../lib
-SLIBLZ4  := $(LZ4DIR)/liblz4.a
-LZ4       = ../programs/lz4
+SLIBLZ4  := $(LIBDIR)/liblz4.a
+LZ4DIR    = ../programs
+LZ4       = $(LZ4DIR)/lz4
 
 default: all
 
-$(SLIBLZ4): $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4.h $(LZ4DIR)/lz4hc.h $(LZ4DIR)/lz4frame.h $(LZ4DIR)/lz4frame_static.h
-	$(MAKE) -j -C $(LZ4DIR) liblz4.a
+$(SLIBLZ4): $(LIBDIR)/lz4.c $(LIBDIR)/lz4hc.c $(LIBDIR)/lz4frame.c $(LIBDIR)/lz4.h $(LIBDIR)/lz4hc.h $(LIBDIR)/lz4frame.h $(LIBDIR)/lz4frame_static.h
+	$(MAKE) -j -C $(LIBDIR) liblz4.a
 
 ALL = print_version \
 	  simple_buffer \
@@ -50,16 +52,18 @@ ALL = print_version \
 	  streamingHC_ringBuffer \
       blockStreaming_lineByLine \
 	  dictionaryRandomAccess \
-	  bench_functions \
+	  bench_functions
 
+.PHONY: all
 all: $(ALL)
 
 $(ALL): $(SLIBLZ4)
 
 .PHONY:$(LZ4)
 $(LZ4) :
-	$(MAKE) -j -C ../programs lz4
+	$(MAKE) -j -C $(LZ4DIR) lz4
 
+.PHONY: test
 test : all $(LZ4)
 	@echo "\n=== Print Version ==="
 	./print_version$(EXT)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -27,16 +27,17 @@
 # kindly provided by Takayuki Matsuoka
 # ##########################################################################
 
-LIBDIR   := ../lib
+LIBDIR    := ../lib
 
-CPPFLAGS += -I$(LIBDIR)
-CFLAGS   ?= -O2
-CFLAGS   += -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes -Wc++-compat
+CPPFLAGS  += -I$(LIBDIR)
+USERCFLAGS:= $(CFLAGS)
+WFLAGS     = -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-prototypes -Wc++-compat
+CFLAGS     = $(WFLAGS) -O2 $(USERCFLAGS)
 
-TESTFILE  = Makefile
-SLIBLZ4  := $(LIBDIR)/liblz4.a
-LZ4DIR    = ../programs
-LZ4       = $(LZ4DIR)/lz4
+TESTFILE   = Makefile
+SLIBLZ4   := $(LIBDIR)/liblz4.a
+LZ4DIR     = ../programs
+LZ4        = $(LZ4DIR)/lz4
 
 default: all
 

--- a/examples/bench_functions.c
+++ b/examples/bench_functions.c
@@ -130,40 +130,40 @@ uint64_t bench(
     case ID__LZ4_COMPRESS_DEFAULT:
       printf("Starting benchmark for function: LZ4_compress_default()\n");
       for(int junk=0; junk<warm_up; junk++)
-        rv = LZ4_compress_default(src, dst, src_size, max_dst_size);
+        rv = LZ4_compress_default(src, dst, (int)src_size, (int)max_dst_size);
       if (rv < 1)
         run_screaming("Couldn't run LZ4_compress_default()... error code received is in exit code.", rv);
       if (memcmp(known_good_dst, dst, max_dst_size) != 0)
         run_screaming("According to memcmp(), the compressed dst we got doesn't match the known_good_dst... ruh roh.", 1);
       start = clock();
       for (int i=1; i<=iterations; i++)
-        LZ4_compress_default(src, dst, src_size, max_dst_size);
+        LZ4_compress_default(src, dst, (int)src_size, (int)max_dst_size);
       break;
 
     case ID__LZ4_COMPRESS_FAST:
       printf("Starting benchmark for function: LZ4_compress_fast()\n");
       for(int junk=0; junk<warm_up; junk++)
-        rv = LZ4_compress_fast(src, dst, src_size, max_dst_size, acceleration);
+        rv = LZ4_compress_fast(src, dst, (int)src_size, (int)max_dst_size, acceleration);
       if (rv < 1)
         run_screaming("Couldn't run LZ4_compress_fast()... error code received is in exit code.", rv);
       if (memcmp(known_good_dst, dst, max_dst_size) != 0)
         run_screaming("According to memcmp(), the compressed dst we got doesn't match the known_good_dst... ruh roh.", 1);
       start = clock();
       for (int i=1; i<=iterations; i++)
-        LZ4_compress_fast(src, dst, src_size, max_dst_size, acceleration);
+        LZ4_compress_fast(src, dst, (int)src_size, (int)max_dst_size, acceleration);
       break;
 
     case ID__LZ4_COMPRESS_FAST_EXTSTATE:
       printf("Starting benchmark for function: LZ4_compress_fast_extState()\n");
       for(int junk=0; junk<warm_up; junk++)
-        rv = LZ4_compress_fast_extState(&state, src, dst, src_size, max_dst_size, acceleration);
+        rv = LZ4_compress_fast_extState(&state, src, dst, (int)src_size, (int)max_dst_size, acceleration);
       if (rv < 1)
         run_screaming("Couldn't run LZ4_compress_fast_extState()... error code received is in exit code.", rv);
       if (memcmp(known_good_dst, dst, max_dst_size) != 0)
         run_screaming("According to memcmp(), the compressed dst we got doesn't match the known_good_dst... ruh roh.", 1);
       start = clock();
       for (int i=1; i<=iterations; i++)
-        LZ4_compress_fast_extState(&state, src, dst, src_size, max_dst_size, acceleration);
+        LZ4_compress_fast_extState(&state, src, dst, (int)src_size, (int)max_dst_size, acceleration);
       break;
 
 //    Disabled until LZ4_compress_generic() is exposed in the header.
@@ -189,27 +189,27 @@ uint64_t bench(
     case ID__LZ4_DECOMPRESS_SAFE:
       printf("Starting benchmark for function: LZ4_decompress_safe()\n");
       for(int junk=0; junk<warm_up; junk++)
-        rv = LZ4_decompress_safe(src, dst, comp_size, src_size);
+        rv = LZ4_decompress_safe(src, dst, (int)comp_size, (int)src_size);
       if (rv < 1)
         run_screaming("Couldn't run LZ4_decompress_safe()... error code received is in exit code.", rv);
       if (memcmp(known_good_dst, dst, src_size) != 0)
         run_screaming("According to memcmp(), the compressed dst we got doesn't match the known_good_dst... ruh roh.", 1);
       start = clock();
       for (int i=1; i<=iterations; i++)
-        LZ4_decompress_safe(src, dst, comp_size, src_size);
+        LZ4_decompress_safe(src, dst, (int)comp_size, (int)src_size);
       break;
 
     case ID__LZ4_DECOMPRESS_FAST:
       printf("Starting benchmark for function: LZ4_decompress_fast()\n");
       for(int junk=0; junk<warm_up; junk++)
-        rv = LZ4_decompress_fast(src, dst, src_size);
+        rv = LZ4_decompress_fast(src, dst, (int)src_size);
       if (rv < 1)
         run_screaming("Couldn't run LZ4_decompress_fast()... error code received is in exit code.", rv);
       if (memcmp(known_good_dst, dst, src_size) != 0)
         run_screaming("According to memcmp(), the compressed dst we got doesn't match the known_good_dst... ruh roh.", 1);
       start = clock();
       for (int i=1; i<=iterations; i++)
-        LZ4_decompress_fast(src, dst, src_size);
+        LZ4_decompress_fast(src, dst, (int)src_size);
       break;
 
     default:
@@ -250,11 +250,11 @@ int main(int argc, char **argv) {
     usage(exeName, "Argument 1 (iterations) must be > 0.");
 
   // First we will create 2 sources (char *) of 2000 bytes each.  One normal text, the other highly-compressible text.
-  const char *src    = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus purus et risus vulputate, et mollis orci ullamcorper. Nulla facilisi. Fusce in ligula sed purus varius aliquet interdum vitae justo. Proin quis diam velit. Nulla varius iaculis auctor. Cras volutpat, justo eu dictum pulvinar, elit sem porttitor metus, et imperdiet metus sapien et ante. Nullam nisi nulla, ornare eu tristique eu, dignissim vitae diam. Nulla sagittis porta libero, a accumsan felis sagittis scelerisque.  Integer laoreet eleifend congue. Etiam rhoncus leo vel dolor fermentum, quis luctus nisl iaculis. Praesent a erat sapien. Aliquam semper mi in lorem ultrices ultricies. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In feugiat risus sed enim ultrices, at sodales nulla tristique. Maecenas eget pellentesque justo, sed pellentesque lectus. Fusce sagittis sit amet elit vel varius. Donec sed ligula nec ligula vulputate rutrum sed ut lectus. Etiam congue pharetra leo vitae cursus. Morbi enim ante, porttitor ut varius vel, tincidunt quis justo. Nunc iaculis, risus id ultrices semper, metus est efficitur ligula, vel posuere risus nunc eget purus. Ut lorem turpis, condimentum at sem sed, porta aliquam turpis. In ut sapien a nulla dictum tincidunt quis sit amet lorem. Fusce at est egestas, luctus neque eu, consectetur tortor. Phasellus eleifend ultricies nulla ac lobortis.  Morbi maximus quam cursus vehicula iaculis. Maecenas cursus vel justo ut rutrum. Curabitur magna orci, dignissim eget dapibus vitae, finibus id lacus. Praesent rhoncus mattis augue vitae bibendum. Praesent porta mauris non ultrices fermentum. Quisque vulputate ipsum in sodales pulvinar. Aliquam nec mollis felis. Donec vitae augue pulvinar, congue nisl sed, pretium purus. Fusce lobortis mi ac neque scelerisque semper. Pellentesque vel est vitae magna aliquet aliquet. Nam non dolor. Nulla facilisi. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi ac lacinia felis metus.";
-  const char *hc_src = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const char src[]    = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed luctus purus et risus vulputate, et mollis orci ullamcorper. Nulla facilisi. Fusce in ligula sed purus varius aliquet interdum vitae justo. Proin quis diam velit. Nulla varius iaculis auctor. Cras volutpat, justo eu dictum pulvinar, elit sem porttitor metus, et imperdiet metus sapien et ante. Nullam nisi nulla, ornare eu tristique eu, dignissim vitae diam. Nulla sagittis porta libero, a accumsan felis sagittis scelerisque.  Integer laoreet eleifend congue. Etiam rhoncus leo vel dolor fermentum, quis luctus nisl iaculis. Praesent a erat sapien. Aliquam semper mi in lorem ultrices ultricies. Lorem ipsum dolor sit amet, consectetur adipiscing elit. In feugiat risus sed enim ultrices, at sodales nulla tristique. Maecenas eget pellentesque justo, sed pellentesque lectus. Fusce sagittis sit amet elit vel varius. Donec sed ligula nec ligula vulputate rutrum sed ut lectus. Etiam congue pharetra leo vitae cursus. Morbi enim ante, porttitor ut varius vel, tincidunt quis justo. Nunc iaculis, risus id ultrices semper, metus est efficitur ligula, vel posuere risus nunc eget purus. Ut lorem turpis, condimentum at sem sed, porta aliquam turpis. In ut sapien a nulla dictum tincidunt quis sit amet lorem. Fusce at est egestas, luctus neque eu, consectetur tortor. Phasellus eleifend ultricies nulla ac lobortis.  Morbi maximus quam cursus vehicula iaculis. Maecenas cursus vel justo ut rutrum. Curabitur magna orci, dignissim eget dapibus vitae, finibus id lacus. Praesent rhoncus mattis augue vitae bibendum. Praesent porta mauris non ultrices fermentum. Quisque vulputate ipsum in sodales pulvinar. Aliquam nec mollis felis. Donec vitae augue pulvinar, congue nisl sed, pretium purus. Fusce lobortis mi ac neque scelerisque semper. Pellentesque vel est vitae magna aliquet aliquet. Nam non dolor. Nulla facilisi. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Morbi ac lacinia felis metus.";
+  const char hc_src[] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   // Set and derive sizes.  Since we're using strings, use strlen() + 1 for \0.
   const size_t src_size = strlen(src) + 1;
-  const size_t max_dst_size = LZ4_compressBound(src_size);
+  const size_t max_dst_size = (size_t)LZ4_compressBound((int)src_size);
   int bytes_returned = 0;
   // Now build allocations for the data we'll be playing with.
   char *dst               = (char*)calloc(1, max_dst_size);
@@ -264,11 +264,11 @@ int main(int argc, char **argv) {
     run_screaming("Couldn't allocate memory for the destination buffers.  Sad :(", 1);
 
   // Create known-good buffers to verify our tests with other functions will produce the same results.
-  bytes_returned = LZ4_compress_default(src, known_good_dst, src_size, max_dst_size);
+  bytes_returned = LZ4_compress_default(src, known_good_dst, (int)src_size, (int)max_dst_size);
   if (bytes_returned < 1)
     run_screaming("Couldn't create a known-good destination buffer for comparison... this is bad.", 1);
   const size_t src_comp_size = bytes_returned;
-  bytes_returned = LZ4_compress_default(hc_src, known_good_hc_dst, src_size, max_dst_size);
+  bytes_returned = LZ4_compress_default(hc_src, known_good_hc_dst, (int)src_size, (int)max_dst_size);
   if (bytes_returned < 1)
     run_screaming("Couldn't create a known-good (highly compressible) destination buffer for comparison... this is bad.", 1);
   const size_t hc_src_comp_size = bytes_returned;
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
   /* LZ4_compress_fast() */
   // Using this function is identical to LZ4_compress_default except we need to specify an "acceleration" value.  Defaults to 1.
   memset(dst, 0, max_dst_size);
-  bytes_returned = LZ4_compress_fast(src, dst, src_size, max_dst_size, 1);
+  bytes_returned = LZ4_compress_fast(src, dst, (int)src_size, (int)max_dst_size, 1);
   if (bytes_returned < 1)
     run_screaming("Failed to compress src using LZ4_compress_fast.  echo $? for return code.", bytes_returned);
   if (memcmp(dst, known_good_dst, bytes_returned) != 0)
@@ -290,7 +290,7 @@ int main(int argc, char **argv) {
   // Using this function directly requires that we build an LZ4_stream_t struct ourselves.  We do NOT have to reset it ourselves.
   memset(dst, 0, max_dst_size);
   LZ4_stream_t state;
-  bytes_returned = LZ4_compress_fast_extState(&state, src, dst, src_size, max_dst_size, 1);
+  bytes_returned = LZ4_compress_fast_extState(&state, src, dst, (int)src_size, (int)max_dst_size, 1);
   if (bytes_returned < 1)
     run_screaming("Failed to compress src using LZ4_compress_fast_extState.  echo $? for return code.", bytes_returned);
   if (memcmp(dst, known_good_dst, bytes_returned) != 0)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -47,13 +47,12 @@ BUILD_SHARED:=yes
 BUILD_STATIC:=yes
 
 CPPFLAGS+= -DXXH_NAMESPACE=LZ4_
-CPPFLAGS+= $(MOREFLAGS)
-CFLAGS  ?= -O3
+usercflags:= -O3 $(CFLAGS)
 DEBUGFLAGS:= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
              -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
              -Wundef -Wpointer-arith -Wstrict-aliasing=1
-CFLAGS  += $(DEBUGFLAGS)
-FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+CFLAGS   = $(DEBUGFLAGS) $(usercflags)
+ALLFLAGS = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 SRCFILES := $(sort $(wildcard *.c))
 
@@ -70,7 +69,7 @@ else
 	ifeq ($(WINBASED),yes)
 		SHARED_EXT = dll
 		SHARED_EXT_VER = $(SHARED_EXT)
-	else
+	else  # posix non-mac
 		SONAME_FLAGS = -Wl,-soname=liblz4.$(SHARED_EXT).$(LIBVER_MAJOR)
 		SHARED_EXT = so
 		SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR)
@@ -84,6 +83,7 @@ default: lib-release
 # silent mode by default; verbose can be triggered by V=1 or VERBOSE=1
 $(V)$(VERBOSE).SILENT:
 
+.PHONY:lib-release
 lib-release: DEBUGFLAGS :=
 lib-release: lib liblz4.pc
 
@@ -97,6 +97,7 @@ all: lib liblz4.pc
 all32: CFLAGS+=-m32
 all32: all
 
+CLEAN += liblz4.a
 liblz4.a: $(SRCFILES)
 ifeq ($(BUILD_STATIC),yes)  # can be disabled on command line
 	@echo compiling static library
@@ -105,6 +106,8 @@ ifeq ($(BUILD_STATIC),yes)  # can be disabled on command line
 endif
 
 ifeq ($(WINBASED),yes)
+
+CLEAN += $(liblz4-dll.rc)
 liblz4-dll.rc: liblz4-dll.rc.in
 	@echo creating library resource
 	$(SED) -e 's|@LIBLZ4@|$(LIBLZ4_NAME)|' \
@@ -116,28 +119,31 @@ liblz4-dll.rc: liblz4-dll.rc.in
 liblz4-dll.o: liblz4-dll.rc
 	$(WINDRES) -i liblz4-dll.rc -o liblz4-dll.o
 
+CLEAN += $(LIBLZ4_EXP)
 $(LIBLZ4): $(SRCFILES) liblz4-dll.o
-ifeq ($(BUILD_SHARED),yes)
+  ifeq ($(BUILD_SHARED),yes)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o $@ -Wl,--out-implib,$(LIBLZ4_EXP)
-endif
+	$(CC) $(ALLFLAGS) -DLZ4_DLL_EXPORT=1 -shared $^ -o $@ -Wl,--out-implib,$(LIBLZ4_EXP)
+  endif
 
 else   # not windows
 
 $(LIBLZ4): $(SRCFILES)
-ifeq ($(BUILD_SHARED),yes)
+  ifeq ($(BUILD_SHARED),yes)
 	@echo compiling dynamic library $(LIBVER)
-	$(CC) $(FLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
+	$(CC) $(ALLFLAGS) -shared $^ -fPIC -fvisibility=hidden $(SONAME_FLAGS) -o $@
 	@echo creating versioned links
 	$(LN_SF) $@ liblz4.$(SHARED_EXT_MAJOR)
 	$(LN_SF) $@ liblz4.$(SHARED_EXT)
-endif
+  endif
 
 endif
+CLEAN += $(LIBLZ4)
 
 .PHONY: liblz4
 liblz4: $(LIBLZ4)
 
+CLEAN += liblz4.pc
 liblz4.pc: liblz4.pc.in Makefile
 	@echo creating pkgconfig
 	$(SED) -e 's|@PREFIX@|$(prefix)|' \
@@ -152,8 +158,8 @@ clean:
 ifeq ($(WINBASED),yes)
 	$(RM) *.rc
 endif
-	$(RM) core *.o liblz4.pc $(LIBLZ4) $(LIBLZ4_EXP)
-	$(RM) *.a *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
+	$(RM) $(CLEAN) core *.o *.a
+	$(RM) *.$(SHARED_EXT) *.$(SHARED_EXT_MAJOR) *.$(SHARED_EXT_VER)
 	@echo Cleaning library completed
 
 #-----------------------------------------------------------------------------
@@ -187,6 +193,7 @@ PKGCONFIGDIR ?= $(libdir)/pkgconfig
   endif
 pkgconfigdir ?= $(PKGCONFIGDIR)
 
+.PHONY: install
 install: lib liblz4.pc
 	$(INSTALL_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
 	$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(pkgconfigdir)/
@@ -215,6 +222,7 @@ install: lib liblz4.pc
 	$(INSTALL_DATA) lz4frame.h $(DESTDIR)$(includedir)/lz4frame.h
 	@echo lz4 libraries installed
 
+.PHONY: uninstall
 uninstall:
 	$(RM) $(DESTDIR)$(pkgconfigdir)/liblz4.pc
   ifeq (WINBASED,yes)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -47,11 +47,11 @@ BUILD_SHARED:=yes
 BUILD_STATIC:=yes
 
 CPPFLAGS+= -DXXH_NAMESPACE=LZ4_
-usercflags:= -O3 $(CFLAGS)
+USERCFLAGS:= -O3 $(CFLAGS)
 DEBUGFLAGS:= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
              -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
              -Wundef -Wpointer-arith -Wstrict-aliasing=1
-CFLAGS   = $(DEBUGFLAGS) $(usercflags)
+CFLAGS   = $(DEBUGFLAGS) $(USERCFLAGS)
 ALLFLAGS = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 SRCFILES := $(sort $(wildcard *.c))

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -31,8 +31,8 @@
 SED ?= sed
 
 # Version numbers
-LZ4DIR   := ../lib
-LIBVER_SRC := $(LZ4DIR)/lz4.h
+LIBDIR   := ../lib
+LIBVER_SRC := $(LIBDIR)/lz4.h
 LIBVER_MAJOR_SCRIPT:=`$(SED) -n '/define[[:blank:]][[:blank:]]*LZ4_VERSION_MAJOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
 LIBVER_MINOR_SCRIPT:=`$(SED) -n '/define[[:blank:]][[:blank:]]*LZ4_VERSION_MINOR/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
 LIBVER_PATCH_SCRIPT:=`$(SED) -n '/define[[:blank:]][[:blank:]]*LZ4_VERSION_RELEASE/s/.*[[:blank:]]\([0-9][0-9]*\).*/\1/p' < $(LIBVER_SRC)`
@@ -42,7 +42,7 @@ LIBVER_MINOR := $(shell echo $(LIBVER_MINOR_SCRIPT))
 LIBVER_PATCH := $(shell echo $(LIBVER_PATCH_SCRIPT))
 LIBVER   := $(shell echo $(LIBVER_SCRIPT))
 
-LIBFILES  = $(wildcard $(LZ4DIR)/*.c)
+LIBFILES  = $(wildcard $(LIBDIR)/*.c)
 SRCFILES  = $(sort $(LIBFILES) $(wildcard *.c))
 OBJFILES  = $(SRCFILES:.c=.o)
 
@@ -51,7 +51,7 @@ DEBUGFLAGS= -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
             -Wpointer-arith -Wstrict-aliasing=1
 usercflags:= -O3 $(CFLAGS) # -O3 can be overruled by user-provided -Ox level
 CFLAGS    = $(DEBUGFLAGS) $(usercflags)
-CPPFLAGS += -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_
+CPPFLAGS += -I$(LIBDIR) -DXXH_NAMESPACE=LZ4_
 
 include ../Makefile.inc
 
@@ -107,8 +107,8 @@ lz4-release: lz4
 
 CLEAN += lz4-wlib
 lz4-wlib: LIBFILES =
-lz4-wlib: SRCFILES+= $(LZ4DIR)/xxhash.c  # benchmark unit needs XXH64()
-lz4-wlib: LDFLAGS += -L $(LZ4DIR)
+lz4-wlib: SRCFILES+= $(LIBDIR)/xxhash.c  # benchmark unit needs XXH64()
+lz4-wlib: LDFLAGS += -L $(LIBDIR)
 lz4-wlib: LDLIBS   = -llz4
 lz4-wlib: liblz4 $(OBJFILES)
 	@echo WARNING: $@ must link to an extended variant of the dynamic library which also exposes unstable symbols
@@ -116,7 +116,7 @@ lz4-wlib: liblz4 $(OBJFILES)
 
 .PHONY:liblz4
 liblz4:
-	CPPFLAGS="-DLZ4F_PUBLISH_STATIC_FUNCTIONS -DLZ4_PUBLISH_STATIC_FUNCTIONS" $(MAKE) -C $(LZ4DIR) liblz4
+	CPPFLAGS="-DLZ4F_PUBLISH_STATIC_FUNCTIONS -DLZ4_PUBLISH_STATIC_FUNCTIONS" $(MAKE) -C $(LIBDIR) liblz4
 
 CLEAN += lz4c
 lz4c: lz4
@@ -154,7 +154,7 @@ clean:
 ifeq ($(WINBASED),yes)
 	$(RM) *.rc
 endif
-	$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
+	$(MAKE) -C $(LIBDIR) $@ > $(VOID)
 	$(RM) $(CLEAN) *.o tmp* *.test core
 	@echo Cleaning completed
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -46,12 +46,12 @@ LIBFILES  = $(wildcard $(LZ4DIR)/*.c)
 SRCFILES  = $(sort $(LIBFILES) $(wildcard *.c))
 OBJFILES  = $(SRCFILES:.c=.o)
 
-CPPFLAGS += -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_
-CFLAGS   ?= -O3
 DEBUGFLAGS= -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
             -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
             -Wpointer-arith -Wstrict-aliasing=1
-CFLAGS   += $(DEBUGFLAGS) $(MOREFLAGS)
+usercflags:= -O3 $(CFLAGS) # -O3 can be overruled by user-provided -Ox level
+CFLAGS    = $(DEBUGFLAGS) $(usercflags)
+CPPFLAGS += -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_
 
 include ../Makefile.inc
 
@@ -67,13 +67,16 @@ MD2ROFF   = ronn
 MD2ROFF_FLAGS = --roff --warnings --manual="User Commands" --organization="lz4 $(LZ4_VERSION)"
 
 
+.PHONY:default
 default: lz4-release
 
 # silent mode by default; verbose can be triggered by V=1 or VERBOSE=1
 $(V)$(VERBOSE).SILENT:
 
-all: lz4 lz4c
+.PHONY:all
+all: lz4 lz4c unlz4 lz4cat
 
+.PHONY:all32
 all32: CFLAGS+=-m32
 all32: all
 
@@ -81,11 +84,11 @@ ifeq ($(WINBASED),yes)
 lz4-exe.rc: lz4-exe.rc.in
 	@echo creating executable resource
 	$(SED) -e 's|@PROGNAME@|lz4|' \
-         -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
-         -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
-         -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
-         -e 's|@EXT@|$(EXT)|g' \
-          $< >$@
+           -e 's|@LIBVER_MAJOR@|$(LIBVER_MAJOR)|g' \
+           -e 's|@LIBVER_MINOR@|$(LIBVER_MINOR)|g' \
+           -e 's|@LIBVER_PATCH@|$(LIBVER_PATCH)|g' \
+           -e 's|@EXT@|.exe|g' \
+           $< >$@
 
 lz4-exe.o: lz4-exe.rc
 	$(WINDRES) -i lz4-exe.rc -o lz4-exe.o
@@ -96,11 +99,13 @@ else
 lz4: $(OBJFILES)
 	$(CC) $(FLAGS) $(OBJFILES) -o $@$(EXT) $(LDLIBS)
 endif
+CLEAN += lz4
 
 .PHONY: lz4-release
 lz4-release: DEBUGFLAGS=
 lz4-release: lz4
 
+CLEAN += lz4-wlib
 lz4-wlib: LIBFILES =
 lz4-wlib: SRCFILES+= $(LZ4DIR)/xxhash.c  # benchmark unit needs XXH64()
 lz4-wlib: LDFLAGS += -L $(LZ4DIR)
@@ -113,32 +118,44 @@ lz4-wlib: liblz4 $(OBJFILES)
 liblz4:
 	CPPFLAGS="-DLZ4F_PUBLISH_STATIC_FUNCTIONS -DLZ4_PUBLISH_STATIC_FUNCTIONS" $(MAKE) -C $(LZ4DIR) liblz4
 
+CLEAN += lz4c
 lz4c: lz4
 	$(LN_SF) lz4$(EXT) lz4c$(EXT)
 
+CLEAN += lz4c32
 lz4c32: CFLAGS += -m32
 lz4c32 : $(SRCFILES)
 	$(CC) $(FLAGS) $^ -o $@$(EXT)
 
+CLEAN += unlz4
+unlz4: lz4
+	$(LN_SF) lz4$(EXT) unlz4$(EXT)
+
+CLEAN += lz4cat
+lz4cat: lz4
+	$(LN_SF) lz4$(EXT) lz4cat$(EXT)
+
 lz4.1: lz4.1.md $(LIBVER_SRC)
 	cat $< | $(MD2ROFF) $(MD2ROFF_FLAGS) | $(SED) -n '/^\.\\\".*/!p' > $@
 
+.PHONY:man
 man: lz4.1
 
+.PHONY:clean-man
 clean-man:
 	$(RM) lz4.1
 
+.PHONY:preview-man
 preview-man: clean-man man
 	man ./lz4.1
 
+.PHONY:clean
 clean:
 ifeq ($(WINBASED),yes)
 	$(RM) *.rc
 endif
 	$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
-	$(RM) core *.o *.test tmp* \
-           lz4$(EXT) lz4c$(EXT) lz4c32$(EXT) lz4-wlib$(EXT) \
-           unlz4$(EXT) lz4cat$(EXT)
+	$(RM) $(CLEAN) *.o tmp* *.test core
 	@echo Cleaning completed
 
 
@@ -146,12 +163,6 @@ endif
 # make install is validated only for Linux, OSX, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
 ifeq ($(POSIX_ENV),Yes)
-
-unlz4: lz4
-	$(LN_SF) lz4$(EXT) unlz4$(EXT)
-
-lz4cat: lz4
-	$(LN_SF) lz4$(EXT) lz4cat$(EXT)
 
 DESTDIR     ?=
 # directory variables : GNU conventions prefer lowercase
@@ -170,6 +181,7 @@ mandir      ?= $(MANDIR)
 MAN1DIR     ?= $(mandir)/man1
 man1dir     ?= $(MAN1DIR)
 
+.PHONY: install
 install: lz4
 	@echo Installing binaries in $(DESTDIR)$(bindir)
 	$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
@@ -184,6 +196,7 @@ install: lz4
 	$(LN_SF) lz4.1 $(DESTDIR)$(man1dir)/unlz4.1
 	@echo lz4 installation completed
 
+.PHONY: uninstall
 uninstall:
 	$(RM) $(DESTDIR)$(bindir)/lz4cat$(EXT)
 	$(RM) $(DESTDIR)$(bindir)/unlz4$(EXT)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -49,8 +49,8 @@ OBJFILES  = $(SRCFILES:.c=.o)
 DEBUGFLAGS= -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
             -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
             -Wpointer-arith -Wstrict-aliasing=1
-usercflags:= -O3 $(CFLAGS) # -O3 can be overruled by user-provided -Ox level
-CFLAGS    = $(DEBUGFLAGS) $(usercflags)
+USERCFLAGS:= -O3 $(CFLAGS) # -O3 can be overruled by user-provided -Ox level
+CFLAGS    = $(DEBUGFLAGS) $(USERCFLAGS)
 CPPFLAGS += -I$(LIBDIR) -DXXH_NAMESPACE=LZ4_
 
 include ../Makefile.inc

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,13 +35,13 @@ PYTHON  ?= python3
 
 DEBUGLEVEL?= 1
 DEBUGFLAGS = -g -DLZ4_DEBUG=$(DEBUGLEVEL)
-CFLAGS  ?= -O3 # can select custom optimization flags. Example : CFLAGS=-O2 make
-CFLAGS  += -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
-           -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
-           -Wpointer-arith -Wstrict-aliasing=1
-CFLAGS  += $(DEBUGFLAGS) $(MOREFLAGS)
-CPPFLAGS+= -I$(LZ4DIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
-FLAGS    = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+USERCFLAGS:= -O3 $(CFLAGS) # appended for higher priority
+WFLAGS    = -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
+            -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
+            -Wpointer-arith -Wstrict-aliasing=1
+CFLAGS    = $(WFLAGS) $(DEBUGFLAGS) $(USERCFLAGS)
+CPPFLAGS += -I$(LZ4DIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
+ALLFLAGS  = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 include ../Makefile.inc
 
@@ -56,81 +56,97 @@ NB_LOOPS     ?= -i1
 .PHONY: default
 default: all
 
+.PHONY: all
 all: fullbench fuzzer frametest roundTripTest datagen checkFrame decompress-partial
 
+.PHONY: all32
 all32: CFLAGS+=-m32
 all32: all
 
+.PHONY: $(LZ4)
+.PHONY: lz4
 lz4:
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="$(CFLAGS)"
 
+.PHONY: lib liblz4.pc
 lib liblz4.pc:
 	$(MAKE) -C $(LZ4DIR) $@ CFLAGS="$(CFLAGS)"
 
 lz4c unlz4 lz4cat: lz4
 	$(LN_SF) $(LZ4) $(PRGDIR)/$@
 
-lz4c32:   # create a 32-bits version for 32/64 interop tests
+.PHONY: lz4c32
+lz4c32:  # create a 32-bits version for 32/64 interop tests
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="-m32 $(CFLAGS)"
 
+# *.o objects are from library
 %.o : $(LZ4DIR)/%.c $(LZ4DIR)/%.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
+CLEAN += fullbench
 fullbench : DEBUGLEVEL=0
+fullbench : CPPFLAGS += -DNDEBUG
 fullbench : lz4.o lz4hc.o lz4frame.o xxhash.o fullbench.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+.PHONY: $(LZ4DIR)/liblz4.a
 $(LZ4DIR)/liblz4.a:
 	$(MAKE) -C $(LZ4DIR) liblz4.a
 
+CLEAN += fullbench-lib
+fullbench-lib : DEBUGLEVEL=0
+fullbench-lib : CPPFLAGS += -DNDEBUG
 fullbench-lib: fullbench.c $(LZ4DIR)/liblz4.a
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+# Note: Windows only
+ifeq ($(WINBASED),yes)
+CLEAN += fullbench-dll
+fullbench-dll : DEBUGLEVEL=0
+fullbench-dll : CPPFLAGS += -DNDEBUG
 fullbench-dll: fullbench.c $(LZ4DIR)/xxhash.c
 	$(MAKE) -C $(LZ4DIR) liblz4
-	$(CC) $(FLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
+endif
 
 # test LZ4_USER_MEMORY_FUNCTIONS
 fullbench-wmalloc: CPPFLAGS += -DLZ4_USER_MEMORY_FUNCTIONS
 fullbench-wmalloc: fullbench
 
+CLEAN += fuzzer
 fuzzer  : lz4.o lz4hc.o xxhash.o fuzzer.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+CLEAN += frametest
 frametest: lz4frame.o lz4.o lz4hc.o xxhash.o frametest.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+CLEAN += roundTripTest
 roundTripTest : lz4.o lz4hc.o xxhash.o roundTripTest.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+CLEAN += datagen
 datagen : $(PRGDIR)/datagen.c datagencli.c
-	$(CC) $(FLAGS) -I$(PRGDIR) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) -I$(PRGDIR) $^ -o $@$(EXT)
 
+CLEAN += checkFrame
 checkFrame : lz4frame.o lz4.o lz4hc.o xxhash.o checkFrame.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+CLEAN += decompress-partial
 decompress-partial: lz4.o decompress-partial.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
+CLEAN += decompress-partial-usingDict
 decompress-partial-usingDict: lz4.o decompress-partial-usingDict.c
-	$(CC) $(FLAGS) $^ -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
 .PHONY: clean
 clean:
 	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
-	@$(RM) -rf core *.o *.test tmp* \
-        fullbench-dll$(EXT) fullbench-lib$(EXT) \
-        fullbench$(EXT) fullbench32$(EXT) \
-        fuzzer$(EXT) fuzzer32$(EXT) \
-        frametest$(EXT) frametest32$(EXT) \
-        fasttest$(EXT) roundTripTest$(EXT) \
-        datagen$(EXT) checkTag$(EXT) \
-        frameTest$(EXT) decompress-partial$(EXT) \
-        abiTest$(EXT) freestanding$(EXT) \
-        checkFrame$(EXT) \
-        lz4_all.c
-	@$(RM) -rf $(TESTDIR)
+	@$(RM) $(CLEAN) core *.o *.test tmp*
+	@$(RM) -r $(TESTDIR)
 	@echo Cleaning completed
 
 .PHONY: versionsTest
@@ -141,68 +157,66 @@ versionsTest:
 listTest: lz4
 	QEMU_SYS=$(QEMU_SYS) $(PYTHON) test-lz4-list.py
 
+# Note: requires liblz4 installed
+CLEAN += abiTest
 abiTest: LDLIBS += -llz4
 
 .PHONY: abiTests
 abiTests:
 	$(PYTHON) test-lz4-abi.py
 
+CLEAN += checkTag
 checkTag: checkTag.c $(LZ4DIR)/lz4.h
-	$(CC) $(FLAGS) $< -o $@$(EXT)
+	$(CC) $(ALLFLAGS) $< -o $@$(EXT)
 
 #-----------------------------------------------------------------------------
 # validated only for Linux, OSX, BSD, Hurd and Solaris targets
 #-----------------------------------------------------------------------------
 ifeq ($(POSIX_ENV),Yes)
 
-MD5:=md5sum
-ifneq (,$(filter $(shell $(UNAME)), Darwin ))
-MD5:=md5 -r
-endif
-
-# note : we should probably settle on a single compare utility
-CMP:=cmp
-GREP:=grep
-DIFF:=diff
-ifneq (,$(filter $(shell $(UNAME)),SunOS))
-DIFF:=gdiff
-endif
-
-CAT:=cat
-DD:=dd
-DATAGEN:=./datagen
+MD5 ?= $(if $(filter Darwin,$(shell $(UNAME))),md5 -r,md5sum)
+CMP ?= cmp
+GREP?= grep
+DIFF?= $(if $(filter SunOS,$(shell $(UNAME))),gdiff,diff)
+CAT ?= cat
+DD  ?= dd
+DATAGEN?=./datagen
 PATH:=../programs:$(shell pwd):$(PATH)
 
 .PHONY: list
 list:
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+	$(GREP) '^[^#[:space:]].*:' Makefile | sed 's/:.*//' | sort | uniq
+
+ifneq ($(TARGETSEARCH),NO)
+ALL_TARGETS := $(shell make list TARGETSEARCH=NO)
+endif
+TEST_TARGETS := $(filter test%,$(ALL_TARGETS))
+.PHONY: $(TEST_TARGETS) # all targets starting by `test` are now .PHONY
+
+test_targets:
+	@echo TEST_TARGETS = $(TEST_TARGETS)
 
 .PHONY: check
 check: test-lz4-essentials
 
-.PHONY: test
 test: test-lz4 test-lz4c test-frametest test-fullbench test-fuzzer test-amalgamation listTest test-decompress-partial
 
-.PHONY: test32
 test32: CFLAGS+=-m32
 test32: test
 
-.PHONY: test-amalgamation
 test-amalgamation: lz4_all.o
 
+CLEAN += lz4_all.c
 lz4_all.c: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c
 	$(CAT) $^ > $@
 
-.PHONY: test-install
 test-install: lz4 lib liblz4.pc
 	lz4_root=.. ./test_install.sh
 
-.PHONY: test-compile-with-lz4-memory-usage
 test-compile-with-lz4-memory-usage:
 	$(MAKE) clean; CFLAGS=-O0 CPPFLAGS=-D'LZ4_MEMORY_USAGE=LZ4_MEMORY_USAGE_MIN' $(MAKE) all
 	$(MAKE) clean; CFLAGS=-O0 CPPFLAGS=-D'LZ4_MEMORY_USAGE=LZ4_MEMORY_USAGE_MAX' $(MAKE) all
 
-.PHONY: test-lz4-sparse
 # Rules regarding Temporary test files :
 # Each test must use its own unique set of names during execution.
 # Each temporary test file must begin by an FPREFIX.
@@ -355,17 +369,8 @@ test-decompress-partial : decompress-partial decompress-partial-usingDict
 #-----------------------------------------------------------------------------
 # freestanding test only for Linux x86_64
 #-----------------------------------------------------------------------------
-ifeq ($(OS),Windows_NT)
-  UNAME_S := Windows
-else
-  UNAME_S := $(shell uname -s)
-endif
-
-ifeq ($(OS),Windows_NT)
-  UNAME_P := Unknown
-else
-  UNAME_P := $(shell uname -p)
-endif
+UNAME_S ?= $(if $(filter Windows_NT,$(OS)),Windows,$(shell uname -s))
+UNAME_P ?= $(if $(filter Windows_NT,$(OS)),Unknown,$(shell uname -p))
 
 FREESTANDING_CFLAGS := -ffreestanding -nostdlib
 
@@ -377,6 +382,7 @@ ifneq ($(UNAME_P), x86_64)
   FREESTANDING_CFLAGS :=
 endif
 
+CLEAN += freestanding
 freestanding: freestanding.c
 	$(CC) $(FREESTANDING_CFLAGS) $^ -o $@$(EXT)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -63,7 +63,6 @@ all: fullbench fuzzer frametest roundTripTest datagen checkFrame decompress-part
 all32: CFLAGS+=-m32
 all32: all
 
-.PHONY: $(LZ4)
 .PHONY: lz4
 lz4:
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="$(CFLAGS)"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@
 # datagen : generates synthetic data samples for tests & benchmarks
 # ##########################################################################
 
-LZ4DIR  := ../lib
+LIBDIR  := ../lib
 PRGDIR  := ../programs
 TESTDIR := versionsTest
 PYTHON  ?= python3
@@ -40,7 +40,7 @@ WFLAGS    = -Wall -Wextra -Wundef -Wcast-qual -Wcast-align -Wshadow \
             -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes \
             -Wpointer-arith -Wstrict-aliasing=1
 CFLAGS    = $(WFLAGS) $(DEBUGFLAGS) $(USERCFLAGS)
-CPPFLAGS += -I$(LZ4DIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
+CPPFLAGS += -I$(LIBDIR) -I$(PRGDIR) -DXXH_NAMESPACE=LZ4_
 ALLFLAGS  = $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 include ../Makefile.inc
@@ -70,7 +70,7 @@ lz4:
 
 .PHONY: lib liblz4.pc
 lib liblz4.pc:
-	$(MAKE) -C $(LZ4DIR) $@ CFLAGS="$(CFLAGS)"
+	$(MAKE) -C $(LIBDIR) $@ CFLAGS="$(CFLAGS)"
 
 lz4c unlz4 lz4cat: lz4
 	$(LN_SF) $(LZ4) $(PRGDIR)/$@
@@ -80,7 +80,7 @@ lz4c32:  # create a 32-bits version for 32/64 interop tests
 	$(MAKE) -C $(PRGDIR) $@ CFLAGS="-m32 $(CFLAGS)"
 
 # *.o objects are from library
-%.o : $(LZ4DIR)/%.c $(LZ4DIR)/%.h
+%.o : $(LIBDIR)/%.c $(LIBDIR)/%.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 CLEAN += fullbench
@@ -89,14 +89,14 @@ fullbench : CPPFLAGS += -DNDEBUG
 fullbench : lz4.o lz4hc.o lz4frame.o xxhash.o fullbench.c
 	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
-.PHONY: $(LZ4DIR)/liblz4.a
-$(LZ4DIR)/liblz4.a:
-	$(MAKE) -C $(LZ4DIR) liblz4.a
+.PHONY: $(LIBDIR)/liblz4.a
+$(LIBDIR)/liblz4.a:
+	$(MAKE) -C $(LIBDIR) liblz4.a
 
 CLEAN += fullbench-lib
 fullbench-lib : DEBUGLEVEL=0
 fullbench-lib : CPPFLAGS += -DNDEBUG
-fullbench-lib: fullbench.c $(LZ4DIR)/liblz4.a
+fullbench-lib: fullbench.c $(LIBDIR)/liblz4.a
 	$(CC) $(ALLFLAGS) $^ -o $@$(EXT)
 
 # Note: Windows only
@@ -104,9 +104,9 @@ ifeq ($(WINBASED),yes)
 CLEAN += fullbench-dll
 fullbench-dll : DEBUGLEVEL=0
 fullbench-dll : CPPFLAGS += -DNDEBUG
-fullbench-dll: fullbench.c $(LZ4DIR)/xxhash.c
-	$(MAKE) -C $(LZ4DIR) liblz4
-	$(CC) $(ALLFLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LZ4DIR)/dll/$(LIBLZ4).dll
+fullbench-dll: fullbench.c $(LIBDIR)/xxhash.c
+	$(MAKE) -C $(LIBDIR) liblz4
+	$(CC) $(ALLFLAGS) $^ -o $@$(EXT) -DLZ4_DLL_IMPORT=1 $(LIBDIR)/dll/$(LIBLZ4).dll
 endif
 
 # test LZ4_USER_MEMORY_FUNCTIONS
@@ -143,7 +143,7 @@ decompress-partial-usingDict: lz4.o decompress-partial-usingDict.c
 
 .PHONY: clean
 clean:
-	@$(MAKE) -C $(LZ4DIR) $@ > $(VOID)
+	@$(MAKE) -C $(LIBDIR) $@ > $(VOID)
 	@$(MAKE) -C $(PRGDIR) $@ > $(VOID)
 	@$(RM) $(CLEAN) core *.o *.test tmp*
 	@$(RM) -r $(TESTDIR)
@@ -166,7 +166,7 @@ abiTests:
 	$(PYTHON) test-lz4-abi.py
 
 CLEAN += checkTag
-checkTag: checkTag.c $(LZ4DIR)/lz4.h
+checkTag: checkTag.c $(LIBDIR)/lz4.h
 	$(CC) $(ALLFLAGS) $< -o $@$(EXT)
 
 #-----------------------------------------------------------------------------
@@ -207,7 +207,7 @@ test32: test
 test-amalgamation: lz4_all.o
 
 CLEAN += lz4_all.c
-lz4_all.c: $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/lz4frame.c
+lz4_all.c: $(LIBDIR)/lz4.c $(LIBDIR)/lz4hc.c $(LIBDIR)/lz4frame.c
 	$(CAT) $^ > $@
 
 test-install: lz4 lib liblz4.pc

--- a/tests/test-lz4-abi.py
+++ b/tests/test-lz4-abi.py
@@ -11,6 +11,7 @@ import glob
 import subprocess
 import filecmp
 import os
+import platform
 import shutil
 import sys
 import hashlib
@@ -26,7 +27,7 @@ head = 'v999'
 def proc(cmd_args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
-    print("Executing command:", cmd_args)
+    print("Executing command {} in directory {}".format(cmd_args, os.getcwd()))
     if pipe:
         s = subprocess.Popen(cmd_args,
                              stdout=subprocess.PIPE,
@@ -64,6 +65,11 @@ def sha1_of_file(filepath):
         return hashlib.sha1(f.read()).hexdigest()
 
 if __name__ == '__main__':
+
+    # Note: the test doesn't work on macOS
+    if platform.system() == 'Darwin':  # Darwin is the system name for macOS
+        print('warning : this test is not validated for macos !')
+
     error_code = 0
     base_dir = os.getcwd() + '/..'           # /path/to/lz4
     tmp_dir = base_dir + '/' + tmp_dir_name  # /path/to/lz4/tests/versionsTest

--- a/tests/test-lz4-abi.py
+++ b/tests/test-lz4-abi.py
@@ -17,7 +17,7 @@ import hashlib
 
 repo_url = 'https://github.com/lz4/lz4.git'
 tmp_dir_name = 'tests/abiTests'
-env_flags = ' ' # '-j MOREFLAGS="-g -O0 -fsanitize=address"'
+env_flags = ' ' # '-j CFLAGS="-g -O0 -fsanitize=address"'
 make_cmd = 'make'
 git_cmd = 'git'
 test_dat_src = ['README.md']
@@ -43,7 +43,8 @@ def make(args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
         # we want the address sanitizer for abi tests
-        env["MOREFLAGS"] = "-fsanitize=address"
+        env["CFLAGS"] = "-fsanitize=address"
+        env["LDFLAGS"] = "-fsanitize=address"
     return proc([make_cmd] + ['-j'] + ['V=1'] + args, pipe, env)
 
 def git(args, pipe=True):
@@ -106,8 +107,8 @@ if __name__ == '__main__':
                 os.chdir(lib_dir)
             make(['clean'])
             build_env = os.environ.copy()
-            build_env["CFLAGS"] = march
-            build_env["MOREFLAGS"] = "-fsanitize=address"
+            build_env["CFLAGS"] = march + " -fsanitize=address"
+            build_env["LDFLAGS"] = "-fsanitize=address"
             make(['liblz4'], env=build_env)
 
         print(' ')
@@ -117,11 +118,11 @@ if __name__ == '__main__':
         os.chdir(test_dir)
         # Start with matching version : should be no problem
         build_env = os.environ.copy()
-        build_env["CFLAGS"] = march
+        build_env["CFLAGS"] = march + " -fsanitize=address"
         build_env["LDFLAGS"] = "-L../lib"
         build_env["LDLIBS"] = "-llz4"
         # we use asan to detect any out-of-bound read or write
-        build_env["MOREFLAGS"] = "-fsanitize=address"
+        build_env["LDFLAGS"] = "-fsanitize=address"
         if os.path.isfile('abiTest'):
             os.remove('abiTest')
         make(['abiTest'], env=build_env, pipe=False)
@@ -154,8 +155,8 @@ if __name__ == '__main__':
                 build_env["CPPFLAGS"] = '-I../lib'
                 build_env["LDFLAGS"] = '-L../lib'
             build_env["LDLIBS"] = "-llz4"
-            build_env["CFLAGS"] = march
-            build_env["MOREFLAGS"] = "-fsanitize=address"
+            build_env["CFLAGS"] = march + " -fsanitize=address"
+            build_env["LDFLAGS"] = "-fsanitize=address"
             os.remove('abiTest')
             make(['abiTest'], pipe=False, env=build_env)
 

--- a/tests/test-lz4-abi.py
+++ b/tests/test-lz4-abi.py
@@ -7,6 +7,7 @@
 # GPL v2 License
 #
 
+import argparse
 import glob
 import subprocess
 import filecmp
@@ -23,10 +24,18 @@ git_cmd = 'git'
 test_dat_src = ['README.md']
 head = 'v999'
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--verbose", action="store_true", help="increase output verbosity")
+args = parser.parse_args()
+
+def debug_message(msg):
+    if args.verbose:
+        print(msg)
+
 def proc(cmd_args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
-    print("Executing command {} with env {}".format(cmd_args, env))
+    debug_message("Executing command {} with env {}".format(cmd_args, env))
     if pipe:
         s = subprocess.Popen(cmd_args,
                              stdout=subprocess.PIPE,

--- a/tests/test-lz4-speed.py
+++ b/tests/test-lz4-speed.py
@@ -204,9 +204,9 @@ def test_commit(branch, commit, last_commit, args, testFilePaths, have_mutt, hav
     local_branch = branch.split('/')[1]
     version = local_branch.rpartition('-')[2] + '_' + commit
     if not args.dry_run:
-        execute('CFLAGS="-Werror -Wconversion -Wno-sign-conversion -DLZ4_GIT_COMMIT=%s" make -C programs clean lz4 CC=clang && ' % version +
+        execute('make clean; CFLAGS="-Werror -Wconversion -Wno-sign-conversion" CPPFLAGS="-DLZ4_GIT_COMMIT=%s" make -C programs lz4 CC=clang && ' % version +
                 'mv programs/lz4 programs/lz4_clang && ' +
-                'CPPFLAGS="-DLZ4_GIT_COMMIT=%s" make -C programs clean lz4 lz4c32 ' % version)
+                'make clean && CPPFLAGS="-DLZ4_GIT_COMMIT=%s" make -C programs lz4 lz4c32 ' % version)
     md5_lz4 = hashfile(hashlib.md5(), clone_path + '/programs/lz4')
     md5_lz4c32 = hashfile(hashlib.md5(), clone_path + '/programs/lz4c32')
     md5_lz4_clang = hashfile(hashlib.md5(), clone_path + '/programs/lz4_clang')

--- a/tests/test-lz4-speed.py
+++ b/tests/test-lz4-speed.py
@@ -204,9 +204,9 @@ def test_commit(branch, commit, last_commit, args, testFilePaths, have_mutt, hav
     local_branch = branch.split('/')[1]
     version = local_branch.rpartition('-')[2] + '_' + commit
     if not args.dry_run:
-        execute('make -C programs clean lz4 CC=clang MOREFLAGS="-Werror -Wconversion -Wno-sign-conversion -DLZ4_GIT_COMMIT=%s" && ' % version +
+        execute('make -C programs clean lz4 CC=clang CFLAGS="-O3 -Werror -Wconversion -Wno-sign-conversion -DLZ4_GIT_COMMIT=%s" && ' % version +
                 'mv programs/lz4 programs/lz4_clang && ' +
-                'make -C programs clean lz4 lz4c32 MOREFLAGS="-DLZ4_GIT_COMMIT=%s"' % version)
+                'make -C programs clean lz4 lz4c32 CPPFLAGS="-DLZ4_GIT_COMMIT=%s"' % version)
     md5_lz4 = hashfile(hashlib.md5(), clone_path + '/programs/lz4')
     md5_lz4c32 = hashfile(hashlib.md5(), clone_path + '/programs/lz4c32')
     md5_lz4_clang = hashfile(hashlib.md5(), clone_path + '/programs/lz4_clang')

--- a/tests/test-lz4-speed.py
+++ b/tests/test-lz4-speed.py
@@ -204,9 +204,9 @@ def test_commit(branch, commit, last_commit, args, testFilePaths, have_mutt, hav
     local_branch = branch.split('/')[1]
     version = local_branch.rpartition('-')[2] + '_' + commit
     if not args.dry_run:
-        execute('make -C programs clean lz4 CC=clang CFLAGS="-O3 -Werror -Wconversion -Wno-sign-conversion -DLZ4_GIT_COMMIT=%s" && ' % version +
+        execute('CFLAGS="-Werror -Wconversion -Wno-sign-conversion -DLZ4_GIT_COMMIT=%s" make -C programs clean lz4 CC=clang && ' % version +
                 'mv programs/lz4 programs/lz4_clang && ' +
-                'make -C programs clean lz4 lz4c32 CPPFLAGS="-DLZ4_GIT_COMMIT=%s"' % version)
+                'CPPFLAGS="-DLZ4_GIT_COMMIT=%s" make -C programs clean lz4 lz4c32 ' % version)
     md5_lz4 = hashfile(hashlib.md5(), clone_path + '/programs/lz4')
     md5_lz4c32 = hashfile(hashlib.md5(), clone_path + '/programs/lz4c32')
     md5_lz4_clang = hashfile(hashlib.md5(), clone_path + '/programs/lz4_clang')

--- a/tests/test-lz4-versions.py
+++ b/tests/test-lz4-versions.py
@@ -7,6 +7,7 @@
 # GPL v2 License
 #
 
+import argparse
 import glob
 import subprocess
 import filecmp
@@ -23,6 +24,14 @@ test_dat_src = 'README.md'
 test_dat = 'test_dat'
 head = 'v999'
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--verbose", action="store_true", help="increase output verbosity")
+args = parser.parse_args()
+
+def debug_message(msg):
+    if args.verbose:
+        print(msg)
+
 def env_or_empty(env, key):
     if key in env:
         return " " + env[key]
@@ -31,7 +40,7 @@ def env_or_empty(env, key):
 def proc(cmd_args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
-    print("Executing command {} with env {}".format(cmd_args, env))
+    debug_message("Executing command {} with env {}".format(cmd_args, env))
     if pipe:
         s = subprocess.Popen(cmd_args,
                              stdout=subprocess.PIPE,

--- a/tests/test-lz4-versions.py
+++ b/tests/test-lz4-versions.py
@@ -23,16 +23,23 @@ test_dat_src = 'README.md'
 test_dat = 'test_dat'
 head = 'v999'
 
-def proc(cmd_args, pipe=True, dummy=False):
-    if dummy:
-        return
+def proc(cmd_args, pipe=True, env=False):
+    if env == False:
+        env = os.environ.copy()
+    print("Executing command {} with env {}".format(cmd_args, env))
     if pipe:
-        subproc = subprocess.Popen(cmd_args,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+        s = subprocess.Popen(cmd_args,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             env = env)
     else:
-        subproc = subprocess.Popen(cmd_args)
-    return subproc.communicate()
+        s = subprocess.Popen(cmd_args, env = env)
+    stdout_data, stderr_data = s.communicate()
+    if s.poll() != 0:
+        print('Error Code:', s.poll())
+        print('Standard Error:', stderr_data.decode())
+        sys.exit(1)
+    return stdout_data, stderr_data
 
 def make(args, pipe=True):
     return proc([make_cmd] + args, pipe)

--- a/tests/test-lz4-versions.py
+++ b/tests/test-lz4-versions.py
@@ -23,6 +23,11 @@ test_dat_src = 'README.md'
 test_dat = 'test_dat'
 head = 'v999'
 
+def env_or_empty(env, key):
+    if key in env:
+        return " " + env[key]
+    return ""
+
 def proc(cmd_args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
@@ -41,8 +46,13 @@ def proc(cmd_args, pipe=True, env=False):
         sys.exit(1)
     return stdout_data, stderr_data
 
-def make(args, pipe=True):
-    return proc([make_cmd] + args, pipe)
+def make(args, pipe=True, env=False):
+    if env == False:
+        env = os.environ.copy()
+    # old versions of lz4 may require MOREFLAGS
+    env["CFLAGS"] = env_or_empty(env, 'CFLAGS') + " -O1"
+    env["MOREFLAGS"] = env_or_empty(env, 'MOREFLAGS') + env_or_empty(env, 'CFLAGS') + env_or_empty(env, 'CPPFLAGS') + env_or_empty(env, 'LDFLAGS')
+    return proc([make_cmd] + args, pipe, env)
 
 def git(args, pipe=True):
     return proc([git_cmd] + args, pipe)
@@ -81,6 +91,7 @@ if __name__ == '__main__':
 
     # Build all release lz4c and lz4c32
     for tag in tags:
+        print("processing tag " + tag)
         os.chdir(base_dir)
         dst_lz4c   = '{}/lz4c.{}'  .format(tmp_dir, tag) # /path/to/lz4/test/lz4test/lz4c.<TAG>
         dst_lz4c32 = '{}/lz4c32.{}'.format(tmp_dir, tag) # /path/to/lz4/test/lz4test/lz4c32.<TAG>

--- a/tests/test-lz4-versions.py
+++ b/tests/test-lz4-versions.py
@@ -58,8 +58,9 @@ def proc(cmd_args, pipe=True, env=False):
 def make(args, pipe=True, env=False):
     if env == False:
         env = os.environ.copy()
+    # favor compilation speed for faster total test time, actual runtime is very short
+    env["CFLAGS"] = env_or_empty(env, 'CFLAGS') + " -O0"
     # old versions of lz4 may require MOREFLAGS
-    env["CFLAGS"] = env_or_empty(env, 'CFLAGS') + " -O1"
     env["MOREFLAGS"] = env_or_empty(env, 'MOREFLAGS') + env_or_empty(env, 'CFLAGS') + env_or_empty(env, 'CPPFLAGS') + env_or_empty(env, 'LDFLAGS')
     return proc([make_cmd] + args, pipe, env)
 
@@ -113,9 +114,11 @@ if __name__ == '__main__':
                 os.chdir(r_dir + '/programs')  # /path/to/lz4/lz4test/<TAG>/programs
             else:
                 os.chdir(programs_dir)
-            make(['clean', 'lz4c'], False)
+            make(['clean'], False)
+            make(['lz4c'], False)
             shutil.copy2('lz4c',   dst_lz4c)
-            make(['clean', 'lz4c32'], False)
+            make(['clean'], False)
+            make(['lz4c32'], False)
             shutil.copy2('lz4c32', dst_lz4c32)
 
     # Compress test.dat by all released lz4c and lz4c32


### PR DESCRIPTION
Mostly centralized the `clean` logic through the use of `CLEAN` variable.
Also:
- Made user-provided `CFLAGS` higher priority, by appending them
- deprecated `MOREFLAGS`, which was used for this purpose
- settings `CFLAGS` does not longer erase `-O3`, which remains now the default optimization setting (though user can easily over-rule it by passing `-Ox` as part of the `CFLAGS` environment or make variable).