### PR TITLE
Added preprocessor checks for Clang on Windows

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -145,6 +145,7 @@ endif()
 include (CheckCCompilerFlag)
 foreach (flag
     # GCC-style
+    -pedantic-errors
     -Wall
     -Wextra
     -Wundef

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -127,11 +127,11 @@
 #endif  /* _MSC_VER */
 
 #ifndef LZ4_FORCE_INLINE
-#  ifdef _MSC_VER    /* Visual Studio */
+#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
 #    define LZ4_FORCE_INLINE static __forceinline
 #  else
 #    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#      ifdef __GNUC__
+#      if defined (__GNUC__) || defined (__clang__)
 #        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
 #      else
 #        define LZ4_FORCE_INLINE static inline

--- a/lib/xxhash.c
+++ b/lib/xxhash.c
@@ -120,12 +120,12 @@ static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcp
 /* *************************************
 *  Compiler Specific Options
 ***************************************/
-#ifdef _MSC_VER    /* Visual Studio */
+#if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
 #  pragma warning(disable : 4127)      /* disable: C4127: conditional expression is constant */
 #  define FORCE_INLINE static __forceinline
 #else
 #  if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#    ifdef __GNUC__
+#    if defined (__GNUC__) || defined (__clang__)
 #      define FORCE_INLINE static inline __attribute__((always_inline))
 #    else
 #      define FORCE_INLINE static inline


### PR DESCRIPTION
MSVC-specific code is used in some places (`__forceinline` in [lz4.c](https://github.com/lz4/lz4/blob/92dada5d84894903d8a5f96934ac1b55d7f10d05/lib/lz4.c#L131) and [xxhash.c](https://github.com/lz4/lz4/blob/92dada5d84894903d8a5f96934ac1b55d7f10d05/lib/xxhash.c#L125)) and compiled only if `_MSC_VER` is set; however, Clang under Windows also defines this, which reports errors on this non-standard code if the `-pedantic-errors` compiler flag is set:
```
lz4/lib/xxhash.c:234:1: error: extension used [-Werror,-Wlanguage-extension-token]
FORCE_INLINE U32 XXH_readLE32_align(const void* ptr, XXH_endianess endian, XXH_alignment align)
^
lz4/lib/xxhash.c:125:31: note: expanded from macro 'FORCE_INLINE'
#  define FORCE_INLINE static __forceinline
                              ^
lz4/lib/lz4.c:461:1: error: extension used [-Werror,-Wlanguage-extension-token]
LZ4_FORCE_INLINE
^
lz4/lib/lz4.c:131:37: note: expanded from macro 'LZ4_FORCE_INLINE'
#    define LZ4_FORCE_INLINE static __forceinline
                                    ^
```

I've also added `-pedantic-errors` as a compiler flag in the CMake script's "GCC-style" flag section, which is also used for Clang; I can absolutely discard it if needed (or add it in the Makefiles too, which I totally overlooked).

---

Related to https://github.com/wolfpld/tracy/pull/733.