### PR TITLE
Update util.h

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -191,7 +191,7 @@ UTIL_STATIC void* UTIL_realloc(void* ptr, size_t size)
 {
     void* const newptr = realloc(ptr, size);
     if (newptr) return newptr;
-    free(ptr);
+    if (size!=0) free(ptr);
     return NULL;
 }
 


### PR DESCRIPTION
double-free risk in UTIL_realloc :
The UTIL_realloc function is used to resize a memory block allocated by malloc, calloc, or realloc. In glibc, when realloc(ptr, 0) is called, it is equivalent to free(ptr) and returns NULL. This behavior is implementation-defined, and while glibc handles it safely, it can lead to confusion and potential double-free issues if not managed correctly.