### PR TITLE
Update function comment

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -530,7 +530,7 @@ LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
 
 /* LZ4_memcpy_using_offset()  presumes :
  * - dstEnd >= dstPtr + MINMATCH
- * - there is at least 8 bytes available to write after dstEnd */
+ * - there is at least 12 bytes available to write after dstEnd */
 LZ4_FORCE_INLINE void
 LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
 {


### PR DESCRIPTION
Hello, I hope you are doing well :)

LZ4_memcpy_using_offset documentation suggests it can overwrite up to 8 bytes after dstEnd.
However, LZ4_memcpy_using_offset_base actually writes at least 16 bytes from dstPtr.
Assuming dstEnd==dstPtr+4, LZ4_memcpy_using_offset can actually overwrite 12 bytes after dstEnd.

This does not seem to be an issue, as LZ4_memcpy_using_offset is only called within the fast dec loop.
Updating the function's documentation may still be worth it for future uses.

Regards,
Nicolas