### PR TITLE
automatically enable multithreading by default on Windows

### DIFF
--- a/programs/lz4conf.h
+++ b/programs/lz4conf.h
@@ -26,15 +26,22 @@
 #define LZ4CONF_H_32432
 
 
-/* Determines if multithreading is enabled or not
- * Default: disabled */
+/* Determines if multithreading is enabled or not */
 #ifndef LZ4IO_MULTITHREAD
-# define LZ4IO_MULTITHREAD 0
+# ifdef _WIN32
+    /* Windows support Completion Ports */
+#   define LZ4IO_MULTITHREAD 1
+# else
+    /* Requires <pthread> support.
+     * Can't be reliably and portably tested at source code level */
+#   define LZ4IO_MULTITHREAD 0
+# endif
 #endif
 
 /* Determines default nb of threads for compression
  * Default value is 0, which means "auto" :
  * nb of threads is determined from detected local cpu.
+ * Can be overriden by Environment Variable LZ4_NBWORKERS.
  * Can be overridden at runtime using -T# command */
 #ifndef LZ4_NBWORKERS_DEFAULT
 # define LZ4_NBWORKERS_DEFAULT 0
@@ -47,7 +54,7 @@
 
 /* Determines default lz4 block size when none provided.
  * Default value is 7, which represents 4 MB.
- * Can also be selected at runtime using -B# command */
+ * Can be overridden at runtime using -B# command */
 #ifndef LZ4_BLOCKSIZEID_DEFAULT
 # define LZ4_BLOCKSIZEID_DEFAULT 7
 #endif

--- a/programs/threadpool.c
+++ b/programs/threadpool.c
@@ -88,8 +88,10 @@ void TPool_free(TPool* pool)
     if (!pool) return;
 
     /* Signal workers to exit by posting NULL completions */
-    for (int i = 0; i < pool->nbWorkers; i++) {
-        PostQueuedCompletionStatus(pool->completionPort, 0, 0, NULL);
+    {   int i;
+        for (i = 0; i < pool->nbWorkers; i++) {
+            PostQueuedCompletionStatus(pool->completionPort, 0, 0, NULL);
+        }
     }
 
     /* Wait for worker threads to finish */


### PR DESCRIPTION
Completion Ports have been supported since basically forever.