### PR TITLE
Fix theoretical risk of double-free in UTIL_realloc()

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -185,13 +185,20 @@ int UTIL_countCores(void);
 ******************************************/
 /*
  * A modified version of realloc().
- * If UTIL_realloc() fails the original block is freed.
-*/
-UTIL_STATIC void* UTIL_realloc(void* ptr, size_t size)
+ * Original block is always freed.
+ */
+UTIL_STATIC void* UTIL_realloc(void* prevPtr, size_t newSize)
 {
-    void* const newptr = realloc(ptr, size);
-    if (newptr) return newptr;
-    free(ptr);
+    if (newSize == 0) {
+        free(prevPtr);
+        return NULL;
+    }
+    /* newSize > 0 */
+    {   void* const newptr = realloc(prevPtr, newSize);
+        if (newptr) return newptr;
+    }
+    /* realloc failed */
+    free(prevPtr);
     return NULL;
 }
 


### PR DESCRIPTION
if the function was called with a `0` argument (which is never the case, but let's fix it nonetheless).

This PR replaces #1565