### PR TITLE
fix 1308

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -243,14 +243,6 @@ LZ4LIB_API int LZ4_compress_fast (const char* src, char* dst, int srcSize, int d
 LZ4LIB_API int LZ4_sizeofState(void);
 LZ4LIB_API int LZ4_compress_fast_extState (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
 
-/*! LZ4_compress_fast_extState_destSize() :
- *  Same as LZ4_compress_fast(), but compresses as much data as possible from 'src' buffer into
- *  already allocated buffer 'dst', of size >= 'dstCapacity'. This function either compresses the
- *  entire 'src' content into 'dst' if it's large enough, or fills 'dst' buffer completely with as
- *  much data as possible from 'src'.
- */
-LZ4LIB_API int LZ4_compress_fast_extState_destSize(void* state, const char* src, char* dst, int *srcSizePtr, int dstCapacity, int acceleration);
-
 /*! LZ4_compress_destSize() :
  *  Reverse the logic : compresses as much data as possible from 'src' buffer
  *  into already allocated buffer 'dst', of size >= 'targetDestSize'.
@@ -274,7 +266,7 @@ LZ4LIB_API int LZ4_compress_fast_extState_destSize(void* state, const char* src,
  *        a dstCapacity which is > decompressedSize, by at least 1 byte.
  *        See https://github.com/lz4/lz4/issues/859 for details
  */
-LZ4LIB_API int LZ4_compress_destSize (const char* src, char* dst, int* srcSizePtr, int targetDstSize);
+LZ4LIB_API int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize);
 
 
 /*! LZ4_decompress_safe_partial() :
@@ -570,6 +562,12 @@ LZ4_decompress_safe_partial_usingDict(const char* src, char* dst,
  *  while LZ4_compress_fast_extState() starts with a call to LZ4_resetStream().
  */
 LZ4LIB_STATIC_API int LZ4_compress_fast_extState_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration);
+
+/*! LZ4_compress_destSize_extState() :
+ *  Same as LZ4_compress_destSize(), but using an externally allocated state.
+ *  Also: exposes @acceleration
+ */
+int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration);
 
 /*! LZ4_attach_dictionary() :
  *  This is an experimental API that allows

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -478,10 +478,23 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         /* Test compression using external state */
         FUZ_DISPLAYTEST("test LZ4_compress_fast_extState()");
         {   int const r = LZ4_compress_fast_extState(stateLZ4, block, compressedBuffer, blockSize, (int)compressedBufferSize, 8);
-            FUZ_CHECKTEST(r==0, "LZ4_compress_fast_extState() failed"); }
+            FUZ_CHECKTEST(r==0, "LZ4_compress_fast_extState() failed");
+
+            FUZ_DISPLAYTEST("test LZ4_compress_fast_extState() with a too small destination buffer (must fail)");
+            {   int const r2 = LZ4_compress_fast_extState(stateLZ4, block, compressedBuffer, blockSize, r-1, 8);
+                FUZ_CHECKTEST(r2!=0, "LZ4_compress_fast_extState() should have failed");
+            }
+
+            FUZ_DISPLAYTEST("test LZ4_compress_destSize_extState() with a too small destination buffer (must succeed, by compressing less than full input)");
+            {   int inputSize = blockSize;
+                int const r3 = LZ4_compress_destSize_extState(stateLZ4, block, compressedBuffer, &inputSize, r-1, 8);
+                FUZ_CHECKTEST(r3==0, "LZ4_compress_destSize_extState() failed");
+                FUZ_CHECKTEST(inputSize>=blockSize, "LZ4_compress_destSize_extState() should consume less than full input");
+            }
+        }
 
         /* Test compression using fast reset external state*/
-        FUZ_DISPLAYTEST();
+        FUZ_DISPLAYTEST("test LZ4_compress_fast_extState_fastReset()");
         {   int const r = LZ4_compress_fast_extState_fastReset(stateLZ4, block, compressedBuffer, blockSize, (int)compressedBufferSize, 8);
             FUZ_CHECKTEST(r==0, "LZ4_compress_fast_extState_fastReset() failed"); }
 


### PR DESCRIPTION
PR #1308 introduces a new symbol, `LZ4_compress_fast_extState_destSize()`, which, upon inspection, doesn't seem to work as advertised. In particular, it fails if `dstCapacity` is not large enough, as opposed to adjusting input size to fit within `dstCapacity`.

Even if it had worked, it would have resulted in problems for the existing `LZ4_compress_fast_extState()`,
that would have stopped failing when `dstCapacity` is not large enough, resulting in silent input truncation.

Changed the approach.
It appears the wanted functionality already exists within `lz4` source code, and is called `LZ4_compress_destSize_extState()`.
It wasn't exposed, presumably due to some (non-verified) problem regarding lz4 state on exit: it's claimed that since the `_destSize` doesn't completely consume the input, the state may end up in an "unfinished" status, making it dangerous to re-employ in later invocations.

Fixed that by enforcing a state initialization at the end of operation.

Also : added some tests,
ensure that `LZ4_compress_fast_extState()` fails as expected when `dstCapacity` is not large enough, and ensure that `LZ4_compress_destSize_extState()` does succeed in the same circumstance, by consuming less input.

Finally, expose `LZ4_compress_destSize_extState()` as a new experimental symbol.