### PR TITLE
change INSTALL_DIR into MAKE_DIR

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -110,4 +110,4 @@ endif
 
 INSTALL_PROGRAM ?= $(INSTALL) -m 755
 INSTALL_DATA    ?= $(INSTALL) -m 644
-INSTALL_DIR     ?= $(INSTALL) -d -m 755
+MAKE_DIR        ?= $(INSTALL) -d -m 755

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -195,7 +195,7 @@ pkgconfigdir ?= $(PKGCONFIGDIR)
 
 .PHONY: install
 install: lib liblz4.pc
-	$(INSTALL_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
+	$(MAKE_DIR) $(DESTDIR)$(pkgconfigdir)/ $(DESTDIR)$(includedir)/ $(DESTDIR)$(libdir)/ $(DESTDIR)$(bindir)/
 	$(INSTALL_DATA) liblz4.pc $(DESTDIR)$(pkgconfigdir)/
 	@echo Installing libraries in $(DESTDIR)$(libdir)
   ifeq ($(BUILD_STATIC),yes)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -203,7 +203,7 @@ man1dir     ?= $(MAN1DIR)
 .PHONY: install
 install: lz4
 	@echo Installing binaries in $(DESTDIR)$(bindir)
-	$(INSTALL_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
+	$(MAKE_DIR) $(DESTDIR)$(bindir)/ $(DESTDIR)$(man1dir)/
 	$(INSTALL_PROGRAM) lz4$(EXT) $(DESTDIR)$(bindir)/lz4$(EXT)
 	$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4c$(EXT)
 	$(LN_SF) lz4$(EXT) $(DESTDIR)$(bindir)/lz4cat$(EXT)


### PR DESCRIPTION
`INSTALL_DIR` is apparently used by `cmake` so it may conflict in some combination of circumstances:
https://cmake.org/cmake/help/latest/module/ExternalProject.html


