### PR TITLE
CMakeLists.txt: respect global CMAKE_POSITION_INDEPENDENT_CODE flag

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -85,11 +85,13 @@ list(APPEND LZ4_CLI_SOURCES ${LZ4_SOURCES}) # LZ4_CLI always use liblz4 sources 
 # Whether to use position independent code for the static library.  If
 # we're building a shared library this is ignored and PIC is always
 # used.
-if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
-  option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ON)
+if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE OR CMAKE_POSITION_INDEPENDENT_CODE)
+  set(LZ4_POSITION_INDEPENDENT_LIB_DEFAULT ON)
 else()
-  set(LZ4_POSITION_INDEPENDENT_LIB OFF CACHE BOOL "Use position independent code for static library (if applicable)" FORCE)
+  set(LZ4_POSITION_INDEPENDENT_LIB_DEFAULT OFF)
 endif()
+
+option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ${LZ4_POSITION_INDEPENDENT_LIB_DEFAULT})
 
 # liblz4
 include(GNUInstallDirs)

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -85,7 +85,11 @@ list(APPEND LZ4_CLI_SOURCES ${LZ4_SOURCES}) # LZ4_CLI always use liblz4 sources 
 # Whether to use position independent code for the static library.  If
 # we're building a shared library this is ignored and PIC is always
 # used.
-option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ON)
+if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+  option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ON)
+else()
+  set(LZ4_POSITION_INDEPENDENT_LIB OFF CACHE BOOL "Use position independent code for static library (if applicable)" FORCE)
+endif()
 
 # liblz4
 include(GNUInstallDirs)


### PR DESCRIPTION
This is a minor change to the CMake build script to facilitate integrating this library as a (possibly nested) dependency of a project which disables PIC.

I'm aware that upstream code would be capable of setting `LZ4_POSITION_INDEPENDENT_LIB`, but this solution is the most natural to allow a top-level project to configure the option for many dependent libraries at once without needing to maintain patches for each one.

Thanks for your consideration!

(Sorry for the force push. I only realized that the patch should be based on the dev branch after seeing GitHub's UI.)