### PR TITLE
Main page: Fix commons-compress link

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@ They are in conformance with the LZ4 [block] and [frame] specifications, and are
 |__Python__ multi-threadable | Iotic Labs       | https://pypi.python.org/pypi/py-lz4framed
 |__Python__ standard handlers | Jonathan Underwood | https://pypi.python.org/pypi/lz4
 |__Python__               | Christopher Jackson | https://github.com/darkdragn/lz4tools
-|__Java__                 | Apache Commons      | https://commons.apache.org/proper/commons-compress/javadocs/api-release/org/apache/commons/compress/compressors/lz4/package-summary.html
+|__Java__                 | Apache Commons      | https://commons.apache.org/proper/commons-compress/apidocs/index.html
 |__Javascript__ (binding) | Pierre Curto        | https://github.com/pierrec/node-lz4
 |__Javascript__ (port)    | Benzinga            | https://github.com/Benzinga/lz4js
 |__C#__                   | Milosz Krajewski    | https://github.com/MiloszKrajewski/K4os.Compression.LZ4


### PR DESCRIPTION
https://commons.apache.org/proper/commons-compress/apidocs/index.html points to the Javadoc page. The alternative is https://commons.apache.org/proper/commons-compress/