### PR TITLE
Specify parameters for repology status

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Most distributions are bundled with a package manager
 which allows easy installation of both the `liblz4` library
 and the `lz4` command line interface.
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/lz4.svg)](https://repology.org/project/lz4/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/lz4.svg?columns=4&exclude_unsupported=1)](https://repology.org/project/lz4/versions)
 
 
 ### Special Thanks


### PR DESCRIPTION
Make the repology badge display 4 columns.
This will prevent the repology badge from stretching too much vertically.
However, when viewed on a tablet computer (larger than a smartphone), the text is affected by the screen and becomes smaller, but I think it can be read without zooming in.

Also, since repositories that are out of date or unsupported can be trimmed, I also added a parameter for that purpose.

I have provided a preview of the difference in how it looks in columns 3, 4 and 5.

  - 3 columns
    https://github.com/dearblue/lz4/blob/0de5853cdb6d719002130b32cd49a6520f952e13/README.md#packaging-status
  - 4 columns (this PR)
    https://github.com/dearblue/lz4/blob/17c36d9c9ed5fdd81deda2e642aa742139b2dde2/README.md#packaging-status
  - 5 columns
    https://github.com/dearblue/lz4/blob/702d9fe236916c102223f569369baf585008b959/README.md#packaging-status

Further information on the parameters can be found at https://repology.org/project/lz4/badges.
:crying_cat_face: Unfortunately, there is no proper anchor, so to check, try searching the page with `exclude_unsupported=1`.
