### PR TITLE
Remove code branch

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -506,10 +506,6 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
         LZ4_memcpy(dstPtr+4, srcPtr, 4);
         srcPtr -= dec64table[offset];
         dstPtr += 8;
-    } else {
-        LZ4_memcpy(dstPtr, srcPtr, 8);
-        dstPtr += 8;
-        srcPtr += 8;
     }
 
     LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);


### PR DESCRIPTION
Hello, I hope you are doing well : )

The code branch being removed is equivalent to one iteration of the loop within LZ4_wildCopy8.
It should be slightly faster to remove the branch and let the loop iterate 1 more time.
Because LZ4_wildCopy8 has a do-while, before this removal a minimum of 16 bytes of memory were written when offset>=8.
Now if the match length is at most 8 bytes while offset>=8, only 8 bytes of memory are written.

Regarding to performance, variance across tests seems to be greater than this change's impact.
However, after several runs, the highest throughputs were achieved when this change was included.


Regards,
Nicolas