### PR TITLE
Fix file size check in LZ4F_readOpen

### DIFF
--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -93,7 +93,7 @@ LZ4F_errorCode_t LZ4F_readOpen(LZ4_readFile_t** lz4fRead, FILE* fp)
 
   (*lz4fRead)->fp = fp;
   consumedSize = fread(buf, 1, sizeof(buf), (*lz4fRead)->fp);
-  if (consumedSize != sizeof(buf)) {
+  if (consumedSize < LZ4F_HEADER_SIZE_MIN + LZ4F_ENDMARK_SIZE) {
     LZ4F_freeAndNullReadFile(lz4fRead);
     RETURN_ERROR(io_read);
   }

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -289,6 +289,9 @@ LZ4FLIB_API LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctx);
 /* Size in bytes of the content checksum. */
 #define LZ4F_CONTENT_CHECKSUM_SIZE 4
 
+/* Size in bytes of the endmark. */
+#define LZ4F_ENDMARK_SIZE 4
+
 /*! LZ4F_compressBegin() :
  *  will write the frame header into dstBuffer.
  *  dstCapacity must be >= LZ4F_HEADER_SIZE_MAX bytes.


### PR DESCRIPTION
When the size of the opened compressed file is less than LZ4F_HEADER_SIZE_MAX (19) bytes, LZ4F_readOpen() will return an io_read error code. The minimum compressed file size is LZ4F_HEADER_SIZE_MIN + LZ4F_ENDMARK_SIZE.

Fix to check the file size with minimum size.

Test with data [a.txt]( https://corpus.canterbury.ac.nz/descriptions/artificl/a.html)
Before this patch:
./fileCompress a.txt
inp = [a.txt]
lz4 = [a.txt.lz4]
dec = [a.txt.lz4.dec]
compress : a.txt -> a.txt.lz4
a.txt: 1 → 16 bytes, 1600.0%
compress : done
decompress : a.txt.lz4 -> a.txt.lz4.dec
LZ4F_readOpen error: ERROR_io_read
compression error: Unspecified error code

After this patch:
$./fileCompress a.txt
inp = [a.txt]
lz4 = [a.txt.lz4]
dec = [a.txt.lz4.dec]
compress : a.txt -> a.txt.lz4
a.txt: 1 → 16 bytes, 1600.0%
compress : done
decompress : a.txt.lz4 -> a.txt.lz4.dec
decompress : done
verify : a.txt <-> a.txt.lz4.dec
verify : OK