### PR TITLE
cmake readability improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,97 +600,11 @@ jobs:
 ###############################################################
 # Build systems (other than make)
 #
-# - cmake
 # - visual
 # - meson
 #
-
-  # cmake
-  lz4-build-cmake:
-    name: cmake
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-
-    - name: Environment info
-      run: |
-        echo && type cmake && which cmake && cmake --version
-        echo && type make && which make && make -v
-
-    - name: cmake
-      run: |
-        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
-        VERBOSE=1 cmake --build build --target install
-        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
-        VERBOSE=1 cmake --build build_test
-
-    - name: cmake minimum version v3.10 test
-      run: |
-        CMAKE_VERSION="3.10.0"
-        CMAKE_MAJOR_MINOR="3.10"
-        BASE_DIR="$(pwd)"
-        DOWNLOAD_DIR="${BASE_DIR}/cmake_download"
-        CMAKE_BIN_DIR="${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64"
-        CMAKE_BIN="${CMAKE_BIN_DIR}/bin/cmake"
-        BUILD_DIR="${BASE_DIR}/cmake_build"
-        INSTALL_TEST_DIR="${BASE_DIR}/cmake_install_test"
-
-        # Create necessary directories
-        mkdir -p "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
-
-        # Download and extract CMake
-        echo "Downloading CMake ${CMAKE_VERSION}..."
-        wget "https://cmake.org/files/v${CMAKE_MAJOR_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -P "${DOWNLOAD_DIR}"
-        tar xzf "${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -C "${DOWNLOAD_DIR}"
-
-        # Verify CMake version
-        echo "Using CMake version:"
-        "${CMAKE_BIN}" --version
-
-        # Configure the build
-        echo "Configuring build..."
-        (cd "${BUILD_DIR}" && "${CMAKE_BIN}" "${BASE_DIR}/build/cmake")
-
-        # Build the project
-        echo "Building project..."
-        "${CMAKE_BIN}" --build "${BUILD_DIR}"
-
-        # Install to test directory
-        echo "Installing to test directory..."
-        DESTDIR="${INSTALL_TEST_DIR}" "${CMAKE_BIN}" --build "${BUILD_DIR}" --target install
-
-        echo "Test completed successfully with cmake ${CMAKE_VERSION}"
-
-        # cleaning
-        rm -rf "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
-
-  lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
-    name: cmake (static lib)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-
-    - name: Environment info
-      run: |
-        echo && type cmake && which cmake && cmake --version
-        echo && type make && which make && make -v
-
-    - name: cmake (static lib)
-      run: |
-        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
-        VERBOSE=1 cmake --build build --target install
-        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
-        VERBOSE=1 cmake --build build_test
-
-  # Invoke cmake via Makefile
-  lz4-build-make-cmake:
-    name: make cmakebuild
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-    - name: make cmakebuild
-      # V=1 for lz4 Makefile, VERBOSE=1 for cmake Makefile.
-      run: make clean; make cmakebuild V=1 VERBOSE=1
+# Note: cmake tests are regrouped in cmake-test.yml
+#
 
   # Windows + Visual
   lz4-platform-windows:

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -23,15 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest]
-        cmake_version: ["3.5.x", "3.16.x", "latest"]
+        cmake_version: ["3.16.x", "latest"]
         build_type: [Release, Debug, MinSizeRel, RelWithDebInfo]
-        exclude:
-          # CMake 3.5.x may not be available on newer runners
-          - os: ubuntu-latest
-            cmake_version: "3.5.x"
-          - os: macos-latest
-            cmake_version: "3.5.x"
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -183,12 +177,6 @@ jobs:
       run: |
         cd build-${{ matrix.build_type }}
         
-        # Check that expected files are installed
-        echo look at install-test
-        ls install-test
-        echo look at install-test/lib
-        ls install-test/lib
-
         # Check for library files using proper glob expansion
         shopt -s nullglob  # Make globs expand to nothing if no matches
         lib_files=(install-test/lib/liblz4* install-test/lib/lz4*)
@@ -226,7 +214,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cmake_version: ["3.5.2", "3.10.0", "3.16.0", "3.20.0", "latest"]
+        cmake_version: ["3.10.0", "3.16.0", "3.20.0", "latest"]
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -1,5 +1,5 @@
-# GitHub Actions workflow to test CMake build system changes
-# This workflow ensures that the CMake improvements remain preserved and functional
+# Simplified CMake Build Tests
+# Focuses on essential functionality while reducing CI runtime
 name: CMake Build Tests
 
 on:
@@ -16,24 +16,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
 jobs:
-  cmake-build-tests:
-    name: CMake Build Tests (${{ matrix.os }}, ${{ matrix.build_type }})
+  # Core functionality test - reduced matrix
+  cmake-core-tests:
+    name: Core CMake Tests (${{ matrix.os }}, ${{ matrix.build_type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:            [ubuntu-latest, windows-latest, macos-latest]
-        cmake_version: [latest]
-        build_type:    [Release, Debug, MinSizeRel, RelWithDebInfo]
-
-        # attach extra key-value pairs to rows that match on `os`
+        # Reduced to essential combinations
         include:
-          - os: ubuntu-latest       # GNU Makefiles are default on Linux
+          - os: ubuntu-latest
+            build_type: Release
             generator: ""
-          - os: macos-latest        # Unix Makefiles are default on macOS
+          - os: ubuntu-latest  
+            build_type: Debug
             generator: ""
-          - os: windows-latest      # MSVC needs an explicit generator
-            generator: '-G "Visual Studio 17 2022" -A x64' # requires cmake 3.21+
+          - os: windows-latest
+            build_type: Release
+            generator: '-G "Visual Studio 17 2022" -A x64'
+          - os: macos-latest
+            build_type: Release
+            generator: ""
 
     steps:
     - name: Checkout repository
@@ -43,202 +46,85 @@ jobs:
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v2
 
-    - name: Check MSBuild Version
-      if: runner.os == 'Windows'
-      run: MSBuild -version
-
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: ${{ matrix.cmake_version }}
+        cmake-version: latest
 
-    - name: Configure CMake (Test default build type)
+    # Combined configuration and build test
+    - name: Configure and Build
       shell: bash
       run: |
-        mkdir -p build-default
-        cd build-default
-        cmake ../build/cmake ${{ matrix.generator }}
+        mkdir cmakebuild
+        cd cmakebuild
         
-        # Verify that Release is set as default build type
-        if [[ "$RUNNER_OS" != "Windows" ]]; then
+        # Configure with specific build type
+        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        
+        # Verify default build type is Release when not specified
+        if [[ "${{ matrix.build_type }}" == "Release" && "$RUNNER_OS" != "Windows" ]]; then
+          mkdir ../build-default && cd ../build-default
+          cmake ../build/cmake ${{ matrix.generator }}
           build_type=$(cmake -LA . | grep CMAKE_BUILD_TYPE | cut -d= -f2)
-          echo "Default build type: $build_type"
           if [[ "$build_type" != "Release" ]]; then
             echo "ERROR: Default build type should be Release, got: $build_type"
             exit 1
           fi
+          cd ../cmakebuild
         fi
-
-    - name: Configure CMake (Test specific build type)
-      shell: bash
-      run: |
-        mkdir -p build-${{ matrix.build_type }}
-        cd build-${{ matrix.build_type }}
-        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-
-    - name: Test LZ4_DEBUG_LEVEL configuration
-      shell: bash
-      run: |
-        mkdir -p build-debug-levels
-        cd build-debug-levels
         
-        # Test different debug levels
-        for level in 0 1 2 4 8; do
-          echo "Testing LZ4_DEBUG_LEVEL=$level"
-          cmake ../build/cmake ${{ matrix.generator }} -DLZ4_DEBUG_LEVEL=$level -DCMAKE_BUILD_TYPE=Debug
-          
-          # Verify the cache variable is set correctly
-          debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
-          echo "Set debug level: $debug_level"
-          if [[ "$debug_level" != "$level" ]]; then
-            echo "ERROR: LZ4_DEBUG_LEVEL should be $level, got: $debug_level"
-            exit 1
-          fi
-          
-          # Clean for next iteration
-          rm -f CMakeCache.txt
-        done
+        # Build
+        cmake --build . --config ${{ matrix.build_type }}
 
-    - name: Test Debug build enables LZ4_DEBUG=1 by default
+    # Combined debug level testing (only for Debug builds)
+    - name: Test Debug Level Configuration
+      if: matrix.build_type == 'Debug'
       shell: bash
       run: |
-        mkdir -p build-debug-default
-        cd build-debug-default
-        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=Debug
+        cd cmakebuild
         
-        # Check if LZ4_DEBUG_LEVEL defaults to 1 in Debug builds
+        # Test that Debug builds default to LZ4_DEBUG=1
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
-        echo "Debug build default level: $debug_level"
         if [[ "$debug_level" != "1" ]]; then
           echo "ERROR: Debug builds should default to LZ4_DEBUG_LEVEL=1, got: $debug_level"
           exit 1
         fi
-
-    - name: Test Release build disables LZ4_DEBUG by default
-      shell: bash
-      run: |
-        mkdir -p build-release-default
-        cd build-release-default
-        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=Release
         
-        # Check if LZ4_DEBUG_LEVEL defaults to 0 in Release builds
+        # Test custom debug level
+        cmake ../build/cmake ${{ matrix.generator }} -DLZ4_DEBUG_LEVEL=2 -DCMAKE_BUILD_TYPE=Debug
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
-        echo "Release build default level: $debug_level"
-        if [[ "$debug_level" != "0" ]]; then
-          echo "ERROR: Release builds should default to LZ4_DEBUG_LEVEL=0, got: $debug_level"
+        if [[ "$debug_level" != "2" ]]; then
+          echo "ERROR: Custom LZ4_DEBUG_LEVEL should be 2, got: $debug_level"
           exit 1
         fi
 
-    - name: Build with specific configuration
+    # Installation test (Linux only to avoid complexity)
+    - name: Test Installation
+      if: runner.os == 'Linux'
       shell: bash
       run: |
-        cd build-${{ matrix.build_type }}
-        cmake --build . --config ${{ matrix.build_type }}
-
-    - name: Test CMake GUI support (cache properties)
-      shell: bash
-      if: runner.os != 'Windows'  # Skip on multi-config generator (e.g. Visual Studio on Windows)
-      run: |
-        mkdir -p build-gui-test
-        cd build-gui-test
-        cmake ../build/cmake ${{ matrix.generator }}
-        
-        # Verify CMAKE_BUILD_TYPE has the correct STRINGS property
-        if cmake -LA . | grep -q "CMAKE_BUILD_TYPE:STRING"; then
-          echo "✓ CMAKE_BUILD_TYPE is properly configured for CMake GUI"
-        else
-          echo "ERROR: CMAKE_BUILD_TYPE should be configured for CMake GUI"
-          exit 1
-        fi
-        
-        # Verify LZ4_DEBUG_LEVEL has the correct STRINGS property
-        if cmake -LA . | grep -q "LZ4_DEBUG_LEVEL:STRING"; then
-          echo "✓ LZ4_DEBUG_LEVEL is properly configured for CMake GUI"
-        else
-          echo "ERROR: LZ4_DEBUG_LEVEL should be configured for CMake GUI"
-          exit 1
-        fi
-
-    - name: Test all build options
-      shell: bash
-      run: |
-        mkdir -p build-options-test
-        cd build-options-test
-        
-        # Test all combinations of major build options
-        cmake ../build/cmake ${{ matrix.generator }} \
-          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DLZ4_BUILD_CLI=ON \
-          -DLZ4_BUILD_LEGACY_LZ4C=ON \
-          -DBUILD_SHARED_LIBS=ON \
-          -DBUILD_STATIC_LIBS=ON \
-          -DLZ4_DEBUG_LEVEL=2
-        
-        cmake --build . --config ${{ matrix.build_type }}
-
-    - name: Test parallel build (symlink race condition fix)
-      shell: bash
-      if: runner.os != 'Windows'  # Skip on Windows as symlinks work differently
-      run: |
-        cd build-${{ matrix.build_type }}
-        # Test parallel build to ensure no race conditions
-        cmake --build . --config ${{ matrix.build_type }} --parallel $(nproc)
-
-    - name: Test installation
-      shell: bash
-      if: runner.os != 'Windows'  # Skip on Windows, issue with matching configurations
-      run: |
-        cd build-${{ matrix.build_type }}
+        cd cmakebuild
         cmake --install . --prefix install-test
-
-    - name: Verify installation structure
-      shell: bash
-      if: runner.os != 'Windows'  # Skip on Windows, since installation test was skipped
-      run: |
-        cd build-${{ matrix.build_type }}
         
-        # Check for library files using proper glob expansion
-        shopt -s nullglob  # Make globs expand to nothing if no matches
-        if [[ "$RUNNER_OS" == "Windows" ]]; then
-          lib_files=(install-test/lib/lz4* install-test/bin/*.dll)
-        else
-          lib_files=(install-test/lib/liblz4* install-test/lib/lz4*)
-        fi
-        shopt -u nullglob
-
-        if [[ ${#lib_files[@]} -gt 0 ]]; then
-          echo "✓ Library files installed: ${lib_files[*]}"
-        else
-          echo "ERROR: Library files not found in installation"
-          ls -la install-test/lib/ || true
+        # Basic installation verification
+        if [[ ! -f "install-test/lib/liblz4.a" && ! -f "install-test/lib/liblz4.so" ]]; then
+          echo "ERROR: Library files not found"
           exit 1
         fi
         
-        if [[ -f "install-test/include/lz4.h" ]]; then
-          echo "✓ Header files installed"
-        else
-          echo "ERROR: Header files not found in installation"
-          ls -la install-test/include/ || true
-          exit 1
-        fi
-        
-        if [[ "$RUNNER_OS" != "Windows" && -f "install-test/bin/lz4" ]]; then
-          echo "✓ Executable installed"
-        elif [[ "$RUNNER_OS" == "Windows" && -f "install-test/bin/lz4.exe" ]]; then
-          echo "✓ Executable installed"
-        else
-          echo "ERROR: Executable not found in installation"
-          ls -la install-test/bin/ || true
+        if [[ ! -f "install-test/include/lz4.h" ]]; then
+          echo "ERROR: Header files not found"
           exit 1
         fi
 
-  cmake-version-compatibility:
-    name: CMake Version Compatibility Test
-    runs-on: ubuntu-22.04
+  # Compatibility test - reduced scope
+  cmake-compatibility:
+    name: CMake Compatibility
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        cmake_version: ["3.10.0", "3.16.0", "3.20.0", "latest"]
+        cmake_version: ["3.10.0", "3.20.0", "latest"]
     
     steps:
     - name: Checkout repository
@@ -249,15 +135,15 @@ jobs:
       with:
         cmake-version: ${{ matrix.cmake_version }}
     
-    - name: Test CMake configuration
+    - name: Test Basic Configuration
       run: |
-        mkdir cmakebuild
-        cd cmakebuild
+        mkdir cmakebuild && cd cmakebuild
         cmake ../build/cmake
         cmake --build .
 
+  # Edge cases - consolidated
   cmake-edge-cases:
-    name: CMake Edge Cases and Regression Tests
+    name: Edge Cases & Integration
     runs-on: ubuntu-latest
     
     steps:
@@ -269,172 +155,67 @@ jobs:
       with:
         cmake-version: latest
     
-    - name: Test bundled mode
+    # Combined edge case testing
+    - name: Test Edge Cases
       run: |
-        mkdir build-bundled
-        cd build-bundled
+        # Test bundled mode
+        mkdir build-bundled && cd build-bundled
         cmake ../build/cmake -DLZ4_BUNDLED_MODE=ON
-        
-        # In bundled mode, installation should be disabled
-        if cmake -LA . | grep -q "LZ4_BUNDLED_MODE.*ON"; then
-          echo "✓ Bundled mode enabled correctly"
-        else
-          echo "ERROR: Bundled mode not set correctly"
-          exit 1
-        fi
-        
         cmake --build .
-
-    - name: Test with custom CMAKE_INSTALL_PREFIX
-      run: |
-        mkdir build-custom-prefix
-        cd build-custom-prefix
+        cd ..
+        
+        # Test package config generation
+        mkdir build-pkg && cd build-pkg
         cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-test
-        cmake --build .
-        cmake --install .
+        cmake --build . && cmake --install .
         
-        # Verify installation in custom location
-        if [[ -f "/tmp/lz4-test/lib/liblz4.a" || -f "/tmp/lz4-test/lib64/liblz4.a" ]]; then
-          echo "✓ Custom install prefix works"
-        else
-          echo "ERROR: Installation with custom prefix failed"
-          find /tmp/lz4-test -name "*lz4*" || true
-          exit 1
-        fi
-
-    - name: Test invalid LZ4_DEBUG_LEVEL values
-      run: |
-        mkdir build-invalid-debug
-        cd build-invalid-debug
-        
-        # Test boundary values - should work
-        for level in 0 8; do
-          cmake ../build/cmake -DLZ4_DEBUG_LEVEL=$level
-          rm -f CMakeCache.txt
-        done
-        
-        echo "✓ Boundary debug levels work correctly"
-
-    - name: Test cross-compilation preparation
-      run: |
-        mkdir build-cross
-        cd build-cross
-        
-        # Test that configuration works for cross-compilation setup
-        cmake ../build/cmake \
-          -DCMAKE_SYSTEM_NAME=Linux \
-          -DCMAKE_C_COMPILER=gcc \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DLZ4_BUILD_CLI=OFF
-        
-        echo "✓ Cross-compilation configuration works"
-
-    - name: Test package config generation
-      run: |
-        mkdir build-pkg-config
-        cd build-pkg-config
-        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-pkg-test
-        cmake --build .
-        cmake --install .
-        
-        # Verify package config files are generated
-        if [[ -f "/tmp/lz4-pkg-test/lib/cmake/lz4/lz4Config.cmake" ]]; then
-          echo "✓ CMake package config generated"
-        else
+        # Verify package config files
+        if [[ ! -f "/tmp/lz4-test/lib/cmake/lz4/lz4Config.cmake" ]]; then
           echo "ERROR: CMake package config not generated"
-          find /tmp/lz4-pkg-test -name "*Config*" || true
           exit 1
         fi
-        
-        if [[ -f "/tmp/lz4-pkg-test/lib/pkgconfig/liblz4.pc" ]]; then
-          echo "✓ pkg-config file generated"
-        else
-          echo "ERROR: pkg-config file not generated"
-          find /tmp/lz4-pkg-test -name "*.pc" || true
-          exit 1
-        fi
-
-  cmake-integration-test:
-    name: CMake Integration Test (External Project)
-    runs-on: ubuntu-latest
+        cd ..
     
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: latest
-    
-    - name: Build and install LZ4
+    # Integration test with external project
+    - name: Test External Integration
       run: |
-        mkdir build
-        cd build
+        # Build and install LZ4 first
+        mkdir cmakebuild && cd cmakebuild
         cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=$PWD/install
-        cmake --build .
-        cmake --install .
-    
-    - name: Test find_package integration
-      run: |
-        cd tests/cmake
-        mkdir build
-        cd build
+        cmake --build . && cmake --install .
+        
+        # Test find_package integration
+        cd ../tests/cmake && mkdir build && cd build
         cmake .. -DCMAKE_PREFIX_PATH=$PWD/../../../build/install
         cmake --build .
-        
-        echo "✓ External project can find and use installed LZ4"
 
-    - name: Test library functionality
-      run: |
-        cd tests/cmake/build
-        # Run the test executables if they were built
-        if [[ -f "./decompress-partial" ]]; then
-          echo "✓ Test executable built successfully"
-        fi
-
+  # Simple summary
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [cmake-build-tests, cmake-version-compatibility, cmake-edge-cases, cmake-integration-test]
+    needs: [cmake-core-tests, cmake-compatibility, cmake-edge-cases]
     if: always()
     
     steps:
-    - name: Check test results
+    - name: Report Results
       run: |
         echo "## CMake Build System Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        if [[ "${{ needs.cmake-build-tests.result }}" == "success" ]]; then
-          echo "✅ **Basic CMake Build Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ needs.cmake-core-tests.result }}" == "success" ]]; then
+          echo "✅ **Core CMake Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
         else
-          echo "❌ **Basic CMake Build Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **Core CMake Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
         fi
         
-        if [[ "${{ needs.cmake-version-compatibility.result }}" == "success" ]]; then
-          echo "✅ **CMake Version Compatibility**: PASSED" >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ needs.cmake-compatibility.result }}" == "success" ]]; then
+          echo "✅ **CMake Compatibility**: PASSED" >> $GITHUB_STEP_SUMMARY
         else
-          echo "❌ **CMake Version Compatibility**: FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **CMake Compatibility**: FAILED" >> $GITHUB_STEP_SUMMARY
         fi
         
         if [[ "${{ needs.cmake-edge-cases.result }}" == "success" ]]; then
-          echo "✅ **Edge Cases and Regression Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Edge Cases & Integration**: PASSED" >> $GITHUB_STEP_SUMMARY
         else
-          echo "❌ **Edge Cases and Regression Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **Edge Cases & Integration**: FAILED" >> $GITHUB_STEP_SUMMARY
         fi
-        
-        if [[ "${{ needs.cmake-integration-test.result }}" == "success" ]]; then
-          echo "✅ **Integration Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "❌ **Integration Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
-        fi
-        
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Key Properties Tested:" >> $GITHUB_STEP_SUMMARY
-        echo "- 🔧 **Default build type** set to Release" >> $GITHUB_STEP_SUMMARY
-        echo "- 🐛 **LZ4_DEBUG_LEVEL** configurable (0-8) with CMake GUI support" >> $GITHUB_STEP_SUMMARY
-        echo "- 🔨 **Debug builds** automatically enable LZ4_DEBUG=1" >> $GITHUB_STEP_SUMMARY
-        echo "- 🚀 **Release builds** automatically disable LZ4_DEBUG (level 0)" >> $GITHUB_STEP_SUMMARY
-        echo "- 🔗 **Symlink race condition** fix in parallel builds" >> $GITHUB_STEP_SUMMARY
-        echo "- 📦 **Package config** generation and installation" >> $GITHUB_STEP_SUMMARY
-        echo "- 🔄 **CMake version compatibility** (3.5 to latest)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -184,8 +184,18 @@ jobs:
         cd build-${{ matrix.build_type }}
         
         # Check that expected files are installed
-        if [[ -f "install-test/lib/liblz4*" || -f "install-test/lib/lz4*" ]]; then
-          echo "✓ Library files installed"
+        echo look at install-test
+        ls install-test
+        echo look at install-test/lib
+        ls install-test/lib
+
+        # Check for library files using proper glob expansion
+        shopt -s nullglob  # Make globs expand to nothing if no matches
+        lib_files=(install-test/lib/liblz4* install-test/lib/lz4*)
+        shopt -u nullglob
+
+        if [[ ${#lib_files[@]} -gt 0 ]]; then
+          echo "✓ Library files installed: ${lib_files[*]}"
         else
           echo "ERROR: Library files not found in installation"
           ls -la install-test/lib/ || true

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -177,17 +177,21 @@ jobs:
         cd ..
     
     # Integration test with external project
-    - name: Test External Integration
+    - name: Integration test preparation
       run: |
-        # Build and install LZ4 first
-        mkdir cmakebuild && cd cmakebuild
+        mkdir cmakebuild
+        cd cmakebuild
+        rm -rf *
         cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=$PWD/install
-        cmake --build . && cmake --install .
-        
-        # Test find_package integration
-        cd ../tests/cmake && mkdir build && cd build
-        cmake .. -DCMAKE_PREFIX_PATH=$PWD/../../../build/install
+        cmake --build . --target install
+
+    - name: test find_package
+      run: |
+        mkdir test_build
+        cd test_build
+        cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/cmakebuild/install $GITHUB_WORKSPACE/tests/cmake
         cmake --build .
+        ctest -V
 
   # Simple summary
   summary:

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -1,0 +1,418 @@
+# GitHub Actions workflow to test CMake build system changes
+# This workflow ensures that the CMake improvements remain preserved and functional
+name: CMake Build System Tests
+
+on:
+  push:
+    branches: ['dev', 'release', '*cmake*']
+  pull_request:
+    branches: ['dev', 'release']
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+
+jobs:
+  cmake-build-tests:
+    name: CMake Build Tests (${{ matrix.os }}, ${{ matrix.cmake_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest]
+        cmake_version: ["3.5.x", "3.16.x", "latest"]
+        build_type: [Release, Debug, MinSizeRel, RelWithDebInfo]
+        exclude:
+          # CMake 3.5.x may not be available on newer runners
+          - os: ubuntu-latest
+            cmake_version: "3.5.x"
+          - os: macos-latest
+            cmake_version: "3.5.x"
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ${{ matrix.cmake_version }}
+
+    - name: Configure CMake (Test default build type)
+      shell: bash
+      run: |
+        mkdir -p build-default
+        cd build-default
+        cmake ../build/cmake
+        
+        # Verify that Release is set as default build type
+        if [[ "$RUNNER_OS" != "Windows" ]]; then
+          build_type=$(cmake -LA . | grep CMAKE_BUILD_TYPE | cut -d= -f2)
+          echo "Default build type: $build_type"
+          if [[ "$build_type" != "Release" ]]; then
+            echo "ERROR: Default build type should be Release, got: $build_type"
+            exit 1
+          fi
+        fi
+
+    - name: Configure CMake (Test specific build type)
+      shell: bash
+      run: |
+        mkdir -p build-${{ matrix.build_type }}
+        cd build-${{ matrix.build_type }}
+        cmake ../build/cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Test LZ4_DEBUG_LEVEL configuration
+      shell: bash
+      run: |
+        mkdir -p build-debug-levels
+        cd build-debug-levels
+        
+        # Test different debug levels
+        for level in 0 1 2 4 8; do
+          echo "Testing LZ4_DEBUG_LEVEL=$level"
+          cmake ../build/cmake -DLZ4_DEBUG_LEVEL=$level -DCMAKE_BUILD_TYPE=Debug
+          
+          # Verify the cache variable is set correctly
+          debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
+          echo "Set debug level: $debug_level"
+          if [[ "$debug_level" != "$level" ]]; then
+            echo "ERROR: LZ4_DEBUG_LEVEL should be $level, got: $debug_level"
+            exit 1
+          fi
+          
+          # Clean for next iteration
+          rm -f CMakeCache.txt
+        done
+
+    - name: Test Debug build enables LZ4_DEBUG=1 by default
+      shell: bash
+      run: |
+        mkdir -p build-debug-default
+        cd build-debug-default
+        cmake ../build/cmake -DCMAKE_BUILD_TYPE=Debug
+        
+        # Check if LZ4_DEBUG_LEVEL defaults to 1 in Debug builds
+        debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
+        echo "Debug build default level: $debug_level"
+        if [[ "$debug_level" != "1" ]]; then
+          echo "ERROR: Debug builds should default to LZ4_DEBUG_LEVEL=1, got: $debug_level"
+          exit 1
+        fi
+
+    - name: Test Release build disables LZ4_DEBUG by default
+      shell: bash
+      run: |
+        mkdir -p build-release-default
+        cd build-release-default
+        cmake ../build/cmake -DCMAKE_BUILD_TYPE=Release
+        
+        # Check if LZ4_DEBUG_LEVEL defaults to 0 in Release builds
+        debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
+        echo "Release build default level: $debug_level"
+        if [[ "$debug_level" != "0" ]]; then
+          echo "ERROR: Release builds should default to LZ4_DEBUG_LEVEL=0, got: $debug_level"
+          exit 1
+        fi
+
+    - name: Build with specific configuration
+      shell: bash
+      run: |
+        cd build-${{ matrix.build_type }}
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test CMake GUI support (cache properties)
+      shell: bash
+      run: |
+        mkdir -p build-gui-test
+        cd build-gui-test
+        cmake ../build/cmake
+        
+        # Verify CMAKE_BUILD_TYPE has the correct STRINGS property
+        if cmake -LA . | grep -q "CMAKE_BUILD_TYPE:STRING"; then
+          echo "✓ CMAKE_BUILD_TYPE is properly configured for CMake GUI"
+        else
+          echo "ERROR: CMAKE_BUILD_TYPE should be configured for CMake GUI"
+          exit 1
+        fi
+        
+        # Verify LZ4_DEBUG_LEVEL has the correct STRINGS property
+        if cmake -LA . | grep -q "LZ4_DEBUG_LEVEL:STRING"; then
+          echo "✓ LZ4_DEBUG_LEVEL is properly configured for CMake GUI"
+        else
+          echo "ERROR: LZ4_DEBUG_LEVEL should be configured for CMake GUI"
+          exit 1
+        fi
+
+    - name: Test all build options
+      shell: bash
+      run: |
+        mkdir -p build-options-test
+        cd build-options-test
+        
+        # Test all combinations of major build options
+        cmake ../build/cmake \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DLZ4_BUILD_CLI=ON \
+          -DLZ4_BUILD_LEGACY_LZ4C=ON \
+          -DBUILD_SHARED_LIBS=ON \
+          -DBUILD_STATIC_LIBS=ON \
+          -DLZ4_DEBUG_LEVEL=2
+        
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Test parallel build (symlink race condition fix)
+      shell: bash
+      if: runner.os != 'Windows'  # Skip on Windows as symlinks work differently
+      run: |
+        cd build-${{ matrix.build_type }}
+        # Test parallel build to ensure no race conditions
+        cmake --build . --config ${{ matrix.build_type }} --parallel $(nproc)
+
+    - name: Test installation
+      shell: bash
+      run: |
+        cd build-${{ matrix.build_type }}
+        cmake --install . --prefix install-test
+
+    - name: Verify installation structure
+      shell: bash
+      run: |
+        cd build-${{ matrix.build_type }}
+        
+        # Check that expected files are installed
+        if [[ -f "install-test/lib/liblz4*" || -f "install-test/lib/lz4*" ]]; then
+          echo "✓ Library files installed"
+        else
+          echo "ERROR: Library files not found in installation"
+          ls -la install-test/lib/ || true
+          exit 1
+        fi
+        
+        if [[ -f "install-test/include/lz4.h" ]]; then
+          echo "✓ Header files installed"
+        else
+          echo "ERROR: Header files not found in installation"
+          ls -la install-test/include/ || true
+          exit 1
+        fi
+        
+        if [[ "$RUNNER_OS" != "Windows" && -f "install-test/bin/lz4" ]]; then
+          echo "✓ Executable installed"
+        elif [[ "$RUNNER_OS" == "Windows" && -f "install-test/bin/lz4.exe" ]]; then
+          echo "✓ Executable installed"
+        else
+          echo "ERROR: Executable not found in installation"
+          ls -la install-test/bin/ || true
+          exit 1
+        fi
+
+  cmake-version-compatibility:
+    name: CMake Version Compatibility Test
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cmake_version: ["3.5.2", "3.10.0", "3.16.0", "3.20.0", "latest"]
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: ${{ matrix.cmake_version }}
+    
+    - name: Test CMake configuration
+      run: |
+        mkdir build
+        cd build
+        cmake ../build/cmake
+        cmake --build .
+
+  cmake-edge-cases:
+    name: CMake Edge Cases and Regression Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: latest
+    
+    - name: Test bundled mode
+      run: |
+        mkdir build-bundled
+        cd build-bundled
+        cmake ../build/cmake -DLZ4_BUNDLED_MODE=ON
+        
+        # In bundled mode, installation should be disabled
+        if cmake -LA . | grep -q "LZ4_BUNDLED_MODE.*ON"; then
+          echo "✓ Bundled mode enabled correctly"
+        else
+          echo "ERROR: Bundled mode not set correctly"
+          exit 1
+        fi
+        
+        cmake --build .
+
+    - name: Test with custom CMAKE_INSTALL_PREFIX
+      run: |
+        mkdir build-custom-prefix
+        cd build-custom-prefix
+        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-test
+        cmake --build .
+        cmake --install .
+        
+        # Verify installation in custom location
+        if [[ -f "/tmp/lz4-test/lib/liblz4.a" || -f "/tmp/lz4-test/lib64/liblz4.a" ]]; then
+          echo "✓ Custom install prefix works"
+        else
+          echo "ERROR: Installation with custom prefix failed"
+          find /tmp/lz4-test -name "*lz4*" || true
+          exit 1
+        fi
+
+    - name: Test invalid LZ4_DEBUG_LEVEL values
+      run: |
+        mkdir build-invalid-debug
+        cd build-invalid-debug
+        
+        # Test boundary values - should work
+        for level in 0 8; do
+          cmake ../build/cmake -DLZ4_DEBUG_LEVEL=$level
+          rm -f CMakeCache.txt
+        done
+        
+        echo "✓ Boundary debug levels work correctly"
+
+    - name: Test cross-compilation preparation
+      run: |
+        mkdir build-cross
+        cd build-cross
+        
+        # Test that configuration works for cross-compilation setup
+        cmake ../build/cmake \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_C_COMPILER=gcc \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DLZ4_BUILD_CLI=OFF
+        
+        echo "✓ Cross-compilation configuration works"
+
+    - name: Test package config generation
+      run: |
+        mkdir build-pkg-config
+        cd build-pkg-config
+        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-pkg-test
+        cmake --build .
+        cmake --install .
+        
+        # Verify package config files are generated
+        if [[ -f "/tmp/lz4-pkg-test/lib/cmake/lz4/lz4Config.cmake" ]]; then
+          echo "✓ CMake package config generated"
+        else
+          echo "ERROR: CMake package config not generated"
+          find /tmp/lz4-pkg-test -name "*Config*" || true
+          exit 1
+        fi
+        
+        if [[ -f "/tmp/lz4-pkg-test/lib/pkgconfig/liblz4.pc" ]]; then
+          echo "✓ pkg-config file generated"
+        else
+          echo "ERROR: pkg-config file not generated"
+          find /tmp/lz4-pkg-test -name "*.pc" || true
+          exit 1
+        fi
+
+  cmake-integration-test:
+    name: CMake Integration Test (External Project)
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Set up CMake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: latest
+    
+    - name: Build and install LZ4
+      run: |
+        mkdir build
+        cd build
+        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=$PWD/install
+        cmake --build .
+        cmake --install .
+    
+    - name: Test find_package integration
+      run: |
+        cd tests/cmake
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_PREFIX_PATH=$PWD/../../../build/install
+        cmake --build .
+        
+        echo "✓ External project can find and use installed LZ4"
+
+    - name: Test library functionality
+      run: |
+        cd tests/cmake/build
+        # Run the test executables if they were built
+        if [[ -f "./decompress-partial" ]]; then
+          echo "✓ Test executable built successfully"
+        fi
+
+  summary:
+    name: Test Summary
+    runs-on: ubuntu-latest
+    needs: [cmake-build-tests, cmake-version-compatibility, cmake-edge-cases, cmake-integration-test]
+    if: always()
+    
+    steps:
+    - name: Check test results
+      run: |
+        echo "## CMake Build System Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        if [[ "${{ needs.cmake-build-tests.result }}" == "success" ]]; then
+          echo "✅ **Basic CMake Build Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Basic CMake Build Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [[ "${{ needs.cmake-version-compatibility.result }}" == "success" ]]; then
+          echo "✅ **CMake Version Compatibility**: PASSED" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **CMake Version Compatibility**: FAILED" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [[ "${{ needs.cmake-edge-cases.result }}" == "success" ]]; then
+          echo "✅ **Edge Cases and Regression Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Edge Cases and Regression Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        if [[ "${{ needs.cmake-integration-test.result }}" == "success" ]]; then
+          echo "✅ **Integration Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Integration Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Key Properties Tested:" >> $GITHUB_STEP_SUMMARY
+        echo "- 🔧 **Default build type** set to Release" >> $GITHUB_STEP_SUMMARY
+        echo "- 🐛 **LZ4_DEBUG_LEVEL** configurable (0-8) with CMake GUI support" >> $GITHUB_STEP_SUMMARY
+        echo "- 🔨 **Debug builds** automatically enable LZ4_DEBUG=1" >> $GITHUB_STEP_SUMMARY
+        echo "- 🚀 **Release builds** automatically disable LZ4_DEBUG (level 0)" >> $GITHUB_STEP_SUMMARY
+        echo "- 🔗 **Symlink race condition** fix in parallel builds" >> $GITHUB_STEP_SUMMARY
+        echo "- 📦 **Package config** generation and installation" >> $GITHUB_STEP_SUMMARY
+        echo "- 🔄 **CMake version compatibility** (3.5 to latest)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -227,8 +227,8 @@ jobs:
     
     - name: Test CMake configuration
       run: |
-        mkdir build
-        cd build
+        mkdir cmakebuild
+        cd cmakebuild
         cmake ../build/cmake
         cmake --build .
 

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -1,5 +1,4 @@
 # Simplified CMake Build Tests
-# Focuses on essential functionality while reducing CI runtime
 name: CMake Build Tests
 
 on:
@@ -16,14 +15,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
 jobs:
-  # Core functionality test - reduced matrix
+  # Core functionality test - multi-platform
   cmake-core-tests:
-    name: Core CMake Tests (${{ matrix.os }}, ${{ matrix.build_type }})
+    name: Core Tests (${{ matrix.os }}, ${{ matrix.build_type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        # Reduced to essential combinations
         include:
           - os: ubuntu-latest
             build_type: Release
@@ -51,80 +49,33 @@ jobs:
       with:
         cmake-version: latest
 
-    # Combined configuration and build test
     - name: Configure and Build
       shell: bash
       run: |
-        mkdir cmakebuild
-        cd cmakebuild
-
-        # Configure with specific build type
+        mkdir cmakebuild && cd cmakebuild
         cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-
-        # Verify default build type is Release when not specified
-        if [[ "${{ matrix.build_type }}" == "Release" && "$RUNNER_OS" != "Windows" ]]; then
-          mkdir ../build-default && cd ../build-default
-          cmake ../build/cmake ${{ matrix.generator }}
-          build_type=$(cmake -LA . | grep CMAKE_BUILD_TYPE | cut -d= -f2)
-          if [[ "$build_type" != "Release" ]]; then
-            echo "ERROR: Default build type should be Release, got: $build_type"
-            exit 1
-          fi
-          cd ../cmakebuild
-        fi
-
-        # Build
         cmake --build . --config ${{ matrix.build_type }}
 
-    # Combined debug level testing (only for Debug builds)
-    - name: Test Debug Level Configuration
-      if: matrix.build_type == 'Debug'
-      shell: bash
-      run: |
-        cd cmakebuild
-
-        # Test that Debug builds default to LZ4_DEBUG=1
-        debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
-        if [[ "$debug_level" != "1" ]]; then
-          echo "ERROR: Debug builds should default to LZ4_DEBUG_LEVEL=1, got: $debug_level"
-          exit 1
-        fi
-
-        # Test custom debug level
-        cmake ../build/cmake ${{ matrix.generator }} -DLZ4_DEBUG_LEVEL=2 -DCMAKE_BUILD_TYPE=Debug
-        debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
-        if [[ "$debug_level" != "2" ]]; then
-          echo "ERROR: Custom LZ4_DEBUG_LEVEL should be 2, got: $debug_level"
-          exit 1
-        fi
-
-    # Installation test (Linux only to avoid complexity)
-    - name: Test Installation
+    - name: Test Installation (Linux only)
       if: runner.os == 'Linux'
       shell: bash
       run: |
         cd cmakebuild
         cmake --install . --prefix install-test
+        test -f "install-test/lib/liblz4.a" || test -f "install-test/lib/liblz4.so"
+        test -f "install-test/include/lz4.h"
 
-        # Basic installation verification
-        if [[ ! -f "install-test/lib/liblz4.a" && ! -f "install-test/lib/liblz4.so" ]]; then
-          echo "ERROR: Library files not found"
-          exit 1
-        fi
-
-        if [[ ! -f "install-test/include/lz4.h" ]]; then
-          echo "ERROR: Header files not found"
-          exit 1
-        fi
-
-  # Compatibility test - reduced scope
-  cmake-compatibility:
-    name: CMake Compatibility
+  # CMake compatibility and integration tests
+  cmake-extended-tests:
+    name: Extended Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        cmake_version: ["3.10.0", "3.20.0", "latest"]
+        test_type: 
+          - cmake_versions
+          - static_lib
+          - integration
 
     steps:
     - name: Checkout repository
@@ -133,149 +84,44 @@ jobs:
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
-        cmake-version: ${{ matrix.cmake_version }}
+        cmake-version: ${{ matrix.test_type == 'cmake_versions' && '3.10.0' || 'latest' }}
 
-    - name: Test Basic Configuration
+    - name: CMake Version Compatibility Test
+      if: matrix.test_type == 'cmake_versions'
       run: |
         mkdir cmakebuild && cd cmakebuild
         cmake ../build/cmake
         cmake --build .
 
-  # Edge cases - consolidated
-  cmake-edge-cases:
-    name: Edge Cases & Integration
-    runs-on: ubuntu-latest
+    - name: Static Library Test
+      if: matrix.test_type == 'static_lib'
+      run: |
+        # Build and install static library
+        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -DBUILD_STATIC_LIBS=ON -DCMAKE_INSTALL_PREFIX=$PWD/install
+        cmake --build build --target install
+        
+        # Test find_package with static library
+        cmake -S tests/cmake -B build_test -DCMAKE_PREFIX_PATH=$PWD/install
+        cmake --build build_test
 
+    - name: Integration Test
+      if: matrix.test_type == 'integration'
+      run: |
+        # Build and install
+        cmake -S build/cmake -B build -DCMAKE_INSTALL_PREFIX=$PWD/install
+        cmake --build build --target install
+        
+        # Test find_package
+        cmake -S tests/cmake -B test_build -DCMAKE_PREFIX_PATH=$PWD/install
+        cmake --build test_build
+        cd test_build && ctest -V
+
+  # Makefile wrapper test
+  make-cmake-test:
+    name: Make CMake
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
-    - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: latest
-
-    # Combined edge case testing
-    - name: Test Edge Cases
-      run: |
-        # Test bundled mode
-        mkdir build-bundled && cd build-bundled
-        cmake ../build/cmake -DLZ4_BUNDLED_MODE=ON
-        cmake --build .
-        cd ..
-
-        # Test package config generation
-        mkdir build-pkg && cd build-pkg
-        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-test
-        cmake --build . && cmake --install .
-
-        # Verify package config files
-        if [[ ! -f "/tmp/lz4-test/lib/cmake/lz4/lz4Config.cmake" ]]; then
-          echo "ERROR: CMake package config not generated"
-          exit 1
-        fi
-        cd ..
-
-    # Integration test with external project
-    - name: Integration test preparation
-      run: |
-        mkdir cmakebuild
-        cd cmakebuild
-        rm -rf *
-        cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=$PWD/install
-        cmake --build . --target install
-
-    - name: test find_package
-      run: |
-        mkdir test_build
-        cd test_build
-        cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/cmakebuild/install $GITHUB_WORKSPACE/tests/cmake
-        cmake --build .
-        ctest -V
-
-  # cmake
-  lz4-build-cmake:
-    name: cmake
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-
-    - name: Environment info
-      run: |
-        echo && type cmake && which cmake && cmake --version
-        echo && type make && which make && make -v
-
-    - name: cmake
-      run: |
-        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
-        VERBOSE=1 cmake --build build --target install
-        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
-        VERBOSE=1 cmake --build build_test
-
-    - name: cmake minimum version v3.10 test
-      run: |
-        CMAKE_VERSION="3.10.0"
-        CMAKE_MAJOR_MINOR="3.10"
-        BASE_DIR="$(pwd)"
-        DOWNLOAD_DIR="${BASE_DIR}/cmake_download"
-        CMAKE_BIN_DIR="${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64"
-        CMAKE_BIN="${CMAKE_BIN_DIR}/bin/cmake"
-        BUILD_DIR="${BASE_DIR}/cmake_build"
-        INSTALL_TEST_DIR="${BASE_DIR}/cmake_install_test"
-
-        # Create necessary directories
-        mkdir -p "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
-
-        # Download and extract CMake
-        echo "Downloading CMake ${CMAKE_VERSION}..."
-        wget "https://cmake.org/files/v${CMAKE_MAJOR_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -P "${DOWNLOAD_DIR}"
-        tar xzf "${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -C "${DOWNLOAD_DIR}"
-
-        # Verify CMake version
-        echo "Using CMake version:"
-        "${CMAKE_BIN}" --version
-
-        # Configure the build
-        echo "Configuring build..."
-        (cd "${BUILD_DIR}" && "${CMAKE_BIN}" "${BASE_DIR}/build/cmake")
-
-        # Build the project
-        echo "Building project..."
-        "${CMAKE_BIN}" --build "${BUILD_DIR}"
-
-        # Install to test directory
-        echo "Installing to test directory..."
-        DESTDIR="${INSTALL_TEST_DIR}" "${CMAKE_BIN}" --build "${BUILD_DIR}" --target install
-
-        echo "Test completed successfully with cmake ${CMAKE_VERSION}"
-
-        # cleaning
-        rm -rf "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
-
-  lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
-    name: cmake (static lib)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-
-    - name: Environment info
-      run: |
-        echo && type cmake && which cmake && cmake --version
-        echo && type make && which make && make -v
-
-    - name: cmake (static lib)
-      run: |
-        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
-        VERBOSE=1 cmake --build build --target install
-        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
-        VERBOSE=1 cmake --build build_test
-
-  # Invoke cmake via Makefile
-  lz4-build-make-cmake:
-    name: make cmakebuild
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
-    - name: make cmakebuild
-      # V=1 for lz4 Makefile, VERBOSE=1 for cmake Makefile.
-      run: make clean; make cmakebuild V=1 VERBOSE=1
+    - name: Test via Makefile
+      run: make clean && make cmakebuild

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -1,6 +1,6 @@
 # GitHub Actions workflow to test CMake build system changes
 # This workflow ensures that the CMake improvements remain preserved and functional
-name: CMake Build System Tests
+name: CMake Build Tests
 
 on:
   push:
@@ -17,18 +17,35 @@ concurrency:
 
 jobs:
   cmake-build-tests:
-    name: CMake Build Tests (${{ matrix.os }}, ${{ matrix.cmake_version }})
+    name: CMake Build Tests (${{ matrix.os }}, ${{ matrix.build_type }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, windows-latest, macos-latest]
-        cmake_version: ["3.16.x", "latest"]
-        build_type: [Release, Debug, MinSizeRel, RelWithDebInfo]
+        os:            [ubuntu-latest, windows-latest, macos-latest]
+        cmake_version: [latest]
+        build_type:    [Release, Debug, MinSizeRel, RelWithDebInfo]
+
+        # attach extra key-value pairs to rows that match on `os`
+        include:
+          - os: ubuntu-latest       # GNU Makefiles are default on Linux
+            generator: ""
+          - os: macos-latest        # Unix Makefiles are default on macOS
+            generator: ""
+          - os: windows-latest      # MSVC needs an explicit generator
+            generator: '-G "Visual Studio 17 2022" -A x64' # requires cmake 3.21+
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Set up MSVC (Windows)
+      if: runner.os == 'Windows'
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Check MSBuild Version
+      if: runner.os == 'Windows'
+      run: MSBuild -version
 
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
@@ -40,7 +57,7 @@ jobs:
       run: |
         mkdir -p build-default
         cd build-default
-        cmake ../build/cmake
+        cmake ../build/cmake ${{ matrix.generator }}
         
         # Verify that Release is set as default build type
         if [[ "$RUNNER_OS" != "Windows" ]]; then
@@ -57,7 +74,7 @@ jobs:
       run: |
         mkdir -p build-${{ matrix.build_type }}
         cd build-${{ matrix.build_type }}
-        cmake ../build/cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
     - name: Test LZ4_DEBUG_LEVEL configuration
       shell: bash
@@ -68,7 +85,7 @@ jobs:
         # Test different debug levels
         for level in 0 1 2 4 8; do
           echo "Testing LZ4_DEBUG_LEVEL=$level"
-          cmake ../build/cmake -DLZ4_DEBUG_LEVEL=$level -DCMAKE_BUILD_TYPE=Debug
+          cmake ../build/cmake ${{ matrix.generator }} -DLZ4_DEBUG_LEVEL=$level -DCMAKE_BUILD_TYPE=Debug
           
           # Verify the cache variable is set correctly
           debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
@@ -87,7 +104,7 @@ jobs:
       run: |
         mkdir -p build-debug-default
         cd build-debug-default
-        cmake ../build/cmake -DCMAKE_BUILD_TYPE=Debug
+        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=Debug
         
         # Check if LZ4_DEBUG_LEVEL defaults to 1 in Debug builds
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
@@ -102,7 +119,7 @@ jobs:
       run: |
         mkdir -p build-release-default
         cd build-release-default
-        cmake ../build/cmake -DCMAKE_BUILD_TYPE=Release
+        cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=Release
         
         # Check if LZ4_DEBUG_LEVEL defaults to 0 in Release builds
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
@@ -120,10 +137,11 @@ jobs:
 
     - name: Test CMake GUI support (cache properties)
       shell: bash
+      if: runner.os != 'Windows'  # Skip on multi-config generator (e.g. Visual Studio on Windows)
       run: |
         mkdir -p build-gui-test
         cd build-gui-test
-        cmake ../build/cmake
+        cmake ../build/cmake ${{ matrix.generator }}
         
         # Verify CMAKE_BUILD_TYPE has the correct STRINGS property
         if cmake -LA . | grep -q "CMAKE_BUILD_TYPE:STRING"; then
@@ -148,7 +166,7 @@ jobs:
         cd build-options-test
         
         # Test all combinations of major build options
-        cmake ../build/cmake \
+        cmake ../build/cmake ${{ matrix.generator }} \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DLZ4_BUILD_CLI=ON \
           -DLZ4_BUILD_LEGACY_LZ4C=ON \
@@ -168,18 +186,24 @@ jobs:
 
     - name: Test installation
       shell: bash
+      if: runner.os != 'Windows'  # Skip on Windows, issue with matching configurations
       run: |
         cd build-${{ matrix.build_type }}
         cmake --install . --prefix install-test
 
     - name: Verify installation structure
       shell: bash
+      if: runner.os != 'Windows'  # Skip on Windows, since installation test was skipped
       run: |
         cd build-${{ matrix.build_type }}
         
         # Check for library files using proper glob expansion
         shopt -s nullglob  # Make globs expand to nothing if no matches
-        lib_files=(install-test/lib/liblz4* install-test/lib/lz4*)
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          lib_files=(install-test/lib/lz4* install-test/bin/*.dll)
+        else
+          lib_files=(install-test/lib/liblz4* install-test/lib/lz4*)
+        fi
         shopt -u nullglob
 
         if [[ ${#lib_files[@]} -gt 0 ]]; then

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             build_type: Release
             generator: ""
-          - os: ubuntu-latest  
+          - os: ubuntu-latest
             build_type: Debug
             generator: ""
           - os: windows-latest
@@ -57,10 +57,10 @@ jobs:
       run: |
         mkdir cmakebuild
         cd cmakebuild
-        
+
         # Configure with specific build type
         cmake ../build/cmake ${{ matrix.generator }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        
+
         # Verify default build type is Release when not specified
         if [[ "${{ matrix.build_type }}" == "Release" && "$RUNNER_OS" != "Windows" ]]; then
           mkdir ../build-default && cd ../build-default
@@ -72,7 +72,7 @@ jobs:
           fi
           cd ../cmakebuild
         fi
-        
+
         # Build
         cmake --build . --config ${{ matrix.build_type }}
 
@@ -82,14 +82,14 @@ jobs:
       shell: bash
       run: |
         cd cmakebuild
-        
+
         # Test that Debug builds default to LZ4_DEBUG=1
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
         if [[ "$debug_level" != "1" ]]; then
           echo "ERROR: Debug builds should default to LZ4_DEBUG_LEVEL=1, got: $debug_level"
           exit 1
         fi
-        
+
         # Test custom debug level
         cmake ../build/cmake ${{ matrix.generator }} -DLZ4_DEBUG_LEVEL=2 -DCMAKE_BUILD_TYPE=Debug
         debug_level=$(cmake -LA . | grep LZ4_DEBUG_LEVEL | cut -d= -f2)
@@ -105,13 +105,13 @@ jobs:
       run: |
         cd cmakebuild
         cmake --install . --prefix install-test
-        
+
         # Basic installation verification
         if [[ ! -f "install-test/lib/liblz4.a" && ! -f "install-test/lib/liblz4.so" ]]; then
           echo "ERROR: Library files not found"
           exit 1
         fi
-        
+
         if [[ ! -f "install-test/include/lz4.h" ]]; then
           echo "ERROR: Header files not found"
           exit 1
@@ -125,16 +125,16 @@ jobs:
       fail-fast: false
       matrix:
         cmake_version: ["3.10.0", "3.20.0", "latest"]
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: ${{ matrix.cmake_version }}
-    
+
     - name: Test Basic Configuration
       run: |
         mkdir cmakebuild && cd cmakebuild
@@ -145,16 +145,16 @@ jobs:
   cmake-edge-cases:
     name: Edge Cases & Integration
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: latest
-    
+
     # Combined edge case testing
     - name: Test Edge Cases
       run: |
@@ -163,19 +163,19 @@ jobs:
         cmake ../build/cmake -DLZ4_BUNDLED_MODE=ON
         cmake --build .
         cd ..
-        
+
         # Test package config generation
         mkdir build-pkg && cd build-pkg
         cmake ../build/cmake -DCMAKE_INSTALL_PREFIX=/tmp/lz4-test
         cmake --build . && cmake --install .
-        
+
         # Verify package config files
         if [[ ! -f "/tmp/lz4-test/lib/cmake/lz4/lz4Config.cmake" ]]; then
           echo "ERROR: CMake package config not generated"
           exit 1
         fi
         cd ..
-    
+
     # Integration test with external project
     - name: Integration test preparation
       run: |
@@ -193,33 +193,89 @@ jobs:
         cmake --build .
         ctest -V
 
-  # Simple summary
-  summary:
-    name: Test Summary
+  # cmake
+  lz4-build-cmake:
+    name: cmake
     runs-on: ubuntu-latest
-    needs: [cmake-core-tests, cmake-compatibility, cmake-edge-cases]
-    if: always()
-    
     steps:
-    - name: Report Results
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
+
+    - name: Environment info
       run: |
-        echo "## CMake Build System Test Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        
-        if [[ "${{ needs.cmake-core-tests.result }}" == "success" ]]; then
-          echo "✅ **Core CMake Tests**: PASSED" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "❌ **Core CMake Tests**: FAILED" >> $GITHUB_STEP_SUMMARY
-        fi
-        
-        if [[ "${{ needs.cmake-compatibility.result }}" == "success" ]]; then
-          echo "✅ **CMake Compatibility**: PASSED" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "❌ **CMake Compatibility**: FAILED" >> $GITHUB_STEP_SUMMARY
-        fi
-        
-        if [[ "${{ needs.cmake-edge-cases.result }}" == "success" ]]; then
-          echo "✅ **Edge Cases & Integration**: PASSED" >> $GITHUB_STEP_SUMMARY
-        else
-          echo "❌ **Edge Cases & Integration**: FAILED" >> $GITHUB_STEP_SUMMARY
-        fi
+        echo && type cmake && which cmake && cmake --version
+        echo && type make && which make && make -v
+
+    - name: cmake
+      run: |
+        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install
+        VERBOSE=1 cmake --build build --target install
+        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install
+        VERBOSE=1 cmake --build build_test
+
+    - name: cmake minimum version v3.10 test
+      run: |
+        CMAKE_VERSION="3.10.0"
+        CMAKE_MAJOR_MINOR="3.10"
+        BASE_DIR="$(pwd)"
+        DOWNLOAD_DIR="${BASE_DIR}/cmake_download"
+        CMAKE_BIN_DIR="${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64"
+        CMAKE_BIN="${CMAKE_BIN_DIR}/bin/cmake"
+        BUILD_DIR="${BASE_DIR}/cmake_build"
+        INSTALL_TEST_DIR="${BASE_DIR}/cmake_install_test"
+
+        # Create necessary directories
+        mkdir -p "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
+
+        # Download and extract CMake
+        echo "Downloading CMake ${CMAKE_VERSION}..."
+        wget "https://cmake.org/files/v${CMAKE_MAJOR_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -P "${DOWNLOAD_DIR}"
+        tar xzf "${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" -C "${DOWNLOAD_DIR}"
+
+        # Verify CMake version
+        echo "Using CMake version:"
+        "${CMAKE_BIN}" --version
+
+        # Configure the build
+        echo "Configuring build..."
+        (cd "${BUILD_DIR}" && "${CMAKE_BIN}" "${BASE_DIR}/build/cmake")
+
+        # Build the project
+        echo "Building project..."
+        "${CMAKE_BIN}" --build "${BUILD_DIR}"
+
+        # Install to test directory
+        echo "Installing to test directory..."
+        DESTDIR="${INSTALL_TEST_DIR}" "${CMAKE_BIN}" --build "${BUILD_DIR}" --target install
+
+        echo "Test completed successfully with cmake ${CMAKE_VERSION}"
+
+        # cleaning
+        rm -rf "${DOWNLOAD_DIR}" "${BUILD_DIR}" "${INSTALL_TEST_DIR}"
+
+  lz4-build-cmake-static-lib: # See https://github.com/lz4/lz4/issues/1269
+    name: cmake (static lib)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
+
+    - name: Environment info
+      run: |
+        echo && type cmake && which cmake && cmake --version
+        echo && type make && which make && make -v
+
+    - name: cmake (static lib)
+      run: |
+        CFLAGS="-Werror -O1" cmake -S build/cmake -B build -D CMAKE_INSTALL_PREFIX=install_test_dir -DBUILD_STATIC_LIBS=ON
+        VERBOSE=1 cmake --build build --target install
+        cmake -S tests/cmake -B build_test -D CMAKE_INSTALL_PREFIX=install_test_dir
+        VERBOSE=1 cmake --build build_test
+
+  # Invoke cmake via Makefile
+  lz4-build-make-cmake:
+    name: make cmakebuild
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # https://github.com/actions/checkout v4.2.2
+    - name: make cmakebuild
+      # V=1 for lz4 Makefile, VERBOSE=1 for cmake Makefile.
+      run: make clean; make cmakebuild V=1 VERBOSE=1

--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -212,7 +212,7 @@ jobs:
 
   cmake-version-compatibility:
     name: CMake Version Compatibility Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -34,6 +34,17 @@ message(STATUS "Creating build script for LZ4 version: ${LZ4_VERSION_STRING}")
 
 project(LZ4 VERSION ${LZ4_VERSION_STRING} LANGUAGES C)
 
+#-----------------------------------------------------------------------------
+# DEFAULT BUILD TYPE - Set Release as default when no build type is specified
+#-----------------------------------------------------------------------------
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 #-----------------------------------------------------------------------------
 # BUILD OPTIONS - Configure build targets and features

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -8,7 +8,9 @@
 # For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 
-cmake_minimum_required(VERSION 3.5...3.16)
+# Use range version specification for policy control while maintaining 
+# compatibility with older CMake versions
+cmake_minimum_required(VERSION 3.5...4.0.2)
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -167,6 +167,17 @@ else()
 endif(BUILD_SHARED_LIBS)
 
 #-----------------------------------------------------------------------------
+# DEBUG CONFIGURATION - Set LZ4_DEBUG for Debug builds to enable assert()
+#-----------------------------------------------------------------------------
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(MSVC)
+    add_definitions(/DLZ4_DEBUG=1)
+  else()
+    add_definitions(-DLZ4_DEBUG=1)
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------
 # NAMESPACE CONFIGURATION - xxHash namespace settings
 #-----------------------------------------------------------------------------
 # xxhash namespace

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -294,6 +294,7 @@ if(NOT LZ4_BUNDLED_MODE)
       add_custom_target("create_${cli_tool}_symlink" ALL
         COMMAND ${CMAKE_COMMAND} -E create_symlink
           $<TARGET_FILE_NAME:lz4cli> ${cli_tool}
+        DEPENDS lz4cli
         COMMENT "Creating symlink for ${cli_tool}"
         VERBATIM)
 

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -167,13 +167,28 @@ else()
 endif(BUILD_SHARED_LIBS)
 
 #-----------------------------------------------------------------------------
-# DEBUG CONFIGURATION - Set LZ4_DEBUG for Debug builds to enable assert()
+# DEBUG CONFIGURATION - Configurable LZ4_DEBUG level
 #-----------------------------------------------------------------------------
+# LZ4_DEBUG levels:
+# 0 - Disable everything (default for Release)
+# 1 - Enable assert() statements  
+# 2-8 - Enable debug traces with increasing verbosity
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(LZ4_DEBUG_LEVEL_DEFAULT 1)
+else()
+  set(LZ4_DEBUG_LEVEL_DEFAULT 0)
+endif()
+
+set(LZ4_DEBUG_LEVEL ${LZ4_DEBUG_LEVEL_DEFAULT} CACHE STRING 
+    "LZ4 debug level: 0=disabled, 1=assert(), 2-8=debug traces with increasing verbosity")
+set_property(CACHE LZ4_DEBUG_LEVEL PROPERTY STRINGS "0" "1" "2" "3" "4" "5" "6" "7" "8")
+
+# Apply LZ4_DEBUG configuration if level > 0
+if(LZ4_DEBUG_LEVEL GREATER 0)
   if(MSVC)
-    add_definitions(/DLZ4_DEBUG=1)
+    add_definitions(/DLZ4_DEBUG=${LZ4_DEBUG_LEVEL})
   else()
-    add_definitions(-DLZ4_DEBUG=1)
+    add_definitions(-DLZ4_DEBUG=${LZ4_DEBUG_LEVEL})
   endif()
 endif()
 

--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -12,7 +12,9 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 set(LZ4_TOP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 
-# Parse version information
+#-----------------------------------------------------------------------------
+# VERSION EXTRACTION - Parse version information from header file
+#-----------------------------------------------------------------------------
 function(parse_lz4_version VERSION_TYPE)
     file(STRINGS "${LZ4_TOP_SOURCE_DIR}/lib/lz4.h" version_line REGEX "^#define LZ4_VERSION_${VERSION_TYPE} +([0-9]+).*$")
     string(REGEX REPLACE "^#define LZ4_VERSION_${VERSION_TYPE} +([0-9]+).*$" "\\1" version_number "${version_line}")
@@ -31,6 +33,9 @@ message(STATUS "Creating build script for LZ4 version: ${LZ4_VERSION_STRING}")
 project(LZ4 VERSION ${LZ4_VERSION_STRING} LANGUAGES C)
 
 
+#-----------------------------------------------------------------------------
+# BUILD OPTIONS - Configure build targets and features
+#-----------------------------------------------------------------------------
 option(LZ4_BUILD_CLI "Build lz4 program" ON)
 option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c program with legacy argument support" OFF)
 
@@ -48,7 +53,9 @@ if(NOT DEFINED LZ4_BUNDLED_MODE)
 endif()
 mark_as_advanced(LZ4_BUNDLED_MODE)
 
-# CPack
+#-----------------------------------------------------------------------------
+# PACKAGING - CPack configuration
+#-----------------------------------------------------------------------------
 if(NOT LZ4_BUNDLED_MODE AND NOT CPack_CMake_INCLUDED)
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LZ4 compression library")
   set(CPACK_PACKAGE_DESCRIPTION_FILE "${LZ4_TOP_SOURCE_DIR}/README.md")
@@ -59,6 +66,9 @@ if(NOT LZ4_BUNDLED_MODE AND NOT CPack_CMake_INCLUDED)
   include(CPack)
 endif(NOT LZ4_BUNDLED_MODE AND NOT CPack_CMake_INCLUDED)
 
+#-----------------------------------------------------------------------------
+# LIBRARY TYPE CONFIGURATION - Static vs Shared libraries
+#-----------------------------------------------------------------------------
 # Allow people to choose whether to build shared or static libraries
 # via the BUILD_SHARED_LIBS option unless we are in bundled mode, in
 # which case we always use static libraries.
@@ -68,8 +78,11 @@ CMAKE_DEPENDENT_OPTION(BUILD_STATIC_LIBS "Build static libraries" OFF "BUILD_SHA
 
 if(NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
   message(FATAL_ERROR "Both BUILD_SHARED_LIBS and BUILD_STATIC_LIBS have been disabled")
-endif()
+endif(NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
 
+#-----------------------------------------------------------------------------
+# SOURCE FILES & DIRECTORIES - Path setup and source file collection
+#-----------------------------------------------------------------------------
 set(LZ4_LIB_SOURCE_DIR "${LZ4_TOP_SOURCE_DIR}/lib")
 set(LZ4_PROG_SOURCE_DIR "${LZ4_TOP_SOURCE_DIR}/programs")
 
@@ -82,6 +95,9 @@ file(GLOB LZ4_CLI_SOURCES
      "${LZ4_PROG_SOURCE_DIR}/*.c")
 list(APPEND LZ4_CLI_SOURCES ${LZ4_SOURCES}) # LZ4_CLI always use liblz4 sources directly.
 
+#-----------------------------------------------------------------------------
+# POSITION INDEPENDENT CODE - PIC settings for static libraries
+#-----------------------------------------------------------------------------
 # Whether to use position independent code for the static library.  If
 # we're building a shared library this is ignored and PIC is always
 # used.
@@ -89,10 +105,13 @@ if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE OR CMAKE_POSITION_INDEPENDENT_COD
   set(LZ4_POSITION_INDEPENDENT_LIB_DEFAULT ON)
 else()
   set(LZ4_POSITION_INDEPENDENT_LIB_DEFAULT OFF)
-endif()
+endif(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE OR CMAKE_POSITION_INDEPENDENT_CODE)
 
 option(LZ4_POSITION_INDEPENDENT_LIB "Use position independent code for static library (if applicable)" ${LZ4_POSITION_INDEPENDENT_LIB_DEFAULT})
 
+#-----------------------------------------------------------------------------
+# TARGETS - Library and executable targets
+#-----------------------------------------------------------------------------
 # liblz4
 include(GNUInstallDirs)
 set(LZ4_LIBRARIES_BUILT)
@@ -108,14 +127,14 @@ if(BUILD_SHARED_LIBS)
   if(MSVC)
     target_compile_definitions(lz4_shared PRIVATE
       LZ4_DLL_EXPORT=1)
-  endif()
+  endif(MSVC)
   list(APPEND LZ4_LIBRARIES_BUILT lz4_shared)
 endif()
 if(BUILD_STATIC_LIBS)
   set(STATIC_LIB_NAME lz4)
-  if (MSVC AND BUILD_SHARED_LIBS)
+  if(MSVC AND BUILD_SHARED_LIBS)
     set(STATIC_LIB_NAME lz4_static)
-  endif()
+  endif(MSVC AND BUILD_SHARED_LIBS)
   add_library(lz4_static STATIC ${LZ4_SOURCES})
   target_include_directories(lz4_static
     PUBLIC $<BUILD_INTERFACE:${LZ4_LIB_SOURCE_DIR}>
@@ -132,38 +151,47 @@ if(BUILD_SHARED_LIBS)
   target_link_libraries(lz4 INTERFACE lz4_shared)
 else()
   target_link_libraries(lz4 INTERFACE lz4_static)
-endif()
+endif(BUILD_SHARED_LIBS)
 
+#-----------------------------------------------------------------------------
+# NAMESPACE CONFIGURATION - xxHash namespace settings
+#-----------------------------------------------------------------------------
 # xxhash namespace
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(lz4_shared PRIVATE
     XXH_NAMESPACE=LZ4_)
-endif()
+endif(BUILD_SHARED_LIBS)
 if(BUILD_STATIC_LIBS)
   target_compile_definitions(lz4_static PRIVATE
     XXH_NAMESPACE=LZ4_)
-endif()
+endif(BUILD_STATIC_LIBS)
 
+#-----------------------------------------------------------------------------
+# CLI EXECUTABLES - Configuring command-line programs
+#-----------------------------------------------------------------------------
 # lz4
-if (LZ4_BUILD_CLI)
+if(LZ4_BUILD_CLI)
   set(LZ4_PROGRAMS_BUILT lz4cli)
   add_executable(lz4cli ${LZ4_CLI_SOURCES})
   set_target_properties(lz4cli PROPERTIES OUTPUT_NAME lz4)
-endif()
+endif(LZ4_BUILD_CLI)
 
 # lz4c
-if (LZ4_BUILD_LEGACY_LZ4C)
+if(LZ4_BUILD_LEGACY_LZ4C)
   list(APPEND LZ4_PROGRAMS_BUILT lz4c)
   add_executable(lz4c ${LZ4_CLI_SOURCES})
   set_target_properties(lz4c PROPERTIES COMPILE_DEFINITIONS "ENABLE_LZ4C_LEGACY_OPTIONS")
-endif()
+endif(LZ4_BUILD_LEGACY_LZ4C)
 
+#-----------------------------------------------------------------------------
+# COMPILER FLAGS - Configure warning flags and compiler-specific options
+#-----------------------------------------------------------------------------
 # Extra warning flags
 if(MSVC)
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /W4")
 else()
-  include (CheckCCompilerFlag)
-  foreach (flag
+  include(CheckCCompilerFlag)
+  foreach(flag
       # GCC-style
       -pedantic-errors
       -Wall
@@ -189,10 +217,13 @@ else()
 
     unset(test_name)
     unset(flag_to_test)
-  endforeach (flag)
-endif()
+  endforeach(flag)
+endif(MSVC)
 
 
+#-----------------------------------------------------------------------------
+# INSTALLATION - Install targets, headers, and documentation
+#-----------------------------------------------------------------------------
 if(NOT LZ4_BUNDLED_MODE)
   install(TARGETS ${LZ4_PROGRAMS_BUILT}
     BUNDLE	DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -213,6 +244,9 @@ if(NOT LZ4_BUNDLED_MODE)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/liblz4.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
+#-----------------------------------------------------------------------------
+# CMAKE PACKAGE CONFIG - Configure CMake package for find_package support
+#-----------------------------------------------------------------------------
   include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/lz4ConfigVersion.cmake"
@@ -237,6 +271,9 @@ if(NOT LZ4_BUNDLED_MODE)
       ${CMAKE_CURRENT_BINARY_DIR}/lz4ConfigVersion.cmake
     DESTINATION ${LZ4_PKG_INSTALLDIR})
 
+#-----------------------------------------------------------------------------
+# SYMLINKS - Create and install Unix symlinks and manpage aliases
+#-----------------------------------------------------------------------------
   # Install lz4cat and unlz4 symlinks on Unix systems
   if(UNIX AND LZ4_BUILD_CLI)
     foreach(cli_tool IN ITEMS lz4cat unlz4)
@@ -262,6 +299,9 @@ if(NOT LZ4_BUNDLED_MODE)
   endif(UNIX AND LZ4_BUILD_CLI)
 endif(NOT LZ4_BUNDLED_MODE)
 
+#-----------------------------------------------------------------------------
+# PKG-CONFIG - Generate and install pkg-config file
+#-----------------------------------------------------------------------------
 # pkg-config
 set(PREFIX "${CMAKE_INSTALL_PREFIX}")
 
@@ -269,13 +309,13 @@ if("${CMAKE_INSTALL_FULL_LIBDIR}" STREQUAL "${CMAKE_INSTALL_PREFIX}/${CMAKE_INST
   set(LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
 else()
   set(LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
-endif()
+endif("${CMAKE_INSTALL_FULL_LIBDIR}" STREQUAL "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 if("${CMAKE_INSTALL_FULL_INCLUDEDIR}" STREQUAL "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
   set(INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 else()
   set(INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
-endif()
+endif("${CMAKE_INSTALL_FULL_INCLUDEDIR}" STREQUAL "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 # for liblz4.pc substitution
 set(VERSION ${LZ4_VERSION_STRING})

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -898,7 +898,7 @@ LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
           || tableType == byPtr
           || inputSize >= 4 KB)
         {
-            DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", cctx);
+            DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", (void*)cctx);
             MEM_INIT(cctx->hashTable, 0, LZ4_HASHTABLESIZE);
             cctx->currentOffset = 0;
             cctx->tableType = (U32)clearedTable;
@@ -1534,7 +1534,7 @@ LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
     LZ4_STATIC_ASSERT(sizeof(LZ4_stream_t) >= sizeof(LZ4_stream_t_internal));
-    DEBUGLOG(4, "LZ4_createStream %p", lz4s);
+    DEBUGLOG(4, "LZ4_createStream %p", (void*)lz4s);
     if (lz4s == NULL) return NULL;
     LZ4_initStream(lz4s, sizeof(*lz4s));
     return lz4s;
@@ -1565,7 +1565,7 @@ LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
  * prefer initStream() which is more general */
 void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
 {
-    DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", LZ4_stream);
+    DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", (void*)LZ4_stream);
     MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t_internal));
 }
 
@@ -1577,7 +1577,7 @@ void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
 int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
 {
     if (!LZ4_stream) return 0;   /* support free on NULL */
-    DEBUGLOG(5, "LZ4_freeStream %p", LZ4_stream);
+    DEBUGLOG(5, "LZ4_freeStream %p", (void*)LZ4_stream);
     FREEMEM(LZ4_stream);
     return (0);
 }
@@ -1596,7 +1596,7 @@ int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
     const BYTE* const dictEnd = p + dictSize;
     U32 idx32;
 
-    DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, dictionary, LZ4_dict);
+    DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, (void*)dictionary, (void*)LZ4_dict);
 
     /* It's necessary to reset the context,
      * and not just continue it with prepareTable()
@@ -1663,7 +1663,7 @@ void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dict
         &(dictionaryStream->internal_donotuse);
 
     DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)",
-             workingStream, dictionaryStream,
+             (void*)workingStream, (void*)dictionaryStream,
              dictCtx != NULL ? dictCtx->dictSize : 0);
 
     if (dictCtx != NULL) {
@@ -1727,7 +1727,7 @@ int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
       && (inputSize > 0)               /* tolerance : don't lose history, in case next invocation would use prefix mode */
       && (streamPtr->dictCtx == NULL)  /* usingDictCtx */
       ) {
-        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, streamPtr->dictionary);
+        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, (void*)streamPtr->dictionary);
         /* remove dictionary existence from history, to employ faster prefix mode */
         streamPtr->dictSize = 0;
         streamPtr->dictionary = (const BYTE*)source;
@@ -1817,7 +1817,7 @@ int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 {
     LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
 
-    DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, safeBuffer);
+    DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, (void*)safeBuffer);
 
     if ((U32)dictSize > 64 KB) { dictSize = 64 KB; } /* useless to define a dictionary > 64 KB */
     if ((U32)dictSize > dict->dictSize) { dictSize = (int)dict->dictSize; }
@@ -2313,8 +2313,8 @@ LZ4_decompress_generic(
                       */
                     if ((ip+length != iend) || (cpy > oend)) {
                         DEBUGLOG(5, "should have been last run of literals")
-                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", ip, (int)length, ip+length, iend);
-                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", cpy, oend-MFLIMIT);
+                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", (void*)ip, (int)length, (void*)(ip+length), (void*)iend);
+                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", (void*)cpy, (void*)(oend-MFLIMIT));
                         DEBUGLOG(5, "after writing %u bytes / %i bytes available", (unsigned)(op-(BYTE*)dst), outputSize);
                         goto _output_error;
                     }

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0.2)
 
 project(cmake_install_test LANGUAGES C)
 


### PR DESCRIPTION
Also:
- use `Release` mode by default when none provided
- enable `assert()` with `LZ4_DEBUG` in `Debug` builds
- fix race condition when building using `--parallel`
- made `LZ4_DEBUG` level configurable via GUI
- added tests to check the new properties