### PR TITLE
meson: do not force c99 mode

### DIFF
--- a/build/meson/meson.build
+++ b/build/meson/meson.build
@@ -16,7 +16,6 @@ project(
   'c',
   license: 'BSD-2-Clause-Patent AND GPL-2.0-or-later',
   default_options: [
-    'c_std=c99',
     'buildtype=release',
     'warning_level=3'
   ],


### PR DESCRIPTION
On Solaris/OpenIndiana hosts forcing (old) C99 means disabling POSIX 2001 functionality, resulting in errors like

In file included from ../../../net/ptah/export/gentoo/working-repos/lz4/programs/bench.c:39: ../../../net/ptah/export/gentoo/working-repos/lz4/programs/util.h: In function  UTIL_getOpenFileSize’: ../../../net/ptah/export/gentoo/working-repos/lz4/programs/util.h:156:23: error: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
  156 | #  define UTIL_fileno fileno
      |                       ^~~~~~
../../../net/ptah/export/gentoo/working-repos/lz4/programs/util.h:325:10: note: in expansion of macro ‘UTIL_fileno’
  325 |     fd = UTIL_fileno(file);
      |          ^~~~~~~~~~~

These can be fixed either by forcing a standard to be applied in programs/platform.h or by not forcing the compiler to use an old standard.

Since CMake and Makefile don't force C99 by default either, just drop it from meson.build.