### PR TITLE
Add a cmake 3.10 build and install test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,19 @@ jobs:
         cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
         VERBOSE=1 cmake --build build_test
 
+    - name: cmake minimum version v3.10 test
+      run: |
+        mkdir -p cmake_bins
+        cd cmake_bins
+        wget https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz -P cmake_bins
+        tar xzf cmake_bins/cmake-3.10.0-Linux-x86_64.tar.gz -C cmake_bins
+        mkdir -p cmake_build
+        mkdir -p cmake_install_test
+        cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --version
+        (cd cmake_build; ../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake ../build/cmake)
+        cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build cmake_build
+        DESTDIR="../cmake_install_test" cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build cmake_build --target install
+
   lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
     name: cmake (static lib)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,16 +626,43 @@ jobs:
 
     - name: cmake minimum version v3.10 test
       run: |
-        mkdir -p cmake_bins
-        cd cmake_bins
-        wget https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz -P cmake_bins
-        tar xzf cmake_bins/cmake-3.10.0-Linux-x86_64.tar.gz -C cmake_bins
-        mkdir -p cmake_build
-        mkdir -p cmake_install_test
-        cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --version
-        (cd cmake_build; ../cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake ../build/cmake)
-        cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build cmake_build
-        DESTDIR="../cmake_install_test" cmake_bins/cmake-3.10.0-Linux-x86_64/bin/cmake --build cmake_build --target install
+        CMAKE_VERSION="3.10.0"
+        CMAKE_MAJOR_MINOR="3.10"
+        BASE_DIR="$(pwd)"
+        DOWNLOAD_DIR="${BASE_DIR}/cmake_download"
+        CMAKE_BIN_DIR="${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64"
+        CMAKE_BIN="${CMAKE_BIN_DIR}/bin/cmake"
+        BUILD_DIR="${BASE_DIR}/cmake_build"
+        INSTALL_TEST_DIR="${BASE_DIR}/cmake_install_test"
+
+        # Create necessary directories
+        mkdir -p "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
+
+        # Download and extract CMake
+        echo "Downloading CMake ${CMAKE_VERSION}..."
+        wget "https://cmake.org/files/v${CMAKE_MAJOR_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -P "${DOWNLOAD_DIR}"
+        tar xzf "${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -C "${DOWNLOAD_DIR}"
+
+        # Verify CMake version
+        echo "Using CMake version:"
+        "${CMAKE_BIN}" --version
+
+        # Configure the build
+        echo "Configuring build..."
+        (cd "${BUILD_DIR}" && "${CMAKE_BIN}" "${BASE_DIR}/build/cmake")
+
+        # Build the project
+        echo "Building project..."
+        "${CMAKE_BIN}" --build "${BUILD_DIR}"
+
+        # Install to test directory
+        echo "Installing to test directory..."
+        DESTDIR="${INSTALL_TEST_DIR}" "${CMAKE_BIN}" --build "${BUILD_DIR}" --target install
+
+        echo "Test completed successfully with cmake ${CMAKE_VERSION}"
+
+        # cleaning
+        rm -rf "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
 
   lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
     name: cmake (static lib)

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@
 *.app
 lz4
 
+# Builders
+cmakebuild/
+builddir/
+
 # IDE / editors files
 .clang_complete
 .vscode
@@ -46,7 +50,9 @@ ld.exe*
 # test artifacts
 *.lz4
 tmp*
-builddir/
+cmake_bins/
+cmake_build/
+cmake_install_test/
 
 # generated Windows resource files
 lib/*.rc

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ ld.exe*
 # test artifacts
 *.lz4
 tmp*
+cmake_download/
 cmake_bins/
 cmake_build/
 cmake_install_test/


### PR DESCRIPTION
Ensures that the `CMakeLists.txt` script works with versions of `cmake` as old as `3.10`.