### PR TITLE
fix #1374

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -88,7 +88,9 @@ static unsigned displayLevel = 2;   /* 0 : no display ; 1: errors only ; 2 : dow
 /*-************************************
 *  Errors and Messages
 ***************************************/
-#define DEBUG 0
+#ifndef DEBUG
+#  define DEBUG 0
+#endif
 #define DEBUGOUTPUT(...) do { if (DEBUG) DISPLAY(__VA_ARGS__); } while (0)
 #define END_PROCESS(error, ...)                                   \
 do {                                                              \

--- a/tests/test-lz4-basic.sh
+++ b/tests/test-lz4-basic.sh
@@ -77,3 +77,5 @@ diff -q $FPREFIX-test $FPREFIX-test2
 # Multithreading commands
 datagen -g16M | lz4 -T2 | lz4 -t
 datagen -g16M | lz4 --threads=2 | lz4 -t
+# bug #1374
+datagen -g4194302 | lz4 -B4 -c > $FPREFIX-test3


### PR DESCRIPTION
The internal output buffer size is sized using the function `LZ4F_compressFrameBound()`, with parameter `NULL`. 
A mention specifies "cover worst scenario", but that was incorrect : using `NULL` covers the _default_ scenario, and there are ways to make the situation worse by using advanced command line options, like `-B4`. In some limit scenarios, it leads to situations where the output buffer is not deemed large enough to guarantee a successful compression.

Switched to determining the main ingredients of `LZ4F_preferences_t` during initialization and using actual compression parameters to determine the output buffer size, thus avoiding corner cases like #1374 where it's under-sized.

Added test from #1379 , where it was failing without this patch.

fix #1374