### PR TITLE
Replaced uint8_t with unsigned char in BYTE typedef for post C99/C++

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -301,12 +301,12 @@ static int LZ4_isAligned(const void* ptr, size_t alignment)
 #include <limits.h>
 #if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
 # include <stdint.h>
-  typedef  uint8_t BYTE;
-  typedef uint16_t U16;
-  typedef uint32_t U32;
-  typedef  int32_t S32;
-  typedef uint64_t U64;
-  typedef uintptr_t uptrval;
+  typedef unsigned char BYTE; /*uint8_t not necessarily blessed to alias arbitrary type*/
+  typedef uint16_t      U16;
+  typedef uint32_t      U32;
+  typedef  int32_t      S32;
+  typedef uint64_t      U64;
+  typedef uintptr_t     uptrval;
 #else
 # if UINT_MAX != 4294967295UL
 #   error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -700,10 +700,10 @@ int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int*
 
 #if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
 # include <stdint.h>
-  typedef  int8_t  LZ4_i8;
-  typedef uint8_t  LZ4_byte;
-  typedef uint16_t LZ4_u16;
-  typedef uint32_t LZ4_u32;
+  typedef int8_t         LZ4_i8;
+  typedef unsigned char  LZ4_byte;
+  typedef uint16_t       LZ4_u16;
+  typedef uint32_t       LZ4_u32;
 #else
   typedef   signed char  LZ4_i8;
   typedef unsigned char  LZ4_byte;


### PR DESCRIPTION
Uint8_t is not necessarily a typedef for char or unsigned char (or std::byte), for this reason, it can be undefined behavior to read or modify arbitrary data through it.

Ideally, we would select uint8_t anyway if it happens to alias one of the types permitted to read or modify arbitrary data, but I don't think it can be implemented without _Generic() 

The types in header are commented as not part of public api so this should not result in ABI break for those who heed the warning. There is no such warning in the .c but I would presume that is only because it is taken for granted.

