### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/lib/liblz4.pc.in
+++ b/lib/liblz4.pc.in
@@ -9,6 +9,7 @@ includedir=@INCLUDEDIR@
 Name: lz4
 Description: extremely fast lossless compression algorithm library
 URL: http://www.lz4.org/
+License: BSD-2-Clause
 Version: @VERSION@
 Libs: -L${libdir} -llz4
 Cflags: -I${includedir}


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. T
his sets BSD-2-Clause to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116