### PR TITLE
Optimize literals encoding during compression

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1126,11 +1126,12 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
             
             if (litLength >= RUN_MASK) {
                 unsigned len = litLength - RUN_MASK;
+                BYTE* opWildCopy;
+                int len = (int)(litLength - RUN_MASK);
                 *token = (RUN_MASK<<ML_BITS);
                 for(; len >= 255 ; len-=255) *op++ = 255;
                 *op++ = (BYTE)len;
                 len = (int)(litLength);
-                BYTE* opWildCopy;
                 opWildCopy = op;
                 do {
                     LZ4_memcpy(opWildCopy, anchor, 8);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1125,7 +1125,6 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                         (int)(anchor-(const BYTE*)source), litLength, (int)(ip-(const BYTE*)source));
             
             if (litLength >= RUN_MASK) {
-                unsigned len = litLength - RUN_MASK;
                 BYTE* opWildCopy;
                 int len = (int)(litLength - RUN_MASK);
                 *token = (RUN_MASK<<ML_BITS);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1129,7 +1129,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 *token = (RUN_MASK<<ML_BITS);
                 for(; len >= 255 ; len-=255) *op++ = 255;
                 *op++ = (BYTE)len;
-                int wildCopyIterations = (litLength >> 3);
+                int wildCopyIterations = (int)(litLength >> 3);
                 BYTE* opWildCopy = op;
                 do {
                     LZ4_memcpy(opWildCopy, anchor, 16);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1130,9 +1130,11 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 for(; len >= 255 ; len-=255) *op++ = 255;
                 *op++ = (BYTE)len;
                 len = (int)(litLength);
-                BYTE* opWildCopy = op;
+                BYTE* opWildCopy;
+                opWildCopy = op;
                 do {
-                    LZ4_memcpy(opWildCopy, anchor, 16);
+                    LZ4_memcpy(opWildCopy, anchor, 8);
+                    LZ4_memcpy(opWildCopy+8, anchor+8, 8);
                     opWildCopy+=16; anchor+=16; len-=16;
                 } while(len>8);
                 if (len>0)

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1129,13 +1129,13 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                 *token = (RUN_MASK<<ML_BITS);
                 for(; len >= 255 ; len-=255) *op++ = 255;
                 *op++ = (BYTE)len;
-                int wildCopyIterations = (int)(litLength >> 3);
+                len = (int)(litLength);
                 BYTE* opWildCopy = op;
                 do {
                     LZ4_memcpy(opWildCopy, anchor, 16);
-                    opWildCopy+=16; anchor+=16; wildCopyIterations-=2;
-                } while(wildCopyIterations>0);
-                if (wildCopyIterations==0)
+                    opWildCopy+=16; anchor+=16; len-=16;
+                } while(len>8);
+                if (len>0)
                     LZ4_memcpy(opWildCopy, anchor, 8);
             }
             else {


### PR DESCRIPTION
Hello, I hope you are doing well : )

I wanted to propose a change into the way the literals are written onto the output buffer during compression.

The intent is to take advantage of the existing execution fork yielded by 'if (litLength >= RUN_MASK)'
The wildCopy loop is now ommited when less than 15 literals need to be copied.
The precondition of having to copy at least 15 literals is used to process them chunks of 16 bytes.

Regarding performance, the same two scenarios of PR#1407 were tested.

Scenario 1:
CPU: Ryzen 5900X
Compilers: gcc-11, clang-8.
Files: enwik9, each file within the silesia corpus, a custom memory dump retrieved from my PC.
Results: Decompression throughput improved in all combinations of files and compilers.

Scenario 2:
CPU: i5-1245U
Compilers: gcc-[9-12], clang-[11-14].
Files: enwik9, 'xml' from the silesia corpus, the custom memory dump retrieved from my PC.
Results: Decompression throughput improved in all combinations of files and compilers.

On the Ryzen 5900:
The change yielded compression throughput improvements for all files when clang was used.
Regarding gcc, throughput decreased for 'sao' and 'x-ray' and increased for all other 12 files.
There seems to be an inclination towards the change improving throughput.

On the weaker i5-1245U:
on gcc-9: 10 files showed better throuhgput, 4 files worsened
on gcc-10: 12 files showed better throuhgput, 2 files worsened
on gcc-11: 13 files showed better throuhgput, 1 file worsened
on gcc-12: 13 files showed better throuhgput, 1 file worsened
on clang-11: 10 files showed better throuhgput, 4 files worsened
on clang-12: 12 files showed better throuhgput, 2 files worsened
on clang-13: 13 files showed better throuhgput, 1 files worsened
on clang-14: 12 files showed better throuhgput, 2 files worsened
Although it has more mixed results, it also showed a noticeable inclination towards including the change

Overall, there seems to be a trend towards improving performance by including the change.
It is relevant to remark that the trend improves as more powerful CPUs and more modern compilers are used.

Thanks,
Nicolas

