### PR TITLE
Update cmake minimum required version

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -8,7 +8,7 @@
 # For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.16)
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 


### PR DESCRIPTION
Update cmake minimum required version to work with CMake v4 and shut up about the deprecation warning (for cmake_minimum_required < 3.10) on CMake v3.31+