### PR TITLE
fix(segv): add  null pointer assertions for file pointers in example files

### DIFF
--- a/examples/blockStreaming_doubleBuffer.c
+++ b/examples/blockStreaming_doubleBuffer.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 enum {
     BLOCK_BYTES = 1024 * 8,
@@ -38,6 +39,8 @@ size_t read_bin(FILE* fp, void* array, size_t arrayBytes) {
 
 void test_compress(FILE* outFp, FILE* inpFp)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_stream_t lz4Stream_body;
     LZ4_stream_t* lz4Stream = &lz4Stream_body;
 
@@ -73,6 +76,8 @@ void test_compress(FILE* outFp, FILE* inpFp)
 
 void test_decompress(FILE* outFp, FILE* inpFp)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_streamDecode_t lz4StreamDecode_body;
     LZ4_streamDecode_t* lz4StreamDecode = &lz4StreamDecode_body;
 
@@ -115,6 +120,8 @@ void test_decompress(FILE* outFp, FILE* inpFp)
 int compare(FILE* fp0, FILE* fp1)
 {
     int result = 0;
+
+    assert(fp0 != NULL); assert(fp1 != NULL);
 
     while(0 == result) {
         char b0[65536];

--- a/examples/blockStreaming_lineByLine.c
+++ b/examples/blockStreaming_lineByLine.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static size_t write_uint16(FILE* fp, uint16_t i)
 {
@@ -40,6 +41,8 @@ static void test_compress(
     size_t messageMaxBytes,
     size_t ringBufferBytes)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_stream_t* const lz4Stream = LZ4_createStream();
     const size_t cmpBufBytes = LZ4_COMPRESSBOUND(messageMaxBytes);
     char* const cmpBuf = (char*) malloc(cmpBufBytes);
@@ -89,6 +92,8 @@ static void test_decompress(
     size_t messageMaxBytes,
     size_t ringBufferBytes)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_streamDecode_t* const lz4StreamDecode = LZ4_createStreamDecode();
     char* const cmpBuf = (char*) malloc(LZ4_COMPRESSBOUND(messageMaxBytes));
     char* const decBuf = (char*) malloc(ringBufferBytes);
@@ -123,6 +128,8 @@ static void test_decompress(
 
 static int compare(FILE* f0, FILE* f1)
 {
+    assert(f0 != NULL); assert(f1 != NULL);
+
     int result = 0;
     const size_t tempBufferBytes = 65536;
     char* const b0 = (char*) malloc(tempBufferBytes);

--- a/examples/dictionaryRandomAccess.c
+++ b/examples/dictionaryRandomAccess.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #define MIN(x, y)  ((x) < (y) ? (x) : (y))
 
@@ -55,6 +56,8 @@ void seek_bin(FILE* fp, long offset, int origin) {
 
 void test_compress(FILE* outFp, FILE* inpFp, void *dict, int dictSize)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_stream_t lz4Stream_body;
     LZ4_stream_t* lz4Stream = &lz4Stream_body;
 
@@ -104,6 +107,8 @@ void test_compress(FILE* outFp, FILE* inpFp, void *dict, int dictSize)
 
 void test_decompress(FILE* outFp, FILE* inpFp, void *dict, int dictSize, int offset, int length)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_streamDecode_t lz4StreamDecode_body;
     LZ4_streamDecode_t* lz4StreamDecode = &lz4StreamDecode_body;
 
@@ -174,6 +179,8 @@ int compare(FILE* fp0, FILE* fp1, int length)
 {
     int result = 0;
 
+    assert(fp0 != NULL); assert(fp1 != NULL);
+
     while(0 == result) {
         char b0[4096];
         char b1[4096];
@@ -225,9 +232,13 @@ int main(int argc, char* argv[])
     printf("offset = [%d]\n", offset);
     printf("length = [%d]\n", length);
 
+    assert(offset < INT32_MAX); assert(length < INT32_MAX);
+
     /* Load dictionary */
     {
         FILE* dictFp = fopen(dictFilename, "rb");
+
+        assert(dictFp != NULL);
         dictSize = (int)read_bin(dictFp, dict, DICTIONARY_BYTES);
         fclose(dictFp);
     }
@@ -262,6 +273,8 @@ int main(int argc, char* argv[])
     {
         FILE* inpFp = fopen(inpFilename, "rb");
         FILE* decFp = fopen(decFilename, "rb");
+
+        assert(inpFp != NULL);assert(decFp != NULL);
         seek_bin(inpFp, offset, SEEK_SET);
 
         printf("verify : %s <-> %s\n", inpFilename, decFilename);

--- a/examples/streamingHC_ringBuffer.c
+++ b/examples/streamingHC_ringBuffer.c
@@ -56,6 +56,8 @@ size_t read_bin(FILE* fp, void* array, int arrayBytes) {
 
 void test_compress(FILE* outFp, FILE* inpFp)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     LZ4_streamHC_t lz4Stream_body = { 0 };
     LZ4_streamHC_t* lz4Stream = &lz4Stream_body;
 
@@ -91,6 +93,8 @@ void test_compress(FILE* outFp, FILE* inpFp)
 
 void test_decompress(FILE* outFp, FILE* inpFp)
 {
+    assert(outFp != NULL); assert(inpFp != NULL);
+
     static char decBuf[DEC_BUFFER_BYTES];
     int decOffset = 0;
     LZ4_streamDecode_t lz4StreamDecode_body = { 0 };
@@ -132,6 +136,8 @@ void test_decompress(FILE* outFp, FILE* inpFp)
 // return ByteNb>0 if different
 size_t compare(FILE* f0, FILE* f1)
 {
+    assert(f0 != NULL); assert(f1 != NULL);
+
     size_t result = 1;
 
     for (;;) {


### PR DESCRIPTION
I'm using some of the binaries in `./examples` for some unit tests and noticed that most of them don't check with assertions when opening a file descriptor for the input/output files.
I have also fixed the `INT32_MAX` value for the offset and length to prevent integer overflow.