### PR TITLE
fixed minor static analyzer warning in fileCompress example

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -258,10 +258,12 @@ LZ4LIB_API int LZ4_compress_fast_extState (void* state, const char* src, char* d
  * @return : Nb bytes written into 'dst' (necessarily <= dstCapacity)
  *           or 0 if compression fails.
  *
- * Note : from v1.8.2 to v1.9.1, this function had a bug (fixed in v1.9.2+):
- *        the produced compressed content could, in specific circumstances,
- *        require to be decompressed into a destination buffer larger
- *        by at least 1 byte than the content to decompress.
+ * Note : 'targetDstSize' must be >= 1, because it's the smallest valid lz4 payload.
+ *
+ * Note 2:from v1.8.2 to v1.9.1, this function had a bug (fixed in v1.9.2+):
+ *        the produced compressed content could, in rare circumstances,
+ *        require to be decompressed into a destination buffer
+ *        larger by at least 1 byte than decompressesSize.
  *        If an application uses `LZ4_compress_destSize()`,
  *        it's highly recommended to update liblz4 to v1.9.2 or better.
  *        If this can't be done or ensured,

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -262,6 +262,30 @@ static void LZ4HC_init_internal (LZ4HC_CCtx_internal* hc4, const BYTE* start)
 /**************************************
 *  Encode
 **************************************/
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
+# define RAWLOG(...) fprintf(stderr, __VA_ARGS__)
+void LZ4HC_hexOut(const void* src, size_t len)
+{
+    const BYTE* p = (const BYTE*)src;
+    size_t n;
+    for (n=0; n<len; n++) {
+        RAWLOG("%02X ", p[n]);
+    }
+    RAWLOG(" \n");
+}
+
+# define HEX_CMP(_lev, _ptr, _ref, _len) \
+    if (LZ4_DEBUG >= _lev) {            \
+        RAWLOG("match bytes: ");        \
+        LZ4HC_hexOut(_ptr, _len);       \
+        RAWLOG("ref bytes: ");          \
+        LZ4HC_hexOut(_ref, _len);       \
+    }
+
+#else
+# define HEX_CMP(l,p,r,_l)
+#endif
+
 /* LZ4HC_encodeSequence() :
  * @return : 0 if ok,
  *           1 if buffer issue detected */
@@ -278,47 +302,49 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 #define op      (*_op)
 #define anchor  (*_anchor)
 
-    size_t length;
     BYTE* const token = op++;
 
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 6)
     static const BYTE* start = NULL;
     static U32 totalCost = 0;
-    U32 const pos = (start==NULL) ? 0 : (U32)(anchor - start);
+    U32 const pos = (start==NULL) ? 0 : (U32)(anchor - start); /* only works for single segment */
     U32 const ll = (U32)(ip - anchor);
     U32 const llAdd = (ll>=15) ? ((ll-15) / 255) + 1 : 0;
     U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
     U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
     if (start==NULL) start = anchor;  /* only works for single segment */
-    /* g_debuglog_enable = (pos >= 2228) & (pos <= 2262); */
     DEBUGLOG(6, "pos:%7u -- literals:%4u, match:%4i, offset:%5i, cost:%4u + %5u",
                 pos,
                 (U32)(ip - anchor), matchLength, offset,
                 cost, totalCost);
+# if 1 /* only works on single segment data */
+    HEX_CMP(7, ip, ip-offset, matchLength);
+# endif
     totalCost += cost;
 #endif
 
     /* Encode Literal length */
-    length = (size_t)(ip - anchor);
-    LZ4_STATIC_ASSERT(notLimited == 0);
-    /* Check output limit */
-    if (limit && ((op + (length / 255) + length + (2 + 1 + LASTLITERALS)) > oend)) {
-        DEBUGLOG(6, "Not enough room to write %i literals (%i bytes remaining)",
-                (int)length, (int)(oend - op));
-        return 1;
-    }
-    if (length >= RUN_MASK) {
-        size_t len = length - RUN_MASK;
-        *token = (RUN_MASK << ML_BITS);
-        for(; len >= 255 ; len -= 255) *op++ = 255;
-        *op++ = (BYTE)len;
-    } else {
-        *token = (BYTE)(length << ML_BITS);
-    }
+    {   size_t litLen = (size_t)(ip - anchor);
+        LZ4_STATIC_ASSERT(notLimited == 0);
+        /* Check output limit */
+        if (limit && ((op + (litLen / 255) + litLen + (2 + 1 + LASTLITERALS)) > oend)) {
+            DEBUGLOG(6, "Not enough room to write %i literals (%i bytes remaining)",
+                    (int)litLen, (int)(oend - op));
+            return 1;
+        }
+        if (litLen >= RUN_MASK) {
+            size_t len = litLen - RUN_MASK;
+            *token = (RUN_MASK << ML_BITS);
+            for(; len >= 255 ; len -= 255) *op++ = 255;
+            *op++ = (BYTE)len;
+        } else {
+            *token = (BYTE)(litLen << ML_BITS);
+        }
 
-    /* Copy Literals */
-    LZ4_wildCopy8(op, anchor, op + length);
-    op += length;
+        /* Copy Literals */
+        LZ4_wildCopy8(op, anchor, op + litLen);
+        op += litLen;
+    }
 
     /* Encode Offset */
     assert(offset <= LZ4_DISTANCE_MAX );
@@ -327,20 +353,20 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 
     /* Encode MatchLength */
     assert(matchLength >= MINMATCH);
-    length = (size_t)matchLength - MINMATCH;
-    if (limit && (op + (length / 255) + (1 + LASTLITERALS) > oend)) {
-        DEBUGLOG(6, "Not enough room to write match length");
-        return 1;   /* Check output limit */
-    }
-    if (length >= ML_MASK) {
-        *token += ML_MASK;
-        length -= ML_MASK;
-        for(; length >= 510 ; length -= 510) { *op++ = 255; *op++ = 255; }
-        if (length >= 255) { length -= 255; *op++ = 255; }
-        *op++ = (BYTE)length;
-    } else {
-        *token += (BYTE)(length);
-    }
+    {   size_t mlCode = (size_t)matchLength - MINMATCH;
+        if (limit && (op + (mlCode / 255) + (1 + LASTLITERALS) > oend)) {
+            DEBUGLOG(6, "Not enough room to write match length");
+            return 1;   /* Check output limit */
+        }
+        if (mlCode >= ML_MASK) {
+            *token += ML_MASK;
+            mlCode -= ML_MASK;
+            for(; mlCode >= 510 ; mlCode -= 510) { *op++ = 255; *op++ = 255; }
+            if (mlCode >= 255) { mlCode -= 255; *op++ = 255; }
+            *op++ = (BYTE)mlCode;
+        } else {
+            *token += (BYTE)(mlCode);
+    }   }
 
     /* Prepare next loop */
     ip += matchLength;
@@ -944,6 +970,7 @@ LZ4HC_InsertAndGetWiderMatch (
                         offset = (int)(ipIndex - matchIndex);
                         sBack = back;
                         DEBUGLOG(7, "Found match of len=%i within prefix, offset=%i, back=%i", longest, offset, -back);
+                        HEX_CMP(7, ip + back, ip + back - offset, (size_t)matchLength);
             }   }   }
         } else {   /* lowestMatchIndex <= matchIndex < dictLimit : within Ext Dict */
             const BYTE* const matchPtr = dictStart + (matchIndex - dictIdx);
@@ -963,6 +990,7 @@ LZ4HC_InsertAndGetWiderMatch (
                     offset = (int)(ipIndex - matchIndex);
                     sBack = back;
                     DEBUGLOG(7, "Found match of len=%i within dict, offset=%i, back=%i", longest, offset, -back);
+                    HEX_CMP(7, ip + back, matchPtr + back, (size_t)matchLength);
         }   }   }
 
         if (chainSwap && matchLength==longest) {   /* better match => select a better chain */

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1427,8 +1427,8 @@ LZ4HC_compress_generic_internal (
             const dictCtx_directive dict
             )
 {
-    DEBUGLOG(5, "LZ4HC_compress_generic_internal(src=%p, srcSize=%d)",
-                src, *srcSizePtr);
+    DEBUGLOG(5, "LZ4HC_compress_generic_internal(src=%p, srcSize=%d, dstCapacity=%d)",
+                src, *srcSizePtr, dstCapacity);
 
     /* input sanitization */
     if ((U32)*srcSizePtr > (U32)LZ4_MAX_INPUT_SIZE) return 0;  /* Unsupported input size (too large or negative) */

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -75,6 +75,7 @@ static const U32 nbTestsDefault = 256 KB;
 static const U32 prime1 = 2654435761U;
 static const U32 prime2 = 2246822519U;
 
+static const U64 extCrcSeed = 1;
 
 /*-************************************
 *  Macros
@@ -298,7 +299,7 @@ static int unitTests(U32 seed, double compressibility)
         goto _output_error;
     }
     FUZ_fillCompressibleNoiseBuffer(CNBuffer, COMPRESSIBLE_NOISE_LENGTH, compressibility, randState);
-    crcOrig = XXH64(CNBuffer, COMPRESSIBLE_NOISE_LENGTH, 1);
+    crcOrig = XXH64(CNBuffer, COMPRESSIBLE_NOISE_LENGTH, extCrcSeed);
 
     /* LZ4F_compressBound() : special case : srcSize == 0 */
     DISPLAYLEVEL(3, "LZ4F_compressBound(0) = ");
@@ -371,7 +372,7 @@ static int unitTests(U32 seed, double compressibility)
 
         DISPLAYLEVEL(3, "Single Pass decompression : ");
         CHECK( LZ4F_decompress(dCtx, decodedBuffer, &decodedBufferSize, compressedBuffer, &compressedBufferSize, NULL) );
-        { U64 const crcDest = XXH64(decodedBuffer, decodedBufferSize, 1);
+        { U64 const crcDest = XXH64(decodedBuffer, decodedBufferSize, extCrcSeed);
           if (crcDest != crcOrig) goto _output_error; }
         DISPLAYLEVEL(3, "Regenerated %u bytes \n", (U32)decodedBufferSize);
 
@@ -398,7 +399,7 @@ static int unitTests(U32 seed, double compressibility)
             if (decResult != 0) goto _output_error;   /* should finish now */
             op += oSize;
             if (op>oend) { DISPLAY("decompression write overflow \n"); goto _output_error; }
-            {   U64 const crcDest = XXH64(decodedBuffer, (size_t)(op-ostart), 1);
+            {   U64 const crcDest = XXH64(decodedBuffer, (size_t)(op-ostart), extCrcSeed);
                 if (crcDest != crcOrig) goto _output_error;
         }   }
 
@@ -471,7 +472,7 @@ static int unitTests(U32 seed, double compressibility)
                 op += oSize;
                 ip += iSize;
             }
-            {   U64 const crcDest = XXH64(decodedBuffer, COMPRESSIBLE_NOISE_LENGTH, 1);
+            {   U64 const crcDest = XXH64(decodedBuffer, COMPRESSIBLE_NOISE_LENGTH, extCrcSeed);
                 if (crcDest != crcOrig) goto _output_error;
             }
             DISPLAYLEVEL(3, "Regenerated %u/%u bytes \n", (unsigned)(op-ostart), (unsigned)COMPRESSIBLE_NOISE_LENGTH);
@@ -515,7 +516,7 @@ static int unitTests(U32 seed, double compressibility)
             ip += iSize;
         }
         {   size_t const decodedSize = (size_t)(op - ostart);
-            U64 const crcDest = XXH64(decodedBuffer, decodedSize, 1);
+            U64 const crcDest = XXH64(decodedBuffer, decodedSize, extCrcSeed);
             if (crcDest != crcOrig) goto _output_error;
             DISPLAYLEVEL(3, "Regenerated %u bytes \n", (U32)decodedSize);
          }
@@ -571,8 +572,8 @@ static int unitTests(U32 seed, double compressibility)
         CHECK( LZ4F_decompress(dctx, decodedBuffer, &decodedSize, compressedBuffer, &iSize, NULL) );
         if (decodedSize != testSize) goto _output_error;
         if (iSize != cSize) goto _output_error;
-        {   U64 const crcDest = XXH64(decodedBuffer, decodedSize, 1);
-            U64 const crcSrc = XXH64(CNBuffer, testSize, 1);
+        {   U64 const crcDest = XXH64(decodedBuffer, decodedSize, extCrcSeed);
+            U64 const crcSrc = XXH64(CNBuffer, testSize, extCrcSeed);
             if (crcDest != crcSrc) goto _output_error;
         }
         DISPLAYLEVEL(3, "Regenerated %u bytes \n", (U32)decodedSize);
@@ -1002,17 +1003,20 @@ static LZ4F_errorCode_t LZ4F_returnErrorCode(LZ4F_errorCodes code)
 #define RETURN_ERROR(e) return LZ4F_returnErrorCode(LZ4F_ERROR_ ## e)
 
 
-/* @return : 0 on success,
- * or LZ4F_ErrorCode */
+/* @o_scenario: output behavior: contiguous, non-contiguous, or overwrite
+ * @crcOrig: xxh64 of original data using extCrcSeed
+ * @return : 0 on success, or LZ4F_ErrorCode
+ * */
 size_t test_lz4f_decompression_wBuffers(
           const void* cSrc, size_t cSize,
-                void* dst, size_t dstCapacity, o_scenario_e o_scenario,
+                void* dst, size_t dstCapacity,
+                o_scenario_e o_scenario,
           const void* srcRef, size_t decompressedSize,
                 U64 crcOrig,
                 U32* const randState,
                 LZ4F_dctx* const dCtx,
                 U32 seed, U32 testNb,
-                int findErrorPos)
+                int shouldSucceed)
 {
     const BYTE* ip = (const BYTE*)cSrc;
     const BYTE* const iend = ip + cSize;
@@ -1025,7 +1029,8 @@ size_t test_lz4f_decompression_wBuffers(
     size_t totalOut = 0;
     size_t moreToFlush = 0;
     XXH64_state_t xxh64;
-    XXH64_reset(&xxh64, 1);
+    XXH64_reset(&xxh64, extCrcSeed);
+    o_scenario = o_contiguous;
     assert(ip < iend);
     while (ip < iend) {
         unsigned const nbBitsI = (FUZ_rand(randState) % (maxBits-1)) + 1;
@@ -1057,7 +1062,7 @@ size_t test_lz4f_decompression_wBuffers(
             moreToFlush = LZ4F_decompress(dCtx, tmpop, &oSize, tmpip, &iSize, &dOptions);
             free(iBuffer);
         }
-        DISPLAYLEVEL(7, "oSize=%u,  readSize=%u \n", (unsigned)oSize, (unsigned)iSize);
+        DISPLAYLEVEL(7, "oSize=%u, readSize=%u \n", (unsigned)oSize, (unsigned)iSize);
 
         if (sentinelTest) {
             CHECK(op[oSizeMax] != mark, "op[oSizeMax] = %02X != %02X : "
@@ -1065,11 +1070,14 @@ size_t test_lz4f_decompression_wBuffers(
                     op[oSizeMax], mark);
         }
         if (LZ4F_getErrorCode(moreToFlush) == LZ4F_ERROR_contentChecksum_invalid) {
-            if (findErrorPos) DISPLAYLEVEL(2, "checksum error detected \n");
-            if (findErrorPos) locateBuffDiff(srcRef, dst, decompressedSize, o_scenario);
+            if (shouldSucceed) DISPLAYLEVEL(1, "checksum error reported after decompressing segment with LZ4F_decompress() \n");
+            if (shouldSucceed) locateBuffDiff(srcRef, dst, decompressedSize, o_scenario);
             RETURN_ERROR(contentChecksum_invalid);
         }
-        if (LZ4F_isError(moreToFlush)) return moreToFlush;
+        if (LZ4F_isError(moreToFlush)) {
+            if (shouldSucceed) DISPLAYLEVEL(1, "error reported after decompressing segment with LZ4F_decompress() \n");
+            return moreToFlush;
+        }
 
         XXH64_update(&xxh64, op, oSize);
         totalOut += oSize;
@@ -1088,15 +1096,15 @@ size_t test_lz4f_decompression_wBuffers(
     if (totalOut) {  /* otherwise, it's a skippable frame */
         U64 const crcDecoded = XXH64_digest(&xxh64);
         if (crcDecoded != crcOrig) {
-            if (findErrorPos) locateBuffDiff(srcRef, dst, decompressedSize, o_scenario);
+            if (shouldSucceed) DISPLAYLEVEL(1, "checksum error detected at end of decompression \n");
+            if (shouldSucceed) locateBuffDiff(srcRef, dst, decompressedSize, o_scenario);
             RETURN_ERROR(contentChecksum_invalid);
     }   }
     return 0;
 }
 
 
-/* @return : 0 on success,
- * or LZ4F_ErrorCode */
+/* @return : 0 on success, or LZ4F_ErrorCode */
 size_t test_lz4f_decompression(const void* cSrc, size_t cSize,
                                const void* srcRef, size_t decompressedSize,
                                U64 crcOrig,
@@ -1108,7 +1116,7 @@ size_t test_lz4f_decompression(const void* cSrc, size_t cSize,
     o_scenario_e const o_scenario = (o_scenario_e)(FUZ_rand(randState) % 3);   /* 0 : contiguous; 1 : non-contiguous; 2 : dst overwritten */
     /* tighten dst buffer conditions */
     size_t const dstCapacity = (o_scenario == o_noncontiguous) ?
-                               (decompressedSize * 2) + 128 :
+                               (decompressedSize * 2) + 128 : /* should provide enough room to insert spaces beween blocks */
                                decompressedSize;
     size_t result;
     void* const dstBuffer = malloc(dstCapacity);
@@ -1165,7 +1173,7 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
         size_t const srcStartId = FUZ_rand(&randState) % (CNBufferLength - srcSize);
         const BYTE* const srcStart = (const BYTE*)CNBuffer + srcStartId;
         unsigned const neverFlush = (FUZ_rand(&randState) & 15) == 1;
-        U64 const crcOrig = XXH64(srcStart, srcSize, 1);
+        U64 const crcOrig = XXH64(srcStart, srcSize, extCrcSeed);
         LZ4F_preferences_t prefs;
         const LZ4F_preferences_t* prefsPtr = &prefs;
         size_t cSize;
@@ -1213,11 +1221,9 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                 size_t iSize = MIN(sampleMax, (size_t)(iend-ip));
                 size_t const oSize = LZ4F_compressBound(iSize, prefsPtr);
                 cOptions.stableSrc = ((FUZ_rand(&randState) & 3) == 1);
-                DISPLAYLEVEL(6, "Sending %u bytes to compress (stableSrc:%u) \n",
-                                (unsigned)iSize, cOptions.stableSrc);
 
 #if 1
-                /* insert uncompressed segment */
+                /* test inserting an uncompressed block */
                 if ( (iSize>0)
                   && !neverFlush   /* do not mess with compressBound when neverFlush is set */
                   && prefsPtr != NULL   /* prefs are set */
@@ -1225,6 +1231,7 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                   && (FUZ_rand(&randState) & 15) == 1 ) {
                     size_t const uSize = FUZ_rand(&randState) % iSize;
                     size_t const flushedSize = LZ4F_uncompressedUpdate(cCtx, op, (size_t)(oend-op), ip, uSize, &cOptions);
+                    DISPLAYLEVEL(6, "Actually sending %u bytes as uncompressed \n", (unsigned)uSize);
                     CHECK(LZ4F_isError(flushedSize), "Insert uncompressed data failed (error %i : %s)",
                             (int)flushedSize, LZ4F_getErrorName(flushedSize));
                     op += flushedSize;
@@ -1233,6 +1240,8 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                 }
 #endif
 
+                DISPLAYLEVEL(6, "Sending %u bytes to compress or buffer (stableSrc:%u) \n",
+                                (unsigned)iSize, cOptions.stableSrc);
                 {   size_t const flushedSize = LZ4F_compressUpdate(cCtx, op, oSize, ip, iSize, &cOptions);
                     CHECK(LZ4F_isError(flushedSize), "Compression failed (error %i : %s)",
                             (int)flushedSize, LZ4F_getErrorName(flushedSize));
@@ -1243,7 +1252,7 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                 {   unsigned const forceFlush = neverFlush ? 0 : ((FUZ_rand(&randState) & 3) == 1);
                     if (forceFlush) {
                         size_t const flushSize = LZ4F_flush(cCtx, op, (size_t)(oend-op), &cOptions);
-                        DISPLAYLEVEL(6,"flushing %u bytes \n", (unsigned)flushSize);
+                        DISPLAYLEVEL(6, "flushing %u bytes \n", (unsigned)flushSize);
                         CHECK(LZ4F_isError(flushSize), "Compression failed (error %i)", (int)flushSize);
                         op += flushSize;
                         if ((FUZ_rand(&randState) % 1024) == 3) {
@@ -1257,7 +1266,10 @@ int fuzzerTests(U32 seed, unsigned nbTests, unsigned startTest, double compressi
                                 op += 4;
                 }   }   }   }
             }  /* while (ip<iend) */
-            CHECK(op>=oend, "LZ4F_compressFrameBound overflow");
+
+            /* check compressBound guarantees */
+            if (neverFlush) CHECK(op>=oend, "LZ4F_compressFrameBound overflow");
+
             {   size_t const dstEndSafeSize = LZ4F_compressBound(0, prefsPtr);
                 int const tooSmallDstEnd = ((FUZ_rand(&randState) & 31) == 3);
                 size_t const dstEndTooSmallSize = (FUZ_rand(&randState) % dstEndSafeSize) + 1;


### PR DESCRIPTION
In the process, discovered a test that was no longer firing in case of error.
Fixing it uncovered a bug that has been silently around since a few PR : 
flushing a single byte with `LZ4F_flush()` would impact the internal indexing scheme within the `lz4hc` state.
So fixing it too, and in the process improved traces a bit, which ended up being a big lion share of this PR.
After that, found another (test) bug, which might have been drowned by the previous issue, and fixed it too.