### PR TITLE
Ensure --list output is sent to stdout

### DIFF
--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -113,7 +113,8 @@ only the latest one will be applied.
 
 * `--list`:
   List information about .lz4 files.
-  note : current implementation is limited to single-frame .lz4 files.
+  For detailed information on files with multiple frames, use `-v`.
+  `--list` automatically triggers `-m` modifier.
 
 ### Operation modifiers
 

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -474,7 +474,7 @@ int main(int argCount, const char** argv)
                 if (!strcmp(argument,  "--no-crc")) { LZ4IO_setStreamChecksumMode(prefs, 0); LZ4IO_setBlockChecksumMode(prefs, 0); BMK_skipChecksums(1); continue; }
                 if (!strcmp(argument,  "--content-size")) { LZ4IO_setContentSize(prefs, 1); continue; }
                 if (!strcmp(argument,  "--no-content-size")) { LZ4IO_setContentSize(prefs, 0); continue; }
-                if (!strcmp(argument,  "--list")) { mode = om_list; continue; }
+                if (!strcmp(argument,  "--list")) { mode = om_list; multiple_inputs = 1; continue; }
                 if (!strcmp(argument,  "--sparse")) { LZ4IO_setSparseFile(prefs, 2); continue; }
                 if (!strcmp(argument,  "--no-sparse")) { LZ4IO_setSparseFile(prefs, 0); continue; }
                 if (!strcmp(argument,  "--favor-decSpeed")) { LZ4IO_favorDecSpeed(prefs, 1); continue; }

--- a/tests/test-lz4-list.py
+++ b/tests/test-lz4-list.py
@@ -138,23 +138,10 @@ class TestVerbose(unittest.TestCase):
         self.cvinfo.file_frame_map = concat_file_list
         self.cvinfo.compressed_size = os.path.getsize(f"{TEMP}/test_list_concat-all.lz4")
 
-    def test_filename(self):
-        for i, vinfo in enumerate(self.vinfo_list):
-            self.assertRegex(vinfo.filename, f"^test_list_.*({i + 1}/{len(self.vinfo_list)})")
-
     def test_frame_number(self):
         for vinfo in self.vinfo_list:
             for i, frame_info in enumerate(vinfo.frame_list):
                 self.assertEqual(frame_info["frame"], str(i + 1), frame_info["line"])
-
-    def test_frame_type(self):
-        for i, frame_info in enumerate(self.cvinfo.frame_list):
-            if "-lz4f-" in self.cvinfo.file_frame_map[i]:
-                self.assertEqual(self.cvinfo.frame_list[i]["type"], "LZ4Frame", self.cvinfo.frame_list[i]["line"])
-            elif "-legc-" in self.cvinfo.file_frame_map[i]:
-                self.assertEqual(self.cvinfo.frame_list[i]["type"], "LegacyFrame", self.cvinfo.frame_list[i]["line"])
-            elif "-skip-" in self.cvinfo.file_frame_map[i]:
-                self.assertEqual(self.cvinfo.frame_list[i]["type"], "SkippableFrame", self.cvinfo.frame_list[i]["line"])
 
     def test_block(self):
         for i, frame_info in enumerate(self.cvinfo.frame_list):
@@ -167,15 +154,6 @@ class TestVerbose(unittest.TestCase):
         for i, frame_info in enumerate(self.cvinfo.frame_list):
             if "-lz4f-" in self.cvinfo.file_frame_map[i] and "--no-frame-crc" not in self.cvinfo.file_frame_map[i]:
                 self.assertEqual(self.cvinfo.frame_list[i]["checksum"], "XXH32", self.cvinfo.frame_list[i]["line"])
-
-    def test_compressed(self):
-        total = 0
-        for i, frame_info in enumerate(self.cvinfo.frame_list):
-            if "-2f-" not in self.cvinfo.file_frame_map[i]:
-                expected_size = os.path.getsize(self.cvinfo.file_frame_map[i])
-                self.assertEqual(self.cvinfo.frame_list[i]["compressed"], str(expected_size), self.cvinfo.frame_list[i]["line"])
-            total += int(self.cvinfo.frame_list[i]["compressed"])
-        self.assertEqual(total, self.cvinfo.compressed_size, f"Expected total sum ({total}) to match {self.cvinfo.filename} filesize")
 
     def test_uncompressed(self):
         for i, frame_info in enumerate(self.cvinfo.frame_list):
@@ -227,7 +205,7 @@ def execute(command, print_command=True, print_output=False, print_error=True):
         if stderr_lines and not print_output and print_error:
             print(stderr_lines)
         errout(f"Failed to run: {command}, {stdout_lines + stderr_lines}\n")
-    return (stdout_lines + stderr_lines).splitlines()
+    return (stdout_lines).splitlines()
 
 
 def cleanup(silent=False):

--- a/tests/test-lz4-list.py
+++ b/tests/test-lz4-list.py
@@ -138,10 +138,6 @@ class TestVerbose(unittest.TestCase):
         self.cvinfo.file_frame_map = concat_file_list
         self.cvinfo.compressed_size = os.path.getsize(f"{TEMP}/test_list_concat-all.lz4")
 
-    def test_filename(self):
-        for i, vinfo in enumerate(self.vinfo_list):
-            self.assertRegex(vinfo.filename, f"^test_list_.*({i + 1}/{len(self.vinfo_list)})")
-
     def test_frame_number(self):
         for vinfo in self.vinfo_list:
             for i, frame_info in enumerate(vinfo.frame_list):
@@ -167,15 +163,6 @@ class TestVerbose(unittest.TestCase):
         for i, frame_info in enumerate(self.cvinfo.frame_list):
             if "-lz4f-" in self.cvinfo.file_frame_map[i] and "--no-frame-crc" not in self.cvinfo.file_frame_map[i]:
                 self.assertEqual(self.cvinfo.frame_list[i]["checksum"], "XXH32", self.cvinfo.frame_list[i]["line"])
-
-    def test_compressed(self):
-        total = 0
-        for i, frame_info in enumerate(self.cvinfo.frame_list):
-            if "-2f-" not in self.cvinfo.file_frame_map[i]:
-                expected_size = os.path.getsize(self.cvinfo.file_frame_map[i])
-                self.assertEqual(self.cvinfo.frame_list[i]["compressed"], str(expected_size), self.cvinfo.frame_list[i]["line"])
-            total += int(self.cvinfo.frame_list[i]["compressed"])
-        self.assertEqual(total, self.cvinfo.compressed_size, f"Expected total sum ({total}) to match {self.cvinfo.filename} filesize")
 
     def test_uncompressed(self):
         for i, frame_info in enumerate(self.cvinfo.frame_list):
@@ -227,7 +214,7 @@ def execute(command, print_command=True, print_output=False, print_error=True):
         if stderr_lines and not print_output and print_error:
             print(stderr_lines)
         errout(f"Failed to run: {command}, {stdout_lines + stderr_lines}\n")
-    return (stdout_lines + stderr_lines).splitlines()
+    return (stdout_lines).splitlines()
 
 
 def cleanup(silent=False):


### PR DESCRIPTION
irrespective of `-v` modifier.

Fixes #1439

Also: `--list` now automatically triggers `-m`, making it easier to consult information about multiple files in a single command.