### PR TITLE
fix(memory): add memory deallocation for srcBuff in roundTripCheck and loadFile functions

### DIFF
--- a/tests/abiTest.c
+++ b/tests/abiTest.c
@@ -97,7 +97,7 @@ static void roundTripTest(void* resultBuff, size_t resultBuffCapacity,
     }
 }
 
-static void roundTripCheck(const void* srcBuff, size_t srcSize)
+static void roundTripCheck(void* srcBuff, size_t srcSize)
 {
     size_t const cBuffSize = LZ4_COMPRESSBOUND(srcSize);
     void* const cBuff = malloc(cBuffSize);
@@ -105,6 +105,7 @@ static void roundTripCheck(const void* srcBuff, size_t srcSize)
 
     if (!cBuff || !rBuff) {
         fprintf(stderr, "not enough memory ! \n");
+        free(srcBuff);
         exit(1);
     }
 
@@ -156,15 +157,20 @@ static void loadFile(void* buffer, const char* fileName, size_t fileSize)
     FILE* const f = fopen(fileName, "rb");
     if (isDirectory(fileName)) {
         MSG("Ignoring %s directory \n", fileName);
+        free(buffer);
+        fclose(f);
         exit(2);
     }
     if (f==NULL) {
         MSG("Impossible to open %s \n", fileName);
+        free(buffer);
         exit(3);
     }
     {   size_t const readSize = fread(buffer, 1, fileSize, f);
         if (readSize != fileSize) {
             MSG("Error reading %s \n", fileName);
+            free(buffer);
+            fclose(f);
             exit(5);
     }   }
     fclose(f);

--- a/tests/roundTripTest.c
+++ b/tests/roundTripTest.c
@@ -124,7 +124,7 @@ static void roundTripTest(void* resultBuff, size_t resultBuffCapacity,
 
 }
 
-static void roundTripCheck(const void* srcBuff, size_t srcSize, int clevel)
+static void roundTripCheck(void* srcBuff, size_t srcSize, int clevel)
 {
     size_t const cBuffSize = LZ4_COMPRESSBOUND(srcSize);
     void* const cBuff = malloc(cBuffSize);
@@ -132,6 +132,7 @@ static void roundTripCheck(const void* srcBuff, size_t srcSize, int clevel)
 
     if (!cBuff || !rBuff) {
         fprintf(stderr, "not enough memory ! \n");
+        free(srcBuff);
         exit(1);
     }
 
@@ -184,15 +185,20 @@ static void loadFile(void* buffer, const char* fileName, size_t fileSize)
     FILE* const f = fopen(fileName, "rb");
     if (isDirectory(fileName)) {
         MSG("Ignoring %s directory \n", fileName);
+        free(buffer);
+        fclose(f);
         exit(2);
     }
     if (f==NULL) {
         MSG("Impossible to open %s \n", fileName);
+        free(buffer);
         exit(3);
     }
     {   size_t const readSize = fread(buffer, 1, fileSize, f);
         if (readSize != fileSize) {
             MSG("Error reading %s \n", fileName);
+            free(buffer);
+            fclose(f);
             exit(5);
     }   }
     fclose(f);


### PR DESCRIPTION
Here are some others minors memory leak found in `tests` files.
The issues occur when tests encounter unexpected conditions like non-existent files or when attempting to use directories as input files.

tested with valgrind : 
```bash
valgrind ./roundTripTest -9 no_exist_file
valgrind ./roundTripTest -9 dir_that_exist
```

Good night from France 😉