### PR TITLE
Add unified CMake target if building only a shared or statric library.

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -116,6 +116,17 @@ if(BUILD_STATIC_LIBS)
     POSITION_INDEPENDENT_CODE ${LZ4_POSITION_INDEPENDENT_LIB})
   list(APPEND LZ4_LIBRARIES_BUILT lz4_static)
 endif()
+# Add unified target if building only a shared or static library.
+if(BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
+  add_library(lz4 INTERFACE)
+  target_link_libraries(lz4 INTERFACE lz4_shared)
+  list(APPEND LZ4_LIBRARIES_BUILT lz4)
+endif()
+if(NOT BUILD_SHARED_LIBS AND BUILD_STATIC_LIBS)
+  add_library(lz4 INTERFACE)
+  target_link_libraries(lz4 INTERFACE lz4_static)
+  list(APPEND LZ4_LIBRARIES_BUILT lz4)
+endif()
 
 # xxhash namesapce
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
This PR exports an `LZ4::lz4` CMake target, if the project was configured to build only a shared or a static library.

c.c. @nemequ