### PR TITLE
build/meson: force `LZ4_DEBUG=0` for `tests/freestanding`

### DIFF
--- a/build/meson/meson/tests/meson.build
+++ b/build/meson/meson/tests/meson.build
@@ -47,7 +47,7 @@ test_exes = {
   },
   'freestanding': {
     'sources': files(lz4_source_root / 'tests/freestanding.c'),
-    'c_args': ['-ffreestanding', '-fno-stack-protector', '-Wno-unused-parameter', '-Wno-declaration-after-statement'],
+    'c_args': ['-ffreestanding', '-fno-stack-protector', '-Wno-unused-parameter', '-Wno-declaration-after-statement', '-DLZ4_DEBUG=0'],
     'link_args': ['-nostdlib'],
     'build': cc.get_id() in ['gcc', 'clang'] and
       host_machine.system() == 'linux' and host_machine.cpu_family() == 'x86_64',


### PR DESCRIPTION
Match the Makefile, which never sets `LZ4_DEBUG` for this test.  If `LZ4_DEBUG` is non-zero, `lib/lz4.c` `#include`s `<assert.h>`, the musl version of which has a [conflicting definition](https://www.openwall.com/lists/musl/2019/03/04/6) for `__assert_fail`.

Fixes build failure:

    ../../../tests/freestanding.c:173:6: error: conflicting types for '__assert_fail'; have 'void(const char *, const char *, unsigned int,  const char *)'
      173 | void __assert_fail(const char * assertion, const char * file, unsigned int line, const char * function) {
          |      ^~~~~~~~~~~~~
    In file included from ../../../tests/../lib/lz4.c:270,
                     from ../../../tests/freestanding.c:49:
    /usr/include/assert.h:19:16: note: previous declaration of '__assert_fail' with type 'void(const char *, const char *, int,  const char *)'
       19 | _Noreturn void __assert_fail (const char *, const char *, int, const char *);
          |                ^~~~~~~~~~~~~