### PR TITLE
removed FreeBSD 13.2 test from Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,6 @@ task:
   freebsd_instance:
     matrix:
       image_family: freebsd-14-0
-      image_family: freebsd-13-2
   install_script: pkg install -y gmake
   script: |
     cc -v


### PR DESCRIPTION
it has been failing for a while and doesn't seem to get fixed.

There is still the FreeBSD 14.0 test running.