### PR TITLE
Touch up double buffer example

### DIFF
--- a/examples/blockStreaming_doubleBuffer.md
+++ b/examples/blockStreaming_doubleBuffer.md
@@ -32,10 +32,16 @@ Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
          |
          v
       {Out#1}
+```
 
+Next, read first block to double buffer's first page. And compress it by `LZ4_compress_continue()`.
+For the first time, LZ4 doesn't know any previous dependencies,
+so it just compress the line without dependencies and generates compressed block {Out#1} to LZ4 compressed data buffer.
+After that, write {Out#1} to the file.
 
+```
       Prefix Dependency
-         +---------+
+
          |         |
          v         |
     +---------+----+----+
@@ -44,8 +50,13 @@ Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
                    |
                    v
                 {Out#2}
+```
 
+Next, read second block to double buffer's second page. And compress it.
+This time, LZ4 can use dependency to Block#1 to improve compression ratio.
+This dependency is called "Prefix mode".
 
+```
    External Dictionary Mode
          +---------+
          |         |
@@ -56,8 +67,13 @@ Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
          |
          v
       {Out#3}
+```
 
+Next, read third block to double buffer's *first* page, and compress it.
+Also this time, LZ4 can use dependency to Block#2.
+This dependency is called "External Dictonaly mode".
 
+```
       Prefix Dependency
          +---------+
          |         |
@@ -69,19 +85,6 @@ Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
                    v
                 {Out#4}
 ```
-
-Next, read first block to double buffer's first page. And compress it by `LZ4_compress_continue()`.
-For the first time, LZ4 doesn't know any previous dependencies,
-so it just compress the line without dependencies and generates compressed block {Out#1} to LZ4 compressed data buffer.
-After that, write {Out#1} to the file.
-
-Next, read second block to double buffer's second page. And compress it.
-This time, LZ4 can use dependency to Block#1 to improve compression ratio.
-This dependency is called "Prefix mode".
-
-Next, read third block to double buffer's *first* page, and compress it.
-Also this time, LZ4 can use dependency to Block#2.
-This dependency is called "External Dictonaly mode".
 
 Continue these procedure to the end of the file.
 

--- a/examples/blockStreaming_doubleBuffer.md
+++ b/examples/blockStreaming_doubleBuffer.md
@@ -13,10 +13,13 @@ Please note:
 
 ## What's the point of this example?
 
-- Handle huge file in small amount of memory
-- Always better compression ratio than Block API
-- Uniform block size
+The LZ4 Streaming API can be used to handle compressing a huge file in a small
+amount of memory. This example shows how to use a "Double Buffer" to compress
+blocks (i.e. chunks) of a uniform size in a stream. The Streaming API used in
+this way *always* yields a better compression ratio than the regular Block API.
 
+For an example with non-uniform blocks, see ["LZ4 Streaming API Example: Line by
+Line Text Compression"](blockStreaming_lineByLine.md).
 
 ## How compression works
 

--- a/examples/blockStreaming_doubleBuffer.md
+++ b/examples/blockStreaming_doubleBuffer.md
@@ -1,28 +1,28 @@
-﻿# LZ4 Streaming API Example : Double Buffer
+﻿# LZ4 Streaming API Example: Double Buffer
 by *Takayuki Matsuoka*
 
-`blockStreaming_doubleBuffer.c` is an example of the LZ4 Streaming API where we
-implement double buffer (de)compression.
+[`blockStreaming_doubleBuffer.c`](blockStreaming_doubleBuffer.c) is an example
+of the LZ4 Streaming API where we implement double buffer (de)compression.
 
-Please note :
+Please note:
 
- - Firstly, read "LZ4 Streaming API Basics".
- - This is a relatively advanced application example.
- - The output file is not compatible with lz4frame and is platform dependent.
+- Firstly, read ["LZ4 Streaming API Basics"](streaming_api_basics.md).
+- This is a relatively advanced application example.
+- The output file is not compatible with lz4frame and is platform dependent.
 
 
-## What's the point of this example ?
+## What's the point of this example?
 
- - Handle huge file in small amount of memory
- - Always better compression ratio than Block API
- - Uniform block size
+- Handle huge file in small amount of memory
+- Always better compression ratio than Block API
+- Uniform block size
 
 
 ## How compression works
 
 Firstly, allocate "Double Buffer" for input and "compressed data buffer" for
-output. Double buffer has two pages, the "first" page (Page#1) and the "second"
-page (Page#2).
+output. Double buffer has two pages, the "first" page (`Page#1`) and the "second"
+page (`Page#2`).
 
 ```
         Double Buffer
@@ -40,7 +40,7 @@ Next, read the first block to the double buffer's first page. Compress it with
 `LZ4_compress_continue()`. On the first compression, LZ4 doesn't have any
 previous dependencies, so it just compresses the block without dependencies and
 writes the compressed block `{Out#1}` to the compressed data buffer. After that,
-write {Out#1} to the file.
+write `{Out#1}` to the file.
 
 ```
       Prefix Dependency
@@ -56,7 +56,7 @@ write {Out#1} to the file.
 ```
 
 Next, read the second block to the double buffer's second page and compress it.
-This time, LZ4 can use the dependency on Block#1 to improve the compression
+This time, LZ4 can use the dependency on `Block#1` to improve the compression
 ratio. This dependency is called "Prefix mode".
 
 ```
@@ -96,11 +96,11 @@ Continue this procedure till the end of the file.
 
 Decompression follows the reverse order:
 
- - Read the first compressed block.
- - Decompress it to the first page and write that page to the file.
- - Read the second compressed block.
- - Decompress it to the second page and write that page to the file.
- - Read the third compressed block.
- - Decompress it to the *first* page and write that page to the file.
+- Read the first compressed block.
+- Decompress it to the first page and write that page to the file.
+- Read the second compressed block.
+- Decompress it to the second page and write that page to the file.
+- Read the third compressed block.
+- Decompress it to the *first* page and write that page to the file.
 
 Continue this procedure till the end of the compressed file.

--- a/examples/blockStreaming_doubleBuffer.md
+++ b/examples/blockStreaming_doubleBuffer.md
@@ -1,13 +1,14 @@
 ﻿# LZ4 Streaming API Example : Double Buffer
 by *Takayuki Matsuoka*
 
-`blockStreaming_doubleBuffer.c` is LZ4 Streaming API example which implements double buffer (de)compression.
+`blockStreaming_doubleBuffer.c` is an example of the LZ4 Streaming API where we
+implement double buffer (de)compression.
 
 Please note :
 
  - Firstly, read "LZ4 Streaming API Basics".
- - This is relatively advanced application example.
- - Output file is not compatible with lz4frame and platform dependent.
+ - This is a relatively advanced application example.
+ - The output file is not compatible with lz4frame and is platform dependent.
 
 
 ## What's the point of this example ?
@@ -17,10 +18,11 @@ Please note :
  - Uniform block size
 
 
-## How the compression works
+## How compression works
 
-First of all, allocate "Double Buffer" for input and LZ4 compressed data buffer for output.
-Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
+Firstly, allocate "Double Buffer" for input and "compressed data buffer" for
+output. Double buffer has two pages, the "first" page (Page#1) and the "second"
+page (Page#2).
 
 ```
         Double Buffer
@@ -34,10 +36,11 @@ Double buffer has two pages, "first" page (Page#1) and "second" page (Page#2).
       {Out#1}
 ```
 
-Next, read first block to double buffer's first page. And compress it by `LZ4_compress_continue()`.
-For the first time, LZ4 doesn't know any previous dependencies,
-so it just compress the line without dependencies and generates compressed block {Out#1} to LZ4 compressed data buffer.
-After that, write {Out#1} to the file.
+Next, read the first block to the double buffer's first page. Compress it with
+`LZ4_compress_continue()`. On the first compression, LZ4 doesn't have any
+previous dependencies, so it just compresses the block without dependencies and
+writes the compressed block `{Out#1}` to the compressed data buffer. After that,
+write {Out#1} to the file.
 
 ```
       Prefix Dependency
@@ -52,9 +55,9 @@ After that, write {Out#1} to the file.
                 {Out#2}
 ```
 
-Next, read second block to double buffer's second page. And compress it.
-This time, LZ4 can use dependency to Block#1 to improve compression ratio.
-This dependency is called "Prefix mode".
+Next, read the second block to the double buffer's second page and compress it.
+This time, LZ4 can use the dependency on Block#1 to improve the compression
+ratio. This dependency is called "Prefix mode".
 
 ```
    External Dictionary Mode
@@ -69,9 +72,9 @@ This dependency is called "Prefix mode".
       {Out#3}
 ```
 
-Next, read third block to double buffer's *first* page, and compress it.
-Also this time, LZ4 can use dependency to Block#2.
-This dependency is called "External Dictonaly mode".
+Next, read the third block to the double buffer's *first* page and compress it.
+This time LZ4 can use dependency on Block#2. This dependency is called "External
+Dictionary mode".
 
 ```
       Prefix Dependency
@@ -86,18 +89,18 @@ This dependency is called "External Dictonaly mode".
                 {Out#4}
 ```
 
-Continue these procedure to the end of the file.
+Continue this procedure till the end of the file.
 
 
-## How the decompression works
+## How decompression works
 
-Decompression will do reverse order.
+Decompression follows the reverse order:
 
- - Read first compressed block.
+ - Read the first compressed block.
  - Decompress it to the first page and write that page to the file.
- - Read second compressed block.
+ - Read the second compressed block.
  - Decompress it to the second page and write that page to the file.
- - Read third compressed block.
+ - Read the third compressed block.
  - Decompress it to the *first* page and write that page to the file.
 
-Continue these procedure to the end of the compressed file.
+Continue this procedure till the end of the compressed file.


### PR DESCRIPTION
This commit touches up the line by line compression example in
`example/blockStreaming_doubleBuffer.md` by:

- Splitting the ASCII illustrations and presenting them in a more natural to
  read order
- Fixing the grammar and rewording some sentences
- Formatting each paragraph (with Emacs' `M-q (fill-paragraph)`)
- Expanding the "What's the point of this example?" section
