### PR TITLE
Fix examples dictionary random access

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -35,6 +35,7 @@ WFLAGS     = -std=gnu99 -Wall -Wextra -Wundef -Wshadow -Wcast-align -Wstrict-pro
 CFLAGS     = $(WFLAGS) -O2 $(USERCFLAGS)
 
 TESTFILE   = Makefile
+TESTFILE_SMALL= .gitignore
 SLIBLZ4   := $(LIBDIR)/liblz4.a
 LZ4DIR     = ../programs
 LZ4        = $(LZ4DIR)/lz4
@@ -80,6 +81,7 @@ test : all $(LZ4)
 	./blockStreaming_lineByLine$(EXT) $(TESTFILE)
 	@echo "\n=== Dictionary Random Access ==="
 	./dictionaryRandomAccess$(EXT) $(TESTFILE) $(TESTFILE) 1100 1400
+	./dictionaryRandomAccess$(EXT) $(TESTFILE_SMALL) $(TESTFILE_SMALL) 0 32
 	@echo "\n=== Frame compression ==="
 	./frameCompress$(EXT) $(TESTFILE)
 	$(LZ4) -vt $(TESTFILE).lz4

--- a/examples/dictionaryRandomAccess.c
+++ b/examples/dictionaryRandomAccess.c
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
         FILE* outFp = fopen(decFilename, "wb");
 
         printf("decompress : %s -> %s\n", lz4Filename, decFilename);
-        test_decompress(outFp, inpFp, dict, DICTIONARY_BYTES, offset, length);
+        test_decompress(outFp, inpFp, dict, dictSize, offset, length);
         printf("decompress : done\n");
 
         fclose(outFp);


### PR DESCRIPTION
This PR adds a new test to reproduce (and will prevent) the issue, and fixes it.

- 184ffbd fails the test (as intended)
- 855a097 pass the test

<details>

<summary>How to test this PR</summary>

```sh
cd
git clone https://github.com/lz4/lz4.git lz4-pr-1544
cd lz4-pr-1544
git pull origin pull/1544/head

# NG
git checkout 184ffbd
make -C examples clean test
#
# === Dictionary Random Access ===
# ...
# verify : .gitignore <-> .gitignore.lz4s-1024.dec
# verify : NG
#


# OK
git checkout 855a097
make -C examples clean test
#
# === Dictionary Random Access ===
# ...
# verify : .gitignore <-> .gitignore.lz4s-1024.dec
# verify : OK
#
```

</details>
