### PR TITLE
[LZ4] Limit disabling LZ4_FAST_DEC_LOOP to aarch64+clang+android

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -490,6 +490,7 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #  else
 #    define LZ4_FAST_DEC_LOOP 0
 #  endif
+#endif
 
 #if LZ4_FAST_DEC_LOOP
 

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -478,17 +478,18 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #ifndef LZ4_FAST_DEC_LOOP
 #  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 #    define LZ4_FAST_DEC_LOOP 1
-#  elif defined(__aarch64__) && defined(__APPLE__)
-#    define LZ4_FAST_DEC_LOOP 1
-#  elif defined(__aarch64__) && !defined(__clang__)
-     /* On non-Apple aarch64, we disable this optimization for clang because
+#  elif defined(__aarch64__)
+#    if defined(__clang__) && defined(__ANDROID__)
+     /* On Android aarch64, we disable this optimization for clang because
       * on certain mobile chipsets, performance is reduced with clang. For
       * more information refer to https://github.com/lz4/lz4/pull/707 */
-#    define LZ4_FAST_DEC_LOOP 1
+#      define LZ4_FAST_DEC_LOOP 0
+#    else
+#      define LZ4_FAST_DEC_LOOP 1
+#    endif
 #  else
 #    define LZ4_FAST_DEC_LOOP 0
 #  endif
-#endif
 
 #if LZ4_FAST_DEC_LOOP
 


### PR DESCRIPTION
[LZ4] Limit disabling LZ4_FAST_DEC_LOOP to aarch64+clang+android
We've seen modern aarch64 server CPUs benefit from LZ4_FAST_DEC_LOOP=1

Previously, LZ4_FAST_DEC_LOOP was disabled when building with clang targeting aarch64. Now we only disable LZ4_FAST_DEC_LOOP if building for Android.