### PR TITLE
meson: fix broken oss-fuzz support

### DIFF
--- a/build/meson/meson/ossfuzz/meson.build
+++ b/build/meson/meson/ossfuzz/meson.build
@@ -1,3 +1,5 @@
+lz4_source_root = '../../../..'
+
 fuzzers = [
   'compress_frame_fuzzer',
   'compress_fuzzer',


### PR DESCRIPTION
Regression in original introduction in commit 198e532300f253ada3acac3ab5428ed991adb085.

Every meson file in the repository must have this variable set, to an appropriate per-file value, in order to cater to the split buildsystem design where the build files are stored in a subdirectory away from the source code.

If ossfuzz is enabled, this file is processed and the missing value will come from some other file instead, which may not be correct.

- Using default values, ossfuzz is enabled but no other subdirs are, other than of course lib, which has a coincidentally identical value, and everything works.

- If contrib is enabled, it will set the per-file variable to a value that is *not* coincidentally the same as ossfuzz.

- If examples is enabled, it will set the per-file variable to a value that is coincidentally the same as ossfuzz... and do so later than contrib.

So, if contrib is enabled but examples is not, then the ossfuzz directory fails to process correctly and the build aborts. Fix this by explicitly adding the correct per-file variable.

Fixes: https://github.com/lz4/lz4/issues/1559