### PR TITLE
build: use `uname -m` to detect processor

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -367,7 +367,7 @@ test-decompress-partial : decompress-partial decompress-partial-usingDict
 # freestanding test only for Linux x86_64
 #-----------------------------------------------------------------------------
 UNAME_S ?= $(if $(filter Windows_NT,$(OS)),Windows,$(shell uname -s))
-UNAME_P ?= $(if $(filter Windows_NT,$(OS)),Unknown,$(shell uname -p))
+UNAME_M ?= $(if $(filter Windows_NT,$(OS)),Unknown,$(shell uname -m))
 
 FREESTANDING_CFLAGS := -ffreestanding -nostdlib
 
@@ -375,7 +375,7 @@ ifneq ($(UNAME_S), Linux)
   FREESTANDING_CFLAGS :=
 endif
 
-ifneq ($(UNAME_P), x86_64)
+ifneq ($(UNAME_M), x86_64)
   FREESTANDING_CFLAGS :=
 endif
 


### PR DESCRIPTION
Ubuntu [patches](https://git.launchpad.net/ubuntu/+source/coreutils/tree/debian/patches/80_fedora_sysinfo.patch?h=ubuntu/oracular) `uname -p` to return the processor type, and Fedora also did [before Fedora 38](https://src.fedoraproject.org/rpms/coreutils/c/cd953e11dd78cada371f0389171cea671949141b), but in general, `uname -p` returns `unknown`.  Use `uname -m` instead.

Fixes build error:

    /usr/bin/ld: /tmp/ccgv9E4e.o: in function `_start':
    freestanding.c:(.text+0x6255a): multiple definition of `_start'; /usr/lib/gcc/x86_64-redhat-linux/14/../../../../lib64/crt1.o:(.text+0x0): first defined here
    collect2: error: ld returned 1 exit status