### PR TITLE
Fix building freestanding test with clang & enabled stack protector

### DIFF
--- a/build/meson/meson/tests/meson.build
+++ b/build/meson/meson/tests/meson.build
@@ -47,7 +47,7 @@ test_exes = {
   },
   'freestanding': {
     'sources': files(lz4_source_root / 'tests/freestanding.c'),
-    'c_args': ['-ffreestanding', '-Wno-unused-parameter', '-Wno-declaration-after-statement'],
+    'c_args': ['-ffreestanding', '-fno-stack-protector', '-Wno-unused-parameter', '-Wno-declaration-after-statement'],
     'link_args': ['-nostdlib'],
     'build': cc.get_id() in ['gcc', 'clang'] and
       host_machine.system() == 'linux' and host_machine.cpu_family() == 'x86_64',


### PR DESCRIPTION
The freestanding test is special as it requires reimplementation of runtime/toolchain functionality. When building with clang where the compiler might be configured to enable the stack-protector by default, building the test fails due to missing __stack_chk_fail symbols; gcc automatically disables the stack-protector when `-ffreestanding` is enabled.
Thefore disable stack protection specifically for this test.
