### PR TITLE
lz4_Frame_format.md: document kernel legacy last block

### DIFF
--- a/doc/lz4_Frame_format.md
+++ b/doc/lz4_Frame_format.md
@@ -358,7 +358,9 @@ Main characteristics of the legacy format :
 - All blocks are always compressed, even when compression is detrimental.
 - The last block is detected either because
   it is followed by the “EOF” (End of File) mark,
-  or because it is followed by a known Frame Magic Number.
+  or because it is followed by a known Frame Magic Number.<br>
+  In the Linux Kernel implementation, it can also be detected because it
+  is followed by a sequence of four zero bytes.
 - No checksum
 - Convention is Little endian
 


### PR DESCRIPTION
Since https://github.com/torvalds/linux/commit/2c484419efc09e7234c667aa72698cb79ba8d8ed, the Linux Kernel is able to discern the end of a legacy LZ4 frame by the presence of four 0 bytes, parsed as a B.CSize of 0 in the decoder. This is originally intended to make it mix well with grub initrd concatenation behavior (which uses a clause in the initramfs format about allowing arbitrary zero paddings), but I think it is a pretty good idea for any application limited to the legacy format in general.