### PR TITLE
Faster Appveyor CI tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,24 @@
 version: 1.0.{build}
 environment:
   matrix:
+  - COMPILER: "visual"
+    CONFIGURATION: "Debug"
+    PLATFORM: "x64"
+  - COMPILER: "visual"
+    CONFIGURATION: "Debug"
+    PLATFORM: "Win32"
+  - COMPILER: "visual"
+    CONFIGURATION: "Release"
+    PLATFORM: "x64"
+  - COMPILER: "visual"
+    CONFIGURATION: "Release"
+    PLATFORM: "Win32"
   - COMPILER: "clang"
     PLATFORM: "mingw64"
   - COMPILER: "gcc"
     PLATFORM: "mingw64"
   - COMPILER: "gcc"
     PLATFORM: "mingw32"
-  - COMPILER: "visual"
-    CONFIGURATION: "Debug"
-    PLATFORM: "x64"
-  - COMPILER: "visual"
-    CONFIGURATION: "Debug"
-    PLATFORM: "Win32"
-  - COMPILER: "visual"
-    CONFIGURATION: "Release"
-    PLATFORM: "x64"
-  - COMPILER: "visual"
-    CONFIGURATION: "Release"
-    PLATFORM: "Win32"
 
 install:
   - ECHO Installing %COMPILER% %PLATFORM% %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,11 +88,11 @@ build_script:
       ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2012 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&
-      msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v110 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v110 /property:Optimize=false /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2013 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&
-      msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v120 /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      msbuild "build\VS2010\lz4.sln" /m /verbosity:minimal /property:PlatformToolset=v120 /property:Optimize=false /t:Clean,Build /p:Platform=%PLATFORM% /p:Configuration=%CONFIGURATION% /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       ECHO *** %TIME% &&
       ECHO *** Building Visual Studio 2015 %PLATFORM%\%CONFIGURATION% &&
       ECHO *** &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,7 +114,7 @@ test_script:
       lz4 -i1b10 lz4.exe &&
       lz4 -i1b15 lz4.exe &&
       echo ------- lz4 tested ------- &&
-      fullbench.exe -i1 fullbench.exe &&
+      fullbench.exe -i0 fullbench.exe &&
       echo Launching test program fuzzer.exe &&
       fuzzer.exe -v -T20s
     )

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -500,7 +500,7 @@ typedef struct {
     int singleChunk;
 } CompressionDesc;
 
-const CompressionDesc compDescArray[] = {
+static const CompressionDesc compDescArray[] = {
     { NULL, NULL, NULL, 0 },
     { "LZ4_compress_default", local_LZ4_compress_default_large, NULL, 0 },
     { "LZ4_compress_default(small dst)", local_LZ4_compress_default_small, NULL, 0 },
@@ -531,7 +531,7 @@ typedef struct {
     int frameFormat;
 } DecompressionDesc;
 
-const DecompressionDesc decDescArray[] = {
+static const DecompressionDesc decDescArray[] = {
     { NULL, NULL, 0, 0 },
     { "LZ4_decompress_fast", local_LZ4_decompress_fast, 1, 0 },
     { "LZ4_decompress_fast_usingDict(prefix)", local_LZ4_decompress_fast_usingDict_prefix, 1, 0 },

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -835,6 +835,23 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
     return 0;
 }
 
+static int list(void)
+{
+    size_t n;
+    DISPLAY("Compression Algorithm ids: \n");
+    for (n=0; n<NB_COMPRESSION_ALGORITHMS; n++) {
+        if (compDescArray[n].name) {
+            DISPLAY("%2u: %s \n", (unsigned)n, compDescArray[n].name);
+        }
+    }
+    DISPLAY("Decompression Algorithm ids: \n");
+    for (n=0; n<NB_DECOMPRESSION_ALGORITHMS; n++) {
+        if (decDescArray[n].name) {
+            DISPLAY("%2u: %s \n", (unsigned)n, decDescArray[n].name);
+        }
+    }
+    return 0;
+}
 
 static int usage(const char* exename)
 {
@@ -854,7 +871,7 @@ static int usage_advanced(void)
     DISPLAY( " -d#    : test only decompression function # [1-%i]\n", (int)NB_DECOMPRESSION_ALGORITHMS);
     DISPLAY( " -i#    : iteration loops [1-9](default : %i)\n", NBLOOPS);
     DISPLAY( " -B#    : Block size [4-7](default : 7)\n");
-    return 0;
+    return list();
 }
 
 static int badusage(const char* exename)
@@ -914,7 +931,8 @@ int main(int argc, const char** argv)
 
                     // Display help on usage
                 case 'h' :
-                case 'H': usage(exename); usage_advanced(); return 0;
+                case 'H': usage(exename); return usage_advanced();
+                case 'l': return list();
 
                     // Modify Block Properties
                 case 'B':

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -312,6 +312,11 @@ static int local_LZ4_decompress_fast_usingExtDict(const char* in, char* out, int
     return outSize;
 }
 
+static int local_LZ4_decompress_safe(const char* in, char* out, int inSize, int outSize)
+{
+    return LZ4_decompress_safe(in, out, inSize, outSize);
+}
+
 static int local_LZ4_decompress_safe_withPrefix64k(const char* in, char* out, int inSize, int outSize)
 {
     LZ4_decompress_safe_withPrefix64k(in, out, inSize, outSize);
@@ -536,7 +541,7 @@ static const DecompressionDesc decDescArray[] = {
     { "LZ4_decompress_fast", local_LZ4_decompress_fast, 1, 0 },
     { "LZ4_decompress_fast_usingDict(prefix)", local_LZ4_decompress_fast_usingDict_prefix, 1, 0 },
     { "LZ4_decompress_fast_using(Ext)Dict", local_LZ4_decompress_fast_usingExtDict, 1, 0 },
-    { "LZ4_decompress_safe", LZ4_decompress_safe, 1, 0 },
+    { "LZ4_decompress_safe", local_LZ4_decompress_safe, 1, 0 },
     { "LZ4_decompress_safe_withPrefix64k", local_LZ4_decompress_safe_withPrefix64k, 1, 0 },
     { "LZ4_decompress_safe_usingDict", local_LZ4_decompress_safe_usingDict, 1, 0 },
     { "LZ4_decompress_safe_partial", local_LZ4_decompress_safe_partial, 0, 0 },

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -58,7 +58,7 @@
 #define WELCOME_MESSAGE "*** %s v%s %i-bits, by %s ***\n", PROGRAM_DESCRIPTION, LZ4_VERSION_STRING, (int)(sizeof(void*)*8), AUTHOR
 
 #define NBLOOPS    6
-#define TIMELOOP   (CLOCKS_PER_SEC * 25 / 10)
+#define TIMELOOP   (CLOCKS_PER_SEC * 19 / 10)
 
 #define KB *(1 <<10)
 #define MB *(1 <<20)
@@ -558,6 +558,12 @@ const DecompressionDesc decDescArray[] = {
 int fullSpeedBench(const char** fileNamesTable, int nbFiles)
 {
     int fileIdx=0;
+    clock_t loopDuration = TIMELOOP;
+
+    if (g_nbIterations==0) {
+        loopDuration = CLOCKS_PER_SEC / 50 + 1;
+        g_nbIterations = 1;
+    }
 
     /* Init */
     { size_t const errorCode = LZ4F_createDecompressionContext(&g_dCtx, LZ4F_VERSION);
@@ -697,7 +703,7 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
                 clockTime = clock();
                 while(clock() == clockTime);
                 clockTime = clock();
-                while(BMK_GetClockSpan(clockTime) < TIMELOOP) {
+                while(BMK_GetClockSpan(clockTime) < loopDuration) {
                     if (initFunction!=NULL) initFunction();
                     for (chunkNb=0; chunkNb<nbChunks; chunkNb++) {
                         chunkP[chunkNb].compressedSize = compressionFunction(chunkP[chunkNb].origBuffer, chunkP[chunkNb].compressedBuffer, chunkP[chunkNb].origSize);
@@ -794,7 +800,7 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
                 clockTime = clock();
                 while(clock() == clockTime);
                 clockTime = clock();
-                while(BMK_GetClockSpan(clockTime) < TIMELOOP) {
+                while(BMK_GetClockSpan(clockTime) < loopDuration) {
                     for (chunkNb=0; chunkNb<nbChunks; chunkNb++) {
                         int const decodedSize = decompressionFunction(chunkP[chunkNb].compressedBuffer, chunkP[chunkNb].origBuffer,
                                                                       chunkP[chunkNb].compressedSize, chunkP[chunkNb].origSize);

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -183,7 +183,7 @@ static void* g_chunk0 = NULL;
 static size_t g_chunk0Size = 0;
 static void local_LZ4_saveDict_init(void)
 {
-    LZ4_loadDict(&LZ4_stream, g_chunk0, (int)g_chunk0Size);
+    LZ4_loadDict(&LZ4_stream, (const char*)g_chunk0, (int)g_chunk0Size);
 }
 
 static int local_LZ4_saveDict(const char* in, char* out, int inSize)
@@ -265,7 +265,7 @@ static void local_LZ4_resetStreamHC(void)
 
 static void local_LZ4_saveDictHC_init(void)
 {
-    LZ4_loadDictHC(&LZ4_streamHC, g_chunk0, (int)g_chunk0Size);
+    LZ4_loadDictHC(&LZ4_streamHC, (const char*)g_chunk0, (int)g_chunk0Size);
 }
 
 static int local_LZ4_saveDictHC(const char* in, char* out, int inSize)

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -481,7 +481,19 @@ static int local_LZ4F_decompress_noHint(const char* src, char* dst, int srcSize,
 
 }
 
+#if 0
+#endif
+
 #define NB_COMPRESSION_ALGORITHMS 100
+
+typedef struct {
+    const char* name;
+    int (*compressionF)(const char*, char*, int);
+    void (*initFunction)(void);
+} CompressionDesc;
+
+const CompressionDesc compDescArray[] = { };
+
 
 typedef struct {
     const char* name;

--- a/tests/fullbench.c
+++ b/tests/fullbench.c
@@ -678,7 +678,7 @@ int fullSpeedBench(const char** fileNamesTable, int nbFiles)
                 DISPLAY("Compression functions : \n");
                 continue;
             }
-            if (cAlgNb > (int)NB_COMPRESSION_ALGORITHMS) {
+            if (cAlgNb >= (int)NB_COMPRESSION_ALGORITHMS) {
                 continue;
             }
             compressorName = compDescArray[cAlgNb].name;


### PR DESCRIPTION
CI tests are frequently waiting on Appveyor,
which is the longest CI, by virtue of being single-threaded.

This patch reduces average test time from ~28mn to ~20mn on Appveyor CI.
This is achieved notably by introducing `fullbench -i0`,
which produces a quick & dirty benchmark analysis,
which is many seconds faster than `-i1`.
The savings compound, as this test is run many times.