### PR TITLE
build/meson: avoid passing long options to `ln`

### DIFF
--- a/build/meson/README.md
+++ b/build/meson/README.md
@@ -10,7 +10,7 @@ This Meson build system is provided with no guarantee.
 
 ## How to build
 
-`cd` to this meson directory (`contrib/meson`)
+`cd` to this meson directory (`build/meson`)
 
 ```sh
 meson setup --buildtype=release -Ddefault_library=shared -Dprograms=true builddir

--- a/build/meson/meson/programs/meson.build
+++ b/build/meson/meson/programs/meson.build
@@ -49,8 +49,8 @@ lz4cat = custom_target(
   output: 'lz4cat',
   command: [
     'ln',
-    '--symbolic',
-    '--force',
+    '-s',
+    '-f',
     fs.name(lz4.full_path()),
     '@OUTPUT@'
   ]
@@ -62,8 +62,8 @@ unlz4 = custom_target(
   output: 'unlz4',
   command: [
     'ln',
-    '--symbolic',
-    '--force',
+    '-s',
+    '-f',
     fs.name(lz4.full_path()),
     '@OUTPUT@'
   ]


### PR DESCRIPTION
On macOS, `ln` only supports short options.

Also update directory path in README.