### PR TITLE
Fix seed 571 test

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1619,20 +1619,20 @@ int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
 
     while (p <= dictEnd-HASH_UNIT) {
         U32 const h = LZ4_hashPosition(p, tableType);
-        // Note: overwriting => favors positions end of dictionary
+        /* Note: overwriting => favors positions end of dictionary */
         LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
         p+=3; idx32+=3;
     }
 
     if (_ld == _ld_slow) {
-        // Fill hash table with additional references, to improve compression capability
+        /* Fill hash table with additional references, to improve compression capability */
         p = dict->dictionary;
         idx32 = dict->currentOffset - dict->dictSize;
         while (p <= dictEnd-HASH_UNIT) {
             U32 const h = LZ4_hashPosition(p, tableType);
             U32 const limit = dict->currentOffset - 64 KB;
             if (LZ4_getIndexOnHash(h, dict->hashTable, tableType) <= limit) {
-                // Note: not overwriting => favors positions beginning of dictionary
+                /* Note: not overwriting => favors positions beginning of dictionary */
                 LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
             }
             p++; idx32++;

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -148,6 +148,7 @@ LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; 
 **************************************/
 /*!
  * LZ4_MEMORY_USAGE :
+ * Can be selected at compile time, by setting LZ4_MEMORY_USAGE.
  * Memory usage formula : N->2^N Bytes (examples : 10 -> 1KB; 12 -> 4KB ; 16 -> 64KB; 20 -> 1MB)
  * Increasing memory usage improves compression ratio, generally at the cost of speed.
  * Reduced memory usage may improve speed at the cost of ratio, thanks to better cache locality.
@@ -157,6 +158,7 @@ LZ4LIB_API const char* LZ4_versionString (void);   /**< library version string; 
 # define LZ4_MEMORY_USAGE LZ4_MEMORY_USAGE_DEFAULT
 #endif
 
+/* These are absolute limits, they should not be changed by users */
 #define LZ4_MEMORY_USAGE_MIN 10
 #define LZ4_MEMORY_USAGE_DEFAULT 14
 #define LZ4_MEMORY_USAGE_MAX 20
@@ -367,6 +369,15 @@ LZ4LIB_API void LZ4_resetStream_fast (LZ4_stream_t* streamPtr);
  * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
  */
 LZ4LIB_API int LZ4_loadDict (LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
+
+/*! LZ4_loadDictSlow() : v1.9.5+
+ *  Same as LZ4_loadDict(),
+ *  but uses a bit more cpu to reference the dictionary content more thoroughly.
+ *  This is expected to slightly improve compression ratio.
+ *  The extra-cpu cost is likely worth it if the dictionary is re-used across multiple sessions.
+ * @return : loaded dictionary size, in bytes (note: only the last 64 KB are loaded)
+ */
+LZ4LIB_API int LZ4_loadDictSlow(LZ4_stream_t* streamPtr, const char* dictionary, int dictSize);
 
 /*! LZ4_compress_fast_continue() :
  *  Compress 'src' content using data from previously compressed blocks, for better compression ratio.

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -552,7 +552,7 @@ LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t di
         LZ4_initStream(cdict->fastCtx, sizeof(LZ4_stream_t));
     cdict->HCCtx = (LZ4_streamHC_t*)LZ4F_malloc(sizeof(LZ4_streamHC_t), cmem);
     if (cdict->HCCtx)
-        LZ4_initStream(cdict->HCCtx, sizeof(LZ4_streamHC_t));
+        LZ4_initStreamHC(cdict->HCCtx, sizeof(LZ4_streamHC_t));
     if (!cdict->dictContent || !cdict->fastCtx || !cdict->HCCtx) {
         LZ4F_freeCDict(cdict);
         return NULL;

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -436,7 +436,7 @@ size_t LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
     BYTE* dstPtr = dstStart;
     BYTE* const dstEnd = dstStart + dstCapacity;
 
-    DEBUGLOG(4, "LZ4F_compressFrame_usingCDict (srcSize=%u)", srcSize);
+    DEBUGLOG(4, "LZ4F_compressFrame_usingCDict (srcSize=%u)", (unsigned)srcSize);
     if (preferencesPtr!=NULL)
         prefs = *preferencesPtr;
     else
@@ -558,7 +558,7 @@ LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t di
         return NULL;
     }
     memcpy(cdict->dictContent, dictStart, dictSize);
-    LZ4_loadDict (cdict->fastCtx, (const char*)cdict->dictContent, (int)dictSize);
+    LZ4_loadDictSlow(cdict->fastCtx, (const char*)cdict->dictContent, (int)dictSize);
     LZ4_setCompressionLevel(cdict->HCCtx, LZ4HC_CLEVEL_DEFAULT);
     LZ4_loadDictHC(cdict->HCCtx, (const char*)cdict->dictContent, (int)dictSize);
     return cdict;

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -172,7 +172,7 @@ unsigned int FUZ_rand(unsigned int* src)
 }
 
 #define RAND_BITS(N) (FUZ_rand(randState) & ((1 << (N))-1))
-#define FUZ_LITERAL (RAND_BITS(6) + 'A')
+#define FUZ_LITERAL (RAND_BITS(6) + '0')
 #define FUZ_ABOUT(_R) ((FUZ_rand(randState) % (_R)) + (FUZ_rand(randState) % (_R)) + 1)
 static void FUZ_fillCompressibleNoiseBuffer(void* buffer, size_t bufferSize, double proba, U32* randState)
 {


### PR DESCRIPTION
This test has been failing due to expectation of guaranteed efficiency when doing dictionary compression.

This PR improves `lz4frame` dictionary compression efficiency in fast mode,
by introducing and using a new dictionary loader variant `LZ4_loadDictSlow()`
which uses more cpu to fill the reference table, leading to better referencing, leading to more match opportunities.

Also: fix init for `lz4frame` dictionary compression in HC mode.