### PR TITLE
Level 2 compatibility with Dictionary compression 

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -380,22 +380,30 @@ LZ4MID_addPosition(U32* hTable, U32 hValue, U32 index)
 #define ADDPOS8(_p, _idx) LZ4MID_addPosition(hash8Table, LZ4MID_hash8Ptr(_p), _idx)
 #define ADDPOS4(_p, _idx) LZ4MID_addPosition(hash4Table, LZ4MID_hash4Ptr(_p), _idx)
 
-/* Update references in hash tables up to ptr (excluded) */
-static void LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const BYTE* ptr)
+/* Fill hash tables with references into dictionary.
+ * The resulting table is only exploitable by LZ4MID (level 2) */
+static void
+LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
 {
     U32* const hash4Table = cctx->hashTable;
     U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
-    const BYTE* const prefixPtr = cctx->prefixStart;
+    const BYTE* const prefixPtr = dict;
     U32 const prefixIdx = cctx->dictLimit;
-    U32 const target = (U32)(ptr - prefixPtr) + prefixIdx;
+    U32 const target = prefixIdx + (U32)size - LZ4MID_HASHSIZE;
     U32 idx = cctx->nextToUpdate;
-    assert(ptr >= prefixPtr);
-    assert(target >= prefixIdx);
+    assert(dict == cctx->prefixStart);
+    DEBUGLOG(4, "LZ4MID_fillHTable (size:%zu)", size);
+    if (size <= LZ4MID_HASHSIZE)
+        return;
 
-    while (idx < target) {
+    for (; idx < target; idx += 3) {
         ADDPOS4(prefixPtr+idx-prefixIdx, idx);
-        ADDPOS8(prefixPtr+idx-prefixIdx+1, idx+1);
-        idx += 3;
+        ADDPOS8(prefixPtr+idx+1-prefixIdx, idx+1);
+    }
+
+    idx = (size > 32 KB + LZ4MID_HASHSIZE) ? target - 32 KB : cctx->nextToUpdate;
+    for (; idx < target; idx += 1) {
+        ADDPOS8(prefixPtr+idx-prefixIdx, idx);
     }
 
     cctx->nextToUpdate = target;
@@ -425,6 +433,8 @@ static int LZ4MID_compress (
     const BYTE* const prefixPtr = ctx->prefixStart;
     const U32 prefixIdx = ctx->dictLimit;
     const U32 ilimitIdx = (U32)(ilimit - prefixPtr) + prefixIdx;
+    const BYTE* const dictStart = ctx->dictStart;
+    const U32 dictIdx = ctx->lowLimit;
     const U32 gDictEndIndex = ctx->lowLimit;
     unsigned matchLength;
     unsigned matchDistance;
@@ -448,57 +458,82 @@ static int LZ4MID_compress (
     while (ip <= mflimit) {
         const U32 ipIndex = (U32)(ip - prefixPtr) + prefixIdx;
         /* search long match */
-        {   U32 h8 = LZ4MID_hash8Ptr(ip);
-            U32 pos8 = hash8Table[h8];
+        {   U32 const h8 = LZ4MID_hash8Ptr(ip);
+            U32 const pos8 = hash8Table[h8];
             assert(h8 < LZ4MID_HASHTABLESIZE);
             assert(pos8 < ipIndex);
             LZ4MID_addPosition(hash8Table, h8, ipIndex);
-            if ( ipIndex - pos8 <= LZ4_DISTANCE_MAX
-              && pos8 >= prefixIdx  /* note: currently only search within prefix */
-              ) {
+            if (ipIndex - pos8 <= LZ4_DISTANCE_MAX) {
                 /* match candidate found */
-                const BYTE* matchPtr = prefixPtr + pos8 - prefixIdx;
-                assert(matchPtr < ip);
-                matchLength = LZ4_count(ip, matchPtr, matchlimit);
-                if (matchLength >= MINMATCH) {
-                    DEBUGLOG(7, "found candidate match at pos %u (len=%u)", pos8, matchLength);
-                    matchDistance = ipIndex - pos8;
-                    goto _lz4mid_encode_sequence;
+                if (pos8 >= prefixIdx) {
+                    const BYTE* const matchPtr = prefixPtr + pos8 - prefixIdx;
+                    assert(matchPtr < ip);
+                    matchLength = LZ4_count(ip, matchPtr, matchlimit);
+                    if (matchLength >= MINMATCH) {
+                        DEBUGLOG(7, "found long match at pos %u (len=%u)", pos8, matchLength);
+                        matchDistance = ipIndex - pos8;
+                        goto _lz4mid_encode_sequence;
+                    }
+                } else {
+                    if (pos8 >= dictIdx) {
+                        /* extDict match candidate */
+                        const BYTE* const matchPtr = dictStart + (pos8 - dictIdx);
+                        const size_t safeLen = MIN(prefixIdx - pos8, (size_t)(matchlimit - ip));
+                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        if (matchLength >= MINMATCH) {
+                            DEBUGLOG(7, "found long match at ExtDict pos %u (len=%u)", pos8, matchLength);
+                            matchDistance = ipIndex - pos8;
+                            goto _lz4mid_encode_sequence;
+                        }
+                    }
                 }
         }   }
         /* search short match */
-        {   U32 h4 = LZ4MID_hash4Ptr(ip);
-            U32 pos4 = hash4Table[h4];
+        {   U32 const h4 = LZ4MID_hash4Ptr(ip);
+            U32 const pos4 = hash4Table[h4];
             assert(h4 < LZ4MID_HASHTABLESIZE);
             assert(pos4 < ipIndex);
             LZ4MID_addPosition(hash4Table, h4, ipIndex);
-            if (ipIndex - pos4 <= LZ4_DISTANCE_MAX
-              && pos4 >= prefixIdx /* only search within prefix */
-              ) {
+            if (ipIndex - pos4 <= LZ4_DISTANCE_MAX) {
                 /* match candidate found */
-                const BYTE* const matchPtr = prefixPtr + (pos4 - prefixIdx);
-                assert(matchPtr < ip);
-                assert(matchPtr >= prefixPtr);
-                matchLength = LZ4_count(ip, matchPtr, matchlimit);
-                if (matchLength >= MINMATCH) {
-                    /* short match found, let's just check ip+1 for longer */
-                    U32 const h8 = LZ4MID_hash8Ptr(ip+1);
-                    U32 const pos8 = hash8Table[h8];
-                    U32 const m2Distance = ipIndex + 1 - pos8;
-                    matchDistance = ipIndex - pos4;
-                    if ( m2Distance <= LZ4_DISTANCE_MAX
-                      && pos8 >= prefixIdx /* only search within prefix */
-                      && likely(ip < mflimit)
-                      ) {
-                        const BYTE* const m2Ptr = prefixPtr + (pos8 - prefixIdx);
-                        unsigned ml2 = LZ4_count(ip+1, m2Ptr, matchlimit);
-                        if (ml2 > matchLength) {
-                            LZ4MID_addPosition(hash8Table, h8, ipIndex+1);
-                            ip++;
-                            matchLength = ml2;
-                            matchDistance = m2Distance;
-                    }   }
-                    goto _lz4mid_encode_sequence;
+                if (pos4 >= prefixIdx) {
+                /* only search within prefix */
+                    const BYTE* const matchPtr = prefixPtr + (pos4 - prefixIdx);
+                    assert(matchPtr < ip);
+                    assert(matchPtr >= prefixPtr);
+                    matchLength = LZ4_count(ip, matchPtr, matchlimit);
+                    if (matchLength >= MINMATCH) {
+                        /* short match found, let's just check ip+1 for longer */
+                        U32 const h8 = LZ4MID_hash8Ptr(ip+1);
+                        U32 const pos8 = hash8Table[h8];
+                        U32 const m2Distance = ipIndex + 1 - pos8;
+                        matchDistance = ipIndex - pos4;
+                        if ( m2Distance <= LZ4_DISTANCE_MAX
+                        && pos8 >= prefixIdx /* only search within prefix */
+                        && likely(ip < mflimit)
+                        ) {
+                            const BYTE* const m2Ptr = prefixPtr + (pos8 - prefixIdx);
+                            unsigned ml2 = LZ4_count(ip+1, m2Ptr, matchlimit);
+                            if (ml2 > matchLength) {
+                                LZ4MID_addPosition(hash8Table, h8, ipIndex+1);
+                                ip++;
+                                matchLength = ml2;
+                                matchDistance = m2Distance;
+                        }   }
+                        goto _lz4mid_encode_sequence;
+                    }
+                } else {
+                    if (pos4 >= dictIdx) {
+                        /* extDict match candidate */
+                        const BYTE* const matchPtr = dictStart + (pos4 - dictIdx);
+                        const size_t safeLen = MIN(prefixIdx - pos4, (size_t)(matchlimit - ip));
+                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        if (matchLength >= MINMATCH) {
+                            DEBUGLOG(7, "found match at ExtDict pos %u (len=%u)", pos4, matchLength);
+                            matchDistance = ipIndex - pos4;
+                            goto _lz4mid_encode_sequence;
+                        }
+                    }
                 }
         }   }
         /* no match found in prefix */
@@ -1508,8 +1543,10 @@ int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr,
               const char* dictionary, int dictSize)
 {
     LZ4HC_CCtx_internal* const ctxPtr = &LZ4_streamHCPtr->internal_donotuse;
-    DEBUGLOG(4, "LZ4_loadDictHC(ctx:%p, dict:%p, dictSize:%d)", LZ4_streamHCPtr, dictionary, dictSize);
+    cParams_t cp;
+    DEBUGLOG(4, "LZ4_loadDictHC(ctx:%p, dict:%p, dictSize:%d, clevel=%d)", LZ4_streamHCPtr, dictionary, dictSize, ctxPtr->compressionLevel);
     assert(LZ4_streamHCPtr != NULL);
+    assert(dictSize >= 0);
     if (dictSize > 64 KB) {
         dictionary += (size_t)dictSize - 64 KB;
         dictSize = 64 KB;
@@ -1518,10 +1555,15 @@ int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr,
     {   int const cLevel = ctxPtr->compressionLevel;
         LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
         LZ4_setCompressionLevel(LZ4_streamHCPtr, cLevel);
+        cp = LZ4HC_getCLevelParams(cLevel);
     }
     LZ4HC_init_internal (ctxPtr, (const BYTE*)dictionary);
     ctxPtr->end = (const BYTE*)dictionary + dictSize;
-    if (dictSize >= LZ4HC_HASHSIZE) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
+    if (cp.strat == lz4mid) {
+        LZ4MID_fillHTable (ctxPtr, dictionary, (size_t)dictSize);
+    } else {
+        if (dictSize >= LZ4HC_HASHSIZE) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
+    }
     return dictSize;
 }
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -387,7 +387,7 @@ LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
 {
     U32* const hash4Table = cctx->hashTable;
     U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
-    const BYTE* const prefixPtr = dict;
+    const BYTE* const prefixPtr = (const BYTE*)dict;
     U32 const prefixIdx = cctx->dictLimit;
     U32 const target = prefixIdx + (U32)size - LZ4MID_HASHSIZE;
     U32 idx = cctx->nextToUpdate;

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -232,18 +232,18 @@ LZ4_attach_HC_dictionary(LZ4_streamHC_t* working_stream,
 typedef struct LZ4HC_CCtx_internal LZ4HC_CCtx_internal;
 struct LZ4HC_CCtx_internal
 {
-    LZ4_u32   hashTable[LZ4HC_HASHTABLESIZE];
-    LZ4_u16   chainTable[LZ4HC_MAXD];
-    const LZ4_byte* end;       /* next block here to continue on current prefix */
+    LZ4_u32 hashTable[LZ4HC_HASHTABLESIZE];
+    LZ4_u16 chainTable[LZ4HC_MAXD];
+    const LZ4_byte* end;     /* next block here to continue on current prefix */
     const LZ4_byte* prefixStart;  /* Indexes relative to this position */
     const LZ4_byte* dictStart; /* alternate reference for extDict */
-    LZ4_u32   dictLimit;       /* below that point, need extDict */
-    LZ4_u32   lowLimit;        /* below that point, no more dict */
-    LZ4_u32   nextToUpdate;    /* index from which to continue dictionary update */
-    short     compressionLevel;
-    LZ4_i8    favorDecSpeed;   /* favor decompression speed if this flag set,
-                                  otherwise, favor compression ratio */
-    LZ4_i8    dirty;           /* stream has to be fully reset if this flag is set */
+    LZ4_u32 dictLimit;       /* below that point, need extDict */
+    LZ4_u32 lowLimit;        /* below that point, no more history */
+    LZ4_u32 nextToUpdate;    /* index from which to continue dictionary update */
+    short   compressionLevel;
+    LZ4_i8  favorDecSpeed;   /* favor decompression speed if this flag set,
+                                otherwise, favor compression ratio */
+    LZ4_i8  dirty;           /* stream has to be fully reset if this flag is set */
     const LZ4HC_CCtx_internal* dictCtx;
 };
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -126,6 +126,8 @@ LZ4LIB_API int             LZ4_freeStreamHC (LZ4_streamHC_t* streamHCPtr);
 
   After reset, a first "fictional block" can be designated as initial dictionary,
   using LZ4_loadDictHC() (Optional).
+  Note: In order for LZ4_loadDictHC() to create the correct data structure,
+  it is essential to set the compression level _before_ loading the dictionary.
 
   Invoke LZ4_compress_HC_continue() to compress each successive block.
   The number of blocks is unlimited.

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -187,7 +187,7 @@ LZ4_compressInitStream(struct compressionParameters* pThis)
     pThis->LZ4_dictStream = LZ4_createStream();
     pThis->LZ4_streamHC = NULL;
     pThis->LZ4_dictStreamHC = NULL;
-    LZ4_loadDict(pThis->LZ4_dictStream, pThis->dictBuf, pThis->dictSize);
+    LZ4_loadDictSlow(pThis->LZ4_dictStream, pThis->dictBuf, pThis->dictSize);
 }
 
 static void
@@ -197,6 +197,7 @@ LZ4_compressInitStreamHC(struct compressionParameters* pThis)
     pThis->LZ4_dictStream = NULL;
     pThis->LZ4_streamHC = LZ4_createStreamHC();
     pThis->LZ4_dictStreamHC = LZ4_createStreamHC();
+    LZ4_resetStreamHC_fast(pThis->LZ4_dictStreamHC, pThis->cLevel);
     LZ4_loadDictHC(pThis->LZ4_dictStreamHC, pThis->dictBuf, pThis->dictSize);
 }
 

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -329,7 +329,7 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
     void* const stateLZ4   = malloc((size_t)LZ4_sizeofState());
     void* const stateLZ4HC = malloc((size_t)LZ4_sizeofStateHC());
     LZ4_stream_t LZ4dictBody;
-    LZ4_streamHC_t* LZ4dictHC = LZ4_createStreamHC();
+    LZ4_streamHC_t* const LZ4dictHC = LZ4_createStreamHC();
     U32 coreRandState = seed;
     clock_t const clockStart = clock();
     clock_t const clockDuration = (clock_t)duration_s * CLOCKS_PER_SEC;

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -933,8 +933,8 @@ static int FUZ_test(U32 seed, U32 nbCycles, const U32 startCycle, const double c
         FUZ_DISPLAYTEST("LZ4_compress_HC_continue with an external dictionary");
         dict -= (FUZ_rand(&randState) & 7);    /* even bigger separation */
         if (dict < (char*)CNBuffer) dict = (char*)CNBuffer;
-        LZ4_loadDictHC(LZ4dictHC, dict, dictSize);
         LZ4_setCompressionLevel (LZ4dictHC, compressionLevel);
+        LZ4_loadDictHC(LZ4dictHC, dict, dictSize);
         blockContinueCompressedSize = LZ4_compress_HC_continue(LZ4dictHC, block, compressedBuffer, blockSize, (int)compressedBufferSize);
         FUZ_CHECKTEST(blockContinueCompressedSize==0, "LZ4_compress_HC_continue failed");
         FUZ_CHECKTEST(LZ4dictHC->internal_donotuse.dirty, "Context should be clean");


### PR DESCRIPTION
Level 2 is a recent level which uses a completely difference algorithm and data layout codenamed `LZ4MID`.
As consequence, `LZ4_loadDictHC()` must be adjusted to build hash tables compatible with `LZ4MID`.

This is achieved in this PR:
| File | level | compression | with dictionary | improvement |
| --- | --- | --- | --- | --- |
| enwik4 | 1 | x1.842 | x2.099 | +14% |
| enwik4 | 2 | x1.920 | x2.436 |  +27% |
| enwik4 | 3 | x1.976 |  x2.835 |  +43% |

Note that, for `LZ4_loadDictHC()` to fill the correct data structure, the compression level must be set _before_ loading the dictionary.