### PR TITLE
Fix stack alignment of _start() in freestanding test

### DIFF
--- a/tests/freestanding.c
+++ b/tests/freestanding.c
@@ -225,7 +225,7 @@ EXTERN_C int memcmp(const void *s1, const void *s2, size_t n) {
 
 
 //
-EXTERN_C void _start(void) {
+EXTERN_C void __attribute__((force_align_arg_pointer)) _start(void) {
     test();
     MY_exit(0);
 }


### PR DESCRIPTION
When the freestanding test is built with any kind of optimization that enables vectorized loops, special care must be taken to align the stack for _start() at a 16-byte boundary.

Fixes: #1466 
