### PR TITLE
removed implicit stdout

### DIFF
--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -775,16 +775,7 @@ int main(int argCount, const char** argv)
     }
 
     /* No output filename ==> try to select one automatically (when possible) */
-    while ((!output_filename) && (multiple_inputs==0)) {
-        if (!IS_CONSOLE(stdout) && mode != om_list) {
-            /* Default to stdout whenever stdout is not the console.
-             * Note : this policy may change in the future, therefore don't rely on it !
-             * To ensure `stdout` is explicitly selected, use `-c` command flag.
-             * Conversely, to ensure output will not become `stdout`, use `-m` command flag */
-            DISPLAYLEVEL(1, "Warning : using stdout as default output. Do not rely on this behavior: use explicit `-c` instead ! \n");
-            output_filename = stdoutmark;
-            break;
-        }
+    if ((!output_filename) && (multiple_inputs==0)) {
         if (mode == om_auto) {  /* auto-determine compression or decompression, based on file extension */
             mode = determineOpMode(input_filename);
         }
@@ -796,9 +787,9 @@ int main(int argCount, const char** argv)
             strcat(dynNameSpace, LZ4_EXTENSION);
             output_filename = dynNameSpace;
             DISPLAYLEVEL(2, "Compressed filename will be : %s \n", output_filename);
-            break;
         }
-        if (mode == om_decompress) {/* decompress to file (automatic output name only works if input filename has correct format extension) */
+        if (mode == om_decompress) {
+            /* decompress to file (automatic output name only works if input filename has correct format extension) */
             size_t outl;
             size_t const inl = strlen(input_filename);
             dynNameSpace = (char*)calloc(1,inl+1);
@@ -811,7 +802,6 @@ int main(int argCount, const char** argv)
             output_filename = dynNameSpace;
             DISPLAYLEVEL(2, "Decoding file %s \n", output_filename);
         }
-        break;
     }
 
     if (mode == om_list) {

--- a/tests/test-lz4-basic.sh
+++ b/tests/test-lz4-basic.sh
@@ -29,6 +29,10 @@ echo "hello world" > $FPREFIX-hw
 lz4 --rm -f $FPREFIX-hw $FPREFIX-hw.lz4
 test ! -f $FPREFIX-hw                   # must fail (--rm)
 test   -f $FPREFIX-hw.lz4
+lz4 -d --rm -f $FPREFIX-hw.lz4
+test ! -f $FPREFIX-hw.lz4
+lz4 --rm -f $FPREFIX-hw > /dev/null
+test   -f $FPREFIX-hw.lz4               # no more implicit stdout
 lz4cat $FPREFIX-hw.lz4 | grep "hello world"
 unlz4 --rm $FPREFIX-hw.lz4 $FPREFIX-hw
 test   -f $FPREFIX-hw
@@ -67,6 +71,9 @@ test "$(datagen -g20KB | lz4 -c -1 | wc -c)" -lt "$(datagen -g20KB| lz4 -c --fas
 test "$(datagen -g20KB | lz4 -c --fast=1 | wc -c)" -eq "$(datagen -g20KB| lz4 -c --fast| wc -c)" # checks default fast compression is -1
 lz4 -c --fast=0 $FPREFIX-dg20K && exit 1  # lz4 should fail when fast=0
 lz4 -c --fast=-1 $FPREFIX-dg20K && exit 1 # lz4 should fail when fast=-1
+# Multithreading commands
+datagen -g16M | lz4 -T2 | lz4 -t
+datagen -g16M | lz4 --threads=2 | lz4 -t
 # High --fast values can result in out-of-bound dereferences #876
 datagen -g1M | lz4 -c --fast=999999999 > $FPREFIX-trash
 # Test for #596
@@ -74,8 +81,5 @@ echo "TEST" > $FPREFIX-test
 lz4 -m $FPREFIX-test
 lz4 $FPREFIX-test.lz4 $FPREFIX-test2
 diff -q $FPREFIX-test $FPREFIX-test2
-# Multithreading commands
-datagen -g16M | lz4 -T2 | lz4 -t
-datagen -g16M | lz4 --threads=2 | lz4 -t
 # bug #1374
 datagen -g4194302 | lz4 -B4 -c > $FPREFIX-test3


### PR DESCRIPTION
fixes #1193.

Implicit `stdout` has been a behavior of the `lz4` cli since its early days, but it ends up being confusing for users, which do not expect this behavior.

The feature is already deprecated, it has been issuing a warning message for several years. It's time to cut it out.

`stdout` must now be explicit, using the `-c` or `--stdout` command.