### PR TITLE
LZ4 Level 2

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -440,6 +440,7 @@ static int LZ4HC_compress_2hashes (
                     /* note: we only search within prefix */
                     matchLength = LZ4_count(ip, matchPtr, matchlimit);
                     if (matchLength >= MINMATCH) {
+                        DEBUGLOG(7, "found candidate match at pos %u (len=%u)", pos8, matchLength);
                         matchDistance = ipIndex - pos8;
                         goto _lz4mid_encode_sequence;
                 }   }
@@ -487,6 +488,7 @@ static int LZ4HC_compress_2hashes (
                     ctx->dictCtx, gDictEndIndex,
                     0, 2);
             if (dMatch.len >= MINMATCH) {
+                DEBUGLOG(7, "found Dictionary match (offset=%i)", dMatch.off);
                 ip += dMatch.back;
                 assert(ip >= anchor);
                 matchLength = (unsigned)dMatch.len;
@@ -500,8 +502,8 @@ static int LZ4HC_compress_2hashes (
 
 _lz4mid_encode_sequence:
         /* catch back */
-        while (((ip > anchor) & (ipIndex - prefixIdx > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
-            ip--; matchLength++;
+        while (((ip > anchor) & ((U32)(ip-prefixPtr) > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
+            ip--;  matchLength++;
         };
 
         /* fill table with beginning of match */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -583,7 +583,7 @@ _lz4mid_dest_overflow:
             /* ll validated; now adjust match length */
             size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
             size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
-            assert(maxMlSize < INT_MAX); assert(matchLength >= 0);
+            assert(maxMlSize < INT_MAX);
             if ((size_t)matchLength > maxMlSize) matchLength= (unsigned)maxMlSize;
             if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + matchLength >= MFLIMIT) {
             DEBUGLOG(6, "Let's encode a last sequence (ll=%u, ml=%u)", (unsigned)ll, matchLength);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -399,6 +399,7 @@ static int LZ4HC_compress_2hashes (
                         const BYTE* const m2Ptr = prefixPtr + (pos8 - prefixIdx);
                         unsigned ml2 = LZ4_count(ip+1, m2Ptr, matchlimit);
                         if (ml2 > matchLength) {
+                            LZ4MID_addPosition(hash8Table, h8, ipIndex+1);
                             ip++;
                             matchLength = ml2;
                             matchDistance = m2Distance;
@@ -417,8 +418,12 @@ _lz4mid_encode_sequence:
         };
 
         /* fill table with beginning of match */
-        {   U32 h8_p1 = LZ4MID_hash8Ptr(ip+1); /* ip has been updated */
+        {   U32 h8_p1 = LZ4MID_hash8Ptr(ip+1);
+            U32 h8_p2 = LZ4MID_hash8Ptr(ip+2);
+            U32 h4_p1 = LZ4MID_hash4Ptr(ip+1);
             LZ4MID_addPosition(hash8Table, h8_p1, ipIndex+1);
+            LZ4MID_addPosition(hash8Table, h8_p2, ipIndex+2);
+            LZ4MID_addPosition(hash4Table, h4_p1, ipIndex+1);
         }
 
         /* encode - note this actions updates @ip, @op and @anchor */
@@ -433,8 +438,10 @@ _lz4mid_encode_sequence:
             if (pos_m2 < ilimitIdx) {
                 U32 pos_m1 = endMatchIdx - 1;
                 U32 h8_m2 = LZ4MID_hash8Ptr(ip-2);
+                U32 h4_m2 = LZ4MID_hash4Ptr(ip-2);
                 U32 h4_m1 = LZ4MID_hash4Ptr(ip-1);
                 LZ4MID_addPosition(hash8Table, h8_m2, pos_m2);
+                LZ4MID_addPosition(hash4Table, h4_m2, pos_m2);
                 LZ4MID_addPosition(hash4Table, h4_m1, pos_m1);
             }
         }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -563,7 +563,6 @@ _lz4mid_last_literals:
         } else {
             *op++ = (BYTE)(lastRunSize << ML_BITS);
         }
-        assert(op < oend);
         assert(lastRunSize <= (size_t)(oend - op));
         LZ4_memcpy(op, anchor, lastRunSize);
         op += lastRunSize;

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -433,18 +433,18 @@ static int LZ4HC_compress_2hashes (
             assert(h8 < LZ4MID_HASHTABLESIZE);
             assert(h8 < ipIndex);
             LZ4MID_addPosition(hash8Table, h8, ipIndex);
-            if (ipIndex - pos8 <= LZ4_DISTANCE_MAX) {
+            if ( ipIndex - pos8 <= LZ4_DISTANCE_MAX
+              && pos8 >= prefixIdx  /* note: currently only search within prefix */
+              ) {
                 /* match candidate found */
                 const BYTE* matchPtr = prefixPtr + pos8 - prefixIdx;
                 assert(matchPtr < ip);
-                if (matchPtr >= prefixPtr) {
-                    /* note: currently only search within prefix */
-                    matchLength = LZ4_count(ip, matchPtr, matchlimit);
-                    if (matchLength >= MINMATCH) {
-                        DEBUGLOG(7, "found candidate match at pos %u (len=%u)", pos8, matchLength);
-                        matchDistance = ipIndex - pos8;
-                        goto _lz4mid_encode_sequence;
-                }   }
+                matchLength = LZ4_count(ip, matchPtr, matchlimit);
+                if (matchLength >= MINMATCH) {
+                    DEBUGLOG(7, "found candidate match at pos %u (len=%u)", pos8, matchLength);
+                    matchDistance = ipIndex - pos8;
+                    goto _lz4mid_encode_sequence;
+                }
         }   }
         /* search short match */
         {   U32 h4 = LZ4MID_hash4Ptr(ip);

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -111,12 +111,25 @@ static U64 LZ4_read64(const void* memPtr)
 #define LZ4MID_HASHLOG (LZ4HC_HASH_LOG-1)
 #define LZ4MID_HASHTABLESIZE (1 << LZ4MID_HASHLOG)
 
-//static U32 LZ4MID_hash8(U64 v) { return (U32)((v * 0xCF1BBCDCB7A56463ULL) >> (64-LZ4MID_HASHLOG)); }
-static U32 LZ4MID_hash8(U64 v) { return (U32)(((v  << (64-56)) * 58295818150454627ULL) >> (64-LZ4MID_HASHLOG)) ; }
-
-static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash8(LZ4_read64(ptr)); }
 static U32 LZ4MID_hash4(U32 v) { return (v * 2654435761U) >> (32-LZ4MID_HASHLOG); }
 static U32 LZ4MID_hash4Ptr(const void* ptr) { return LZ4MID_hash4(LZ4_read32(ptr)); }
+/* note: hash7 hashes the lower 56-bits.
+ * It presumes input was read using little endian.*/
+static U32 LZ4MID_hash7(U64 v) { return (U32)(((v  << (64-56)) * 58295818150454627ULL) >> (64-LZ4MID_HASHLOG)) ; }
+static U64 LZ4_readLE64(const void* memPtr);
+static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash7(LZ4_readLE64(ptr)); }
+
+static U64 LZ4_readLE64(const void* memPtr)
+{
+    if (LZ4_isLittleEndian()) {
+        return LZ4_read64(memPtr);
+    } else {
+        const BYTE* p = (const BYTE*)memPtr;
+        /* note: relies on the compiler to simplify this expression */
+        return (U64)p[0] + ((U64)p[1]<<8) + ((U64)p[2]<<16) + ((U64)p[3]<<24)
+            + ((U64)p[4]<<32) + ((U64)p[5]<<40) + ((U64)p[6]<<48) + ((U64)p[7]<<56);
+    }
+}
 
 
 /*===   Count match length   ===*/

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -110,7 +110,10 @@ static U64 LZ4_read64(const void* memPtr)
 #define LZ4MID_HASHSIZE 8
 #define LZ4MID_HASHLOG (LZ4HC_HASH_LOG-1)
 #define LZ4MID_HASHTABLESIZE (1 << LZ4MID_HASHLOG)
-static U32 LZ4MID_hash8(U64 v) { return (U32)((v * 0xCF1BBCDCB7A56463ULL) >> (64-LZ4MID_HASHLOG)); }
+
+//static U32 LZ4MID_hash8(U64 v) { return (U32)((v * 0xCF1BBCDCB7A56463ULL) >> (64-LZ4MID_HASHLOG)); }
+static U32 LZ4MID_hash8(U64 v) { return (U32)(((v  << (64-56)) * 58295818150454627ULL) >> (64-LZ4MID_HASHLOG)) ; }
+
 static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash8(LZ4_read64(ptr)); }
 static U32 LZ4MID_hash4(U32 v) { return (v * 2654435761U) >> (32-LZ4MID_HASHLOG); }
 static U32 LZ4MID_hash4Ptr(const void* ptr) { return LZ4MID_hash4(LZ4_read32(ptr)); }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -407,7 +407,7 @@ static int LZ4HC_compress_2hashes (
                 }
         }   }
         /* no match found */
-        ip++;
+        ip += 1 + ((ip-anchor) >> 9);  /* skip faster over incompressible data */
         continue;
 
 _lz4mid_encode_sequence:

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -110,7 +110,7 @@ static U64 LZ4_read64(const void* memPtr)
 #define LZ4MID_HASHSIZE 8
 #define LZ4MID_HASHLOG (LZ4HC_HASH_LOG-1)
 #define LZ4MID_HASHTABLESIZE (1 << LZ4MID_HASHLOG)
-static U32 LZ4MID_hash8(U64 v) { return (U32)(v * 0xCF1BBCDCB7A56463ULL) >> (32-LZ4MID_HASHLOG); }
+static U32 LZ4MID_hash8(U64 v) { return (U32)((v * 0xCF1BBCDCB7A56463ULL) >> (64-LZ4MID_HASHLOG)); }
 static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash8(LZ4_read64(ptr)); }
 static U32 LZ4MID_hash4(U32 v) { return (v * 2654435761U) >> (32-LZ4MID_HASHLOG); }
 static U32 LZ4MID_hash4Ptr(const void* ptr) { return LZ4MID_hash4(LZ4_read32(ptr)); }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -500,7 +500,7 @@ static int LZ4HC_compress_2hashes (
 
 _lz4mid_encode_sequence:
         /* catch back */
-        while (((ip > anchor) & (ip - prefixPtr > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
+        while (((ip > anchor) & (ipIndex - prefixIdx > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
             ip--; matchLength++;
         };
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -44,7 +44,7 @@ extern "C" {
 
 
 /* --- Useful constants --- */
-#define LZ4HC_CLEVEL_MIN         3
+#define LZ4HC_CLEVEL_MIN         2
 #define LZ4HC_CLEVEL_DEFAULT     9
 #define LZ4HC_CLEVEL_OPT_MIN    10
 #define LZ4HC_CLEVEL_MAX        12

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -83,6 +83,7 @@ static const size_t maxMemory = (sizeof(size_t)==4)  ?  (2 GB - 64 MB) : (size_t
 /* *************************************
 *  console display
 ***************************************/
+#define DISPLAYOUT(...)      fprintf(stdout, __VA_ARGS__)
 #define DISPLAY(...)         fprintf(stderr, __VA_ARGS__)
 #define DISPLAYLEVEL(l, ...) if (g_displayLevel>=l) { DISPLAY(__VA_ARGS__); }
 static U32 g_displayLevel = 2;   /* 0 : no display;   1: errors;   2 : + result + interaction + warnings;   3 : + progression;   4 : + information */
@@ -439,6 +440,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
         double ratio = 0.;
 
         DISPLAYLEVEL(2, "\r%79s\r", "");
+        if (g_nbSeconds==0) { nbCompressionLoops = 1; nbDecodeLoops = 1; }
         while (!cCompleted || !dCompleted) {
             /* overheat protection */
             if (TIME_clockSpan_ns(coolTime) > ACTIVEPERIOD_NANOSEC) {
@@ -595,9 +597,9 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
             double const cSpeed = ((double)srcSize / (double)fastestC) * 1000;
             double const dSpeed = ((double)srcSize / (double)fastestD) * 1000;
             if (g_additionalParam)
-                DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, g_additionalParam);
+                DISPLAYOUT("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s (param=%d)\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName, g_additionalParam);
             else
-                DISPLAY("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName);
+                DISPLAYOUT("-%-3i%11i (%5.3f) %6.2f MB/s %6.1f MB/s  %s\n", cLevel, (int)cSize, ratio, cSpeed, dSpeed, displayName);
         }
         DISPLAYLEVEL(2, "%2i#\n", cLevel);
     }   /* Bench */

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -485,7 +485,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
                 FUZ_CHECKTEST(r2!=0, "LZ4_compress_fast_extState() should have failed");
             }
 
-            FUZ_DISPLAYTEST("test LZ4_compress_destSize_extState() with a too small destination buffer (must succeed, by compressing less than full input)");
+            FUZ_DISPLAYTEST("test LZ4_compress_destSize_extState() with too small dest buffer (must succeed, compress less than full input)");
             {   int inputSize = blockSize;
                 int const r3 = LZ4_compress_destSize_extState(stateLZ4, block, compressedBuffer, &inputSize, r-1, 8);
                 FUZ_CHECKTEST(r3==0, "LZ4_compress_destSize_extState() failed");


### PR DESCRIPTION
Level 2 is currently the same as level 1. This slot has been reserved for something intermediate between the fastest HC (High Compression) level, which is 3, and the default "fast" mode, which occupies level 1. The difference in speed between these levels is pretty steep, typically > x5.

This patch finally executes on this objective, by providing a specialized parser, dedicated to this speed range. It's a reasonable trade-off, as illustrated in the following benchmarks, run on a i7-9700k @3.6GHz:

__Speed comparison__ : 
| filename | size | level 1 | __level 2__ | level 3 |
| --- | ---:| ---:| ---:| ---:|
| enwik7 | 10000000 | 387 MB/s | 174 MB/s | 66 MB/s | 
| calgary/bib | 111261 | 388 MB/s | 180 MB/s | 79 MB/s |
| calgary/book1 | 768771 | 351 MB/s | 163 MB/s | 56 MB/s |
| calgary/book2 | 610856 | 361 MB/s | 191 MB/s | 71 MB/s |
| calgary/pic | 513216 | 1076 MB/s | 494 MB/s | 188 MB/s |
| calgary/progl | 71646 | 508 MB/s | 253 MB/s | 105 MB/s |
| calgary.tar | 3153920 | 438 MB/s | 200 MB/s | 73 MB/s |
| silesia/dickens | 10192446 | 341 MB/s | 179 MB/s | 57 MB/s |
| silesia/nci | 33553445 | 907 MB/s | 619 MB/s | 176 MB//s |
| silesia/osdb | 10085684 | 479 MB/s | 206 MB/s | 85 MB/s | 
| silesia/xml | 5345280 | 736 MB/s | 443 MB/s | 150 MB/s |
| silesia.tar | 211957760 | 525 MB/s | 225 MB/s | 78 MB/s |
 
__Ratio comparison__ : 
| filename | size | level 1 | __level 2__ | level 3 |
| --- | ---:| ---:| ---:| ---:|
| enwik7 | 10000000 | x1.728 | x2.036 | x2.264 | 
| calgary/bib | 111261 | x1.963 | x2.353 | x2.659 |
| calgary/book1 | 768771 | x1.470 | x1.768 | x1.985 |
| calgary/book2 | 610856 | x1.832 | x2.176 | x2.436 |
| calgary/pic | 513216 | x5.907 | x6.405 | x7.380 |
| calgary/progl | 71646 | x2.655 | x3.031 | x3.347 | 
| calgary.tar | 3153920 | x1.943 | x2.267 | x2.523 |
| silesia/dickens | 10192446 | x1.585 | x1.903 | x2.133 | 
| silesia/nci | 33553445 | x6.064 | x6.723 | x7.892 |
| silesia/osdb | 10085684 | x1.919 | x2.378 | x2.493 |
| silesia/xml | 5345280 | x4.355 | x5.075 | x6.268 |
| silesia.tar | 211957760 | x2.101 | x2.378 | x2.606 |
