### PR TITLE
Introduce Async I/O for decompression

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -24,7 +24,7 @@ These variables are read by the preprocessor at compilation time, they influence
 and are exposed from `programs/lz4conf.h`.
 Assignment methods vary depending on environments.
 On a typical `posix` + `gcc` + `make` setup, they can be defined with `CPPFLAGS=-DVARIABLE=value` assignment.
-- `LZ4_MULTITHREAD`: enable multithreading support
+- `LZ4IO_MULTITHREAD`: enable multithreading support
 - `LZ4_NBTHREADS_DEFAULT`: default nb of threads in multithreading mode.
    Default is `0`, which means "auto-determine" based on local cpu.
 - `LZ4_BLOCKSIZEID_DEFAULT`: default `lz4` block size code. Valid values are [4-7].

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -57,7 +57,7 @@
 /*****************************
 *  Constants
 ******************************/
-#if LZ4_MULTITHREAD
+#if LZ4IO_MULTITHREAD
 # define IO_MT "multithread"
 #else
 # define IO_MT "single-thread"
@@ -683,7 +683,7 @@ int main(int argCount, const char** argv)
 #ifdef _FILE_OFFSET_BITS
     DISPLAYLEVEL(5, "_FILE_OFFSET_BITS defined: %ldL\n", (long) _FILE_OFFSET_BITS);
 #endif
-#if !LZ4_MULTITHREAD
+#if !LZ4IO_MULTITHREAD
     if (nbWorkers > 1)
         DISPLAYLEVEL(2, "warning: this executable doesn't support multithreading \n");
 #endif
@@ -822,7 +822,7 @@ int main(int argCount, const char** argv)
     } else if (mode == om_list){
         operationResult = LZ4IO_displayCompressedFilesInfo(inFileNames, ifnIdx);
     } else {   /* compression is default action */
-#if LZ4_MULTITHREAD
+#if LZ4IO_MULTITHREAD
         if (nbWorkers != 1) {
             if (nbWorkers==0)
                 nbWorkers = (unsigned)LZ4IO_defaultNbWorkers();

--- a/programs/lz4conf.h
+++ b/programs/lz4conf.h
@@ -28,8 +28,8 @@
 
 /* Determines if multithreading is enabled or not
  * Default: disabled */
-#ifndef LZ4_MULTITHREAD
-# define LZ4_MULTITHREAD 0
+#ifndef LZ4IO_MULTITHREAD
+# define LZ4IO_MULTITHREAD 0
 #endif
 
 /* Determines default nb of threads for compression

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -111,7 +111,7 @@ static TIME_t g_time = { 0 };
 
 static void LZ4IO_finalTimeDisplay(TIME_t timeStart, clock_t cpuStart, unsigned long long size)
 {
-#if LZ4_MULTITHREAD
+#if LZ4IO_MULTITHREAD
     if (!TIME_support_MT_measurements()) {
         DISPLAYLEVEL(5, "time measurements not compatible with multithreading \n");
     } else
@@ -152,7 +152,7 @@ static void LZ4IO_finalTimeDisplay(TIME_t timeStart, clock_t cpuStart, unsigned 
 
 int LZ4IO_defaultNbWorkers(void)
 {
-#if LZ4_MULTITHREAD
+#if LZ4IO_MULTITHREAD
     int const nbCores = UTIL_countCores();
     int const spared = 1 + ((unsigned)nbCores >> 3);
     if (nbCores <= spared) return 1;
@@ -1471,7 +1471,7 @@ LZ4IO_compressFilename_extRess(unsigned long long* inStreamSize,
                                int compressionLevel,
                                const LZ4IO_prefs_t* const io_prefs)
 {
-#if LZ4_MULTITHREAD
+#if LZ4IO_MULTITHREAD
     /* only employ multi-threading in the following scenarios: */
     if ( (io_prefs->nbWorkers != 1)
       && (io_prefs->blockIndependence == LZ4F_blockIndependent)  /* blocks must be independent */

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1659,7 +1659,7 @@ static void LZ4IO_fwriteSparseEnd(FILE* file, unsigned storedSkips)
 
 static unsigned g_magicRead = 0;   /* out-parameter of LZ4IO_decodeLegacyStream() */
 
-#if 1
+#if LZ4IO_MULTITHREAD
 
 typedef struct {
     void* buffer;

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1695,9 +1695,9 @@ typedef struct {
 static void LZ4IO_decompressBlockLegacy(void* arg)
 {
     int decodedSize;
-    LegacyBlockInput* const lbi = arg;
+    LegacyBlockInput* const lbi = (LegacyBlockInput*)arg;
 
-    decodedSize = LZ4_decompress_safe(lbi->inBuffer, lbi->outBuffer, (int)lbi->inSize, LEGACY_BLOCKSIZE);
+    decodedSize = LZ4_decompress_safe((const char*)lbi->inBuffer, (char*)lbi->outBuffer, (int)lbi->inSize, LEGACY_BLOCKSIZE);
     if (decodedSize < 0) END_PROCESS(64, "Decoding Failed ! Corrupted input detected !");
     *lbi->totalSize += (unsigned long long)decodedSize; /* note: works because only 1 thread */
 

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1562,10 +1562,10 @@ int LZ4IO_compressMultipleFilenames(
 /* ********************** LZ4 file-stream Decompression **************** */
 /* ********************************************************************* */
 
-/* It's presumed that s points to a memory space of size >= 4 */
-static unsigned LZ4IO_readLE32 (const void* s)
+/* It's presumed that @p points to a memory space of size >= 4 */
+static unsigned LZ4IO_readLE32 (const void* p)
 {
-    const unsigned char* const srcPtr = (const unsigned char*)s;
+    const unsigned char* const srcPtr = (const unsigned char*)p;
     unsigned value32 = srcPtr[0];
     value32 += (unsigned)srcPtr[1] <<  8;
     value32 += (unsigned)srcPtr[2] << 16;
@@ -1659,6 +1659,149 @@ static void LZ4IO_fwriteSparseEnd(FILE* file, unsigned storedSkips)
 
 static unsigned g_magicRead = 0;   /* out-parameter of LZ4IO_decodeLegacyStream() */
 
+#if 1
+
+typedef struct {
+    void* buffer;
+    size_t size;
+    FILE* f;
+    int sparseEnable;
+    unsigned* storedSkips;
+} ChunkToWrite;
+
+static void LZ4IO_writeDecodedChunk(void* arg)
+{
+    ChunkToWrite* const ctw = (ChunkToWrite*)arg;
+    assert(ctw != NULL);
+
+    /* note: works because only 1 thread */
+    *ctw->storedSkips = LZ4IO_fwriteSparse(ctw->f, ctw->buffer, ctw->size, ctw->sparseEnable, *ctw->storedSkips); /* success or die */
+
+    /* clean up */
+    free(ctw);
+}
+
+typedef struct {
+    void* inBuffer;
+    size_t inSize;
+    void* outBuffer;
+    unsigned long long* totalSize;
+    TPOOL_ctx* wPool;
+    FILE* foutput;
+    int sparseEnable;
+    unsigned* storedSkips;
+} LegacyBlockInput;
+
+static void LZ4IO_decompressBlockLegacy(void* arg)
+{
+    int decodedSize;
+    LegacyBlockInput* const lbi = arg;
+
+    decodedSize = LZ4_decompress_safe(lbi->inBuffer, lbi->outBuffer, (int)lbi->inSize, LEGACY_BLOCKSIZE);
+    if (decodedSize < 0) END_PROCESS(64, "Decoding Failed ! Corrupted input detected !");
+    *lbi->totalSize += (unsigned long long)decodedSize; /* note: works because only 1 thread */
+
+    /* push to write thread */
+    {   ChunkToWrite* const ctw = (ChunkToWrite*)malloc(sizeof(*ctw));
+        if (ctw==NULL) {
+            END_PROCESS(33, "Allocation error : can't describe new write job");
+        }
+        ctw->buffer = lbi->outBuffer;
+        ctw->size = (size_t)decodedSize;
+        ctw->f = lbi->foutput;
+        ctw->sparseEnable = lbi->sparseEnable;
+        ctw->storedSkips = lbi->storedSkips;
+        TPOOL_submitJob(lbi->wPool, LZ4IO_writeDecodedChunk, ctw);
+    }
+
+    /* clean up */
+    free(lbi);
+}
+
+static unsigned long long
+LZ4IO_decodeLegacyStream(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
+{
+    unsigned long long streamSize = 0;
+    unsigned storedSkips = 0;
+
+    TPOOL_ctx* const tPool = TPOOL_create(1, 1);
+    TPOOL_ctx* const wPool = TPOOL_create(1, 1);
+#define NB_BUFFSETS 4 /* 1 being read, 1 being processed, 1 being written, 1 being queued */
+    void* inBuffs[NB_BUFFSETS];
+    void* outBuffs[NB_BUFFSETS];
+    int bSetNb;
+
+    if (tPool == NULL || wPool == NULL)
+        END_PROCESS(21, "threadpool creation error ");
+    /* allocate buffers up front */
+
+    for (bSetNb=0; bSetNb<NB_BUFFSETS; bSetNb++) {
+        inBuffs[bSetNb] = malloc((size_t)LZ4_compressBound(LEGACY_BLOCKSIZE));
+        outBuffs[bSetNb] = malloc(LEGACY_BLOCKSIZE);
+        if (!inBuffs[bSetNb] || !outBuffs[bSetNb])
+            END_PROCESS(31, "Allocation error : can't allocate buffer for legacy decoding");
+    }
+
+    /* Main Loop */
+    for (bSetNb = 0;;bSetNb = (bSetNb+1) % NB_BUFFSETS) {
+        char header[LZ4IO_LEGACY_BLOCK_HEADER_SIZE];
+        unsigned int blockSize;
+
+        /* Block Size */
+        {   size_t const sizeCheck = fread(header, 1, LZ4IO_LEGACY_BLOCK_HEADER_SIZE, finput);
+            if (sizeCheck == 0) break;                   /* Nothing to read : file read is completed */
+            if (sizeCheck != LZ4IO_LEGACY_BLOCK_HEADER_SIZE)
+                END_PROCESS(61, "Error: cannot read block size in Legacy format");
+        }
+        blockSize = LZ4IO_readLE32(header);       /* Convert to Little Endian */
+        if (blockSize > LZ4_COMPRESSBOUND(LEGACY_BLOCKSIZE)) {
+            /* Cannot read next block : maybe new stream ? */
+            g_magicRead = blockSize;
+            break;
+        }
+
+        /* Read Block */
+        {   size_t const sizeCheck = fread(inBuffs[bSetNb], 1, blockSize, finput);
+            if (sizeCheck != blockSize)
+                END_PROCESS(63, "Read error : cannot access compressed block !");
+            /* push to decoding thread */
+            {   LegacyBlockInput* const lbi = (LegacyBlockInput*)malloc(sizeof(*lbi));
+                if (lbi==NULL)
+                    END_PROCESS(64, "Allocation error : not enough memory to allocate job descriptor");
+                lbi->inBuffer = inBuffs[bSetNb];
+                lbi->inSize = blockSize;
+                lbi->outBuffer = outBuffs[bSetNb];
+                lbi->wPool = wPool;
+                lbi->totalSize = &streamSize;
+                lbi->foutput = foutput;
+                lbi->sparseEnable = prefs->sparseFileSupport;
+                lbi->storedSkips = &storedSkips;
+                TPOOL_submitJob(tPool, LZ4IO_decompressBlockLegacy, lbi);
+            }
+        }
+    }
+    if (ferror(finput)) END_PROCESS(65, "Read error : ferror");
+
+    /* Wait for all completion */
+    TPOOL_completeJobs(tPool);
+    TPOOL_completeJobs(wPool);
+
+    /* flush last zeroes */
+    LZ4IO_fwriteSparseEnd(foutput, storedSkips);
+
+    /* Free */
+    TPOOL_free(wPool);
+    TPOOL_free(tPool);
+    for (bSetNb=0; bSetNb<NB_BUFFSETS; bSetNb++) {
+        free(inBuffs[bSetNb]);
+        free(outBuffs[bSetNb]);
+    }
+
+    return streamSize;
+}
+
+#else
+
 static unsigned long long
 LZ4IO_decodeLegacyStream(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs)
 {
@@ -1708,6 +1851,7 @@ LZ4IO_decodeLegacyStream(FILE* finput, FILE* foutput, const LZ4IO_prefs_t* prefs
 
     return streamSize;
 }
+#endif
 
 
 typedef struct {

--- a/programs/threadpool.c
+++ b/programs/threadpool.c
@@ -35,7 +35,7 @@
 #endif
 
 
-#if !LZ4_MULTITHREAD
+#if !LZ4IO_MULTITHREAD
 
 /* ===================================================== */
 /* Backup implementation with no multi-threading support */


### PR DESCRIPTION
The main idea is that the decompression operation is mostly bounded by I/O.
So, by overlapping decompression proper with I/O, it makes decompression essentially parallel to I/O, improving user-perceived speed by ~30%, though there's a large variability depending on use case and platform.

Legacy frames only for the time being, to give time to test.

Some decompression speed benchmark, for the record: 

| platform | file | destination | `dev` | this PR | improvement |
| --- | --- | --- | --- | --- | --- |
| M1 Pro | enwik9 | `/dev/null` | 0.31s | 0.27s | +15% |
| M1 Pro | enwik9 | SSD | 0.53s | 0.30s | +75% |
| Ubuntu, i7-9700 | enwik9 | SSD | 1.42s | 1.05s | +35% |

The benefit is more significant when writing to a physical file system.

Also :
renamed compilation variable to `LZ4IO_MULTITHREAD`, to underline the functionality is carried by `lz4io` unit (not `liblz4`).
