### PR TITLE
minor: removed year from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ in single-thread mode.
 [lzbench]: https://github.com/inikep/lzbench
 [Silesia Corpus]: http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia
 
-|  Compressor             | Ratio   | Compression | Decompression |
+|  Compressor             | Factor  | Compression | Decompression |
 |  ----------             | -----   | ----------- | ------------- |
 |  memcpy                 |  1.000  | 13700 MB/s  |  13700 MB/s   |
 |**LZ4 default (v1.9.0)** |**2.101**| **780 MB/s**| **4970 MB/s** |

--- a/lib/README.md
+++ b/lib/README.md
@@ -17,7 +17,7 @@ They generate and decode data using the [LZ4 block format].
 
 #### Level 2 : High Compression variant
 
-For more compression ratio at the cost of compression speed,
+For better compression ratio at the cost of compression speed,
 the High Compression variant called **lz4hc** is available.
 Add files **`lz4hc.c`** and **`lz4hc.h`**.
 This variant also compresses data using the [LZ4 block format],

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1,6 +1,6 @@
 /*
    LZ4 - Fast LZ compression algorithm
-   Copyright (C) 2011-2023, Yann Collet.
+   Copyright (c) Yann Collet. All rights reserved.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -1,7 +1,7 @@
 /*
  *  LZ4 - Fast LZ compression algorithm
  *  Header File
- *  Copyright (C) 2011-2023, Yann Collet.
+ *  Copyright (c) Yann Collet. All rights reserved.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -1,6 +1,6 @@
 /*
  * LZ4 file library
- * Copyright (C) 2022, Xiaomi Inc.
+ * Copyright (c) Yann Collet and LZ4 contributors. All rights reserved.
  *
  * BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
  *

--- a/lib/lz4file.h
+++ b/lib/lz4file.h
@@ -1,7 +1,8 @@
 /*
    LZ4 file library
    Header File
-   Copyright (C) 2022, Xiaomi Inc.
+   Copyright (c) Yann Collet and LZ4 contributors. All rights reserved.
+
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -1,6 +1,6 @@
 /*
  * LZ4 auto-framing library
- * Copyright (C) 2011-2016, Yann Collet.
+ * Copyright (c) Yann Collet. All rights reserved.
  *
  * BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
  *

--- a/lib/lz4frame.h
+++ b/lib/lz4frame.h
@@ -1,7 +1,8 @@
 /*
    LZ4F - LZ4-Frame library
    Header File
-   Copyright (C) 2011-2020, Yann Collet.
+   Copyright (c) Yann Collet. All rights reserved.
+
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without

--- a/lib/lz4frame_static.h
+++ b/lib/lz4frame_static.h
@@ -1,7 +1,7 @@
 /*
    LZ4 auto-framing library
    Header File for static linking only
-   Copyright (C) 2011-2020, Yann Collet.
+   Copyright (c) Yann Collet. All rights reserved.
 
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1,6 +1,6 @@
 /*
     LZ4 HC - High Compression Mode of LZ4
-    Copyright (C) 2011-2020, Yann Collet.
+    Copyright (c) Yann Collet. All rights reserved.
 
     BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -1,7 +1,7 @@
 /*
    LZ4 HC - High Compression Mode of LZ4
    Header File
-   Copyright (C) 2011-2020, Yann Collet.
+   Copyright (c) Yann Collet. All rights reserved.
    BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
 
    Redistribution and use in source and binary forms, with or without

--- a/programs/README.md
+++ b/programs/README.md
@@ -58,7 +58,7 @@ The files are then read entirely into memory, to eliminate I/O overhead.
 When multiple files are provided, they are bundled into the same benchmark session (though each file is a separate compression / decompression). Using `-S` command separates them (one session per file).
 When no file is provided, uses an internal Lorem Ipsum generator instead.
 
-The benchmark measures ratio, compressed size, compression and decompression speed.
+The benchmark measures compressed size, compression factor, compression and decompression speed.
 One can select multiple compression levels starting from `-b` and ending with `-e` (ascending).
 The `-i` parameter selects a number of seconds used for each session.
 

--- a/programs/bench.c
+++ b/programs/bench.c
@@ -1,6 +1,6 @@
 /*
     bench.c - Demo program to benchmark open-source compression algorithms
-    Copyright (C) Yann Collet 2012-2020
+    Copyright (c) Yann Collet. All rights reserved.
 
     GPL v2 License
 

--- a/programs/bench.h
+++ b/programs/bench.h
@@ -1,6 +1,6 @@
 /*
     bench.h - Demo program to benchmark open-source compression algorithm
-    Copyright (C) Yann Collet 2012-2020
+    Copyright (c) Yann Collet. All rights reserved.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/programs/lorem.c
+++ b/programs/lorem.c
@@ -1,6 +1,6 @@
 /*
     lorem.c - lorem ipsum generator
-    Copyright (C) Yann Collet 2024
+    Copyright (c) Yann Collet. All rights reserved.
 
     GPL v2 License
 

--- a/programs/lorem.h
+++ b/programs/lorem.h
@@ -1,6 +1,6 @@
 /*
     lorem.h - lorem ipsum generator
-    Copyright (C) Yann Collet 2024
+    Copyright (c) Yann Collet. All rights reserved.
 
     GPL v2 License
 

--- a/programs/lz4.1.md
+++ b/programs/lz4.1.md
@@ -20,7 +20,7 @@ DESCRIPTION
 
 `lz4` is a CLI based on `liblz4`, an extremely fast implementation of lossless compression algorithm.
 It provides a default compression speed of typically > 500 MB/s per core.
-Speed can traded for higher compression ratio, by increasing the compression level parameter.
+Speed can traded for better compression ratio, by increasing the compression level parameter.
 While decompression is single-threaded, it reaches multiple GB/s, generally fast enough to be I/O bound.
 `lz4` native file format is the `.lz4` format.
 
@@ -120,7 +120,7 @@ only the latest one will be applied.
 
 * `-#`:
   Compression level, with # being any value from 1 to 12.
-  Higher values trade compression speed for compression ratio.
+  Higher values trade compression speed for better compression ratio.
   Values above 12 are considered the same as 12.
   Recommended values are 1 for fast compression (default),
   and 9 for high compression.
@@ -129,7 +129,7 @@ only the latest one will be applied.
 
 * `--fast[=#]`:
   Switch to ultra-fast compression levels.
-  The higher the value, the faster the compression speed, at the cost of some compression ratio.
+  The higher the value, the faster the compression speed, but at the cost of compressed size.
   If `=#` is not present, it defaults to `1`.
   This setting overrides compression level if one was set previously.
   Similarly, if a compression level is set after `--fast`, it overrides it.

--- a/programs/lz4cli.c
+++ b/programs/lz4cli.c
@@ -1,6 +1,6 @@
 /*
   LZ4cli - LZ4 Command Line Interface
-  Copyright (C) Yann Collet 2011-2023
+  Copyright (c) Yann Collet. All rights reserved.
 
   GPL v2 License
 

--- a/programs/lz4conf.h
+++ b/programs/lz4conf.h
@@ -1,6 +1,6 @@
 /*
   LZ4conf.h - compile-time parameters
-  Copyright (C) Yann Collet 2011-2024
+  Copyright (c) Yann Collet. All rights reserved.
   GPL v2 License
 
   This program is free software; you can redistribute it and/or modify

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -1,6 +1,6 @@
 /*
   LZ4io.c - LZ4 File/Stream Interface
-  Copyright (C) Yann Collet 2011-2024
+  Copyright (c) Yann Collet. All rights reserved.
 
   GPL v2 License
 

--- a/programs/lz4io.h
+++ b/programs/lz4io.h
@@ -1,6 +1,6 @@
 /*
   LZ4io.h - LZ4 File/Stream Interface
-  Copyright (C) Yann Collet 2011-2023
+  Copyright (c) Yann Collet. All rights reserved.
   GPL v2 License
 
   This program is free software; you can redistribute it and/or modify

--- a/programs/platform.h
+++ b/programs/platform.h
@@ -1,6 +1,6 @@
 /*
     platform.h - compiler and OS detection
-    Copyright (C) 2016-2020, Przemyslaw Skibinski, Yann Collet
+    Copyright (c) Przemyslaw Skibinski, Yann Collet. All rights reserved.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/programs/threadpool.c
+++ b/programs/threadpool.c
@@ -1,6 +1,6 @@
 /*
   threadpool.h - part of lz4 project
-  Copyright (C) Yann Collet 2023
+  Copyright (c) Yann Collet. All rights reserved.
   GPL v2 License
 
   This program is free software; you can redistribute it and/or modify

--- a/programs/threadpool.h
+++ b/programs/threadpool.h
@@ -1,6 +1,6 @@
 /*
   threadpool.h - part of lz4 project
-  Copyright (C) Yann Collet 2023
+  Copyright (c) Yann Collet. All rights reserved.
   GPL v2 License
 
   This program is free software; you can redistribute it and/or modify

--- a/programs/timefn.c
+++ b/programs/timefn.c
@@ -1,6 +1,6 @@
 /*
   timefn.c - portable time measurement functions
-  Copyright (C) Yann Collet 2023
+  Copyright (c) Yann Collet. All rights reserved.
 
   GPL v2 License
 

--- a/programs/timefn.h
+++ b/programs/timefn.h
@@ -1,6 +1,6 @@
 /*
   timefn.h - portable time measurement functions
-  Copyright (C) Yann Collet 2023
+  Copyright (c) Yann Collet. All rights reserved.
 
   GPL v2 License
 

--- a/programs/util.c
+++ b/programs/util.c
@@ -1,6 +1,6 @@
 /*
     util.h - utility functions
-    Copyright (C) 2023, Yann Collet
+    Copyright (c) Yann Collet. All rights reserved.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/programs/util.h
+++ b/programs/util.h
@@ -1,6 +1,6 @@
 /*
     util.h - utility functions
-    Copyright (C) 2016-2023, Przemyslaw Skibinski, Yann Collet
+    Copyright (c) Yann Collet. All rights reserved.
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
it's a burden to maintain, and wasn't consistently updated.

Now rely on git dating.