### PR TITLE
removed lz4c target from cmake recipe

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -32,7 +32,6 @@ project(LZ4 VERSION ${LZ4_VERSION_STRING} LANGUAGES C)
 
 
 option(LZ4_BUILD_CLI "Build lz4 program" ON)
-option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c program with legacy argument support" ON)
 
 
 # Determine if LZ4 is being built as part of another project.
@@ -143,13 +142,6 @@ if (LZ4_BUILD_CLI)
   set(LZ4_PROGRAMS_BUILT lz4cli)
   add_executable(lz4cli ${LZ4_CLI_SOURCES})
   set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
-endif()
-
-# lz4c
-if (LZ4_BUILD_LEGACY_LZ4C)
-  list(APPEND LZ4_PROGRAMS_BUILT lz4c)
-  add_executable(lz4c ${LZ4_CLI_SOURCES})
-  set_target_properties(lz4c PROPERTIES COMPILE_DEFINITIONS "ENABLE_LZ4C_LEGACY_OPTIONS")
 endif()
 
 # Extra warning flags


### PR DESCRIPTION
this legacy target should no longer be necessary.

Besides, since `cmake` is now used to generate `visual` solutions, it's also better to discourage creation of this legacy binary by not making it readily available.