### PR TITLE
len should be unsigned

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1121,7 +1121,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 goto _last_literals;
             }
             if (litLength >= RUN_MASK) {
-                int len = (int)(litLength - RUN_MASK);
+                unsigned len = litLength - RUN_MASK;
                 *token = (RUN_MASK<<ML_BITS);
                 for(; len >= 255 ; len-=255) *op++ = 255;
                 *op++ = (BYTE)len;


### PR DESCRIPTION
len will never underflow, as it is already bounds-checked, and casting is potentially another instruction.