### PR TITLE
AIX build failure fix

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -81,7 +81,7 @@ VOID  := /dev/null
   endif
 endif
 
-ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD MINGW% CYGWIN% MSYS%,$(shell $(UNAME))))
+ifneq (,$(filter Linux Darwin GNU/kFreeBSD GNU OpenBSD FreeBSD NetBSD DragonFly SunOS Haiku MidnightBSD MINGW% CYGWIN% MSYS% AIX,$(shell $(UNAME))))
 POSIX_ENV = Yes
 else
 POSIX_ENV = No

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -76,6 +76,10 @@ else
 		SHARED_EXT_MAJOR = $(SHARED_EXT).$(LIBVER_MAJOR)
 		SHARED_EXT_VER = $(SHARED_EXT).$(LIBVER)
 	endif
+# AIX linker doesn't support -soname, hence assigning nil string
+ifeq ($(TARGET_OS), AIX)
+	SONAME_FLAGS =
+endif
 endif
 
 .PHONY: default


### PR DESCRIPTION
AIX entry added for POSIX_ENV.
SONAME_FLAGS variable assigned nil string since AIX linker doesn't support soname option.

Closure:#1597