### PR TITLE
build: minor: fix lz4 project in VS2017 solution

### DIFF
--- a/build/VS2017/lz4/lz4.vcxproj
+++ b/build/VS2017/lz4/lz4.vcxproj
@@ -155,6 +155,9 @@
     <ClCompile Include="..\..\..\programs\lorem.c" />
     <ClCompile Include="..\..\..\programs\lz4cli.c" />
     <ClCompile Include="..\..\..\programs\lz4io.c" />
+    <ClCompile Include="..\..\..\programs\threadpool.c" />
+    <ClCompile Include="..\..\..\programs\timefn.c" />
+    <ClCompile Include="..\..\..\programs\util.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\lib\lz4.h" />
@@ -165,6 +168,9 @@
     <ClInclude Include="..\..\..\programs\bench.h" />
     <ClInclude Include="..\..\..\programs\lorem.h" />
     <ClInclude Include="..\..\..\programs\lz4io.h" />
+    <ClInclude Include="..\..\..\programs\threadpool.h" />
+    <ClInclude Include="..\..\..\programs\timefn.h" />
+    <ClInclude Include="..\..\..\programs\util.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="lz4.rc" />


### PR DESCRIPTION
Note: it would probably be better to stop shipping and maintaining separate Visual Studio solutions manually,
and instead have them generated procedurally from (typically) `cmake` recipe before release.
But that's a project in itself...