### PR TITLE
Configure LZ4_FORCE_MEMORY_ACCESS=2 for RISC-V with Zicclsm extension

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -77,7 +77,8 @@
 #ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally */
 #  if defined(__GNUC__) && \
   ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) \
-  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) )
+  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) \
+  || (defined(__riscv) && defined(__riscv_zicclsm)) )
 #    define LZ4_FORCE_MEMORY_ACCESS 2
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || defined(__GNUC__) || defined(_MSC_VER)
 #    define LZ4_FORCE_MEMORY_ACCESS 1


### PR DESCRIPTION
During testing, we found that direct access to unaligned memory is currently the optimal approach on RISC-V, similar to the approach on ARMv6. We found that GCC has a corresponding macro, [Zicclsm](https://gcc.gnu.org/pipermail/gcc-patches/2024-February/644655.html), that can determine whether the hardware is accessing unaligned memory, and the Zicclsm extension is mandatory per the [RVA20U64 specification](https://github.com/riscv/riscv-profiles/blob/5879c13c924ec5636995c5883f40337e83f6049a/src/profiles.adoc#L658). Furthermore, I have tested that on servers that do not support the Zicclsm extension, this modification does not affect the original judgment criteria.

Supported versions: GCC14.1.0 and above
**Description**
Zicclsm: Main memory supports misaligned loads/stores

## **Test data**
environment information
```shell
[root@localhost lzbench-master]# dmidecode -t processor | grep "Version"
        Version: SG2044
[root@localhost lzbench-master]# uname -a
Linux localhost.localdomain 6.12.21-0.0.0.0.riscv64 #1 SMP Tue Apr  1 03:58:14 CST 2025 riscv64 riscv64 riscv64 GNU/Linux
```

### Performance Comparison
| Configuration | Test Runs | Compression Speed (MB/s) | Average Speed (MB/s) | Improvement Ratio |
|---------------|-----------|--------------------------|----------------------|-------------------|
| Without Zicclsm extension | 1st run | 160 | 160 | - (Baseline) |
|  | 2nd run | 160 |  |  |
|  | 3rd run | 160 |  |  |
| With Zicclsm extension | 1st run | 218 | 215 | +34.38% |
|  | 2nd run | 211 |  |  |
|  | 3rd run | 216 |  |  |

### Scenario 1
Compile without the zicclsm extension
```shell
make CC=/home/gcc-15.2.0/install/bin/riscv64-unknown-linux-gnu-gcc \
CXX=/home/gcc-15.2.0/install/bin/riscv64-unknown-linux-gnu-g++ \
MOREFLAGS="-march=rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt \
-fpermissive -static -g -L/home/gcc-15.2.0/install/lib"  \
DONT_BUILD_TORNADO=1 -j64
```
Test speed
<img width="704" height="274" alt="image" src="https://github.com/user-attachments/assets/30801539-cb27-4bdb-beb5-6f05a02ec465" />

### Scenario 2
Compile with the zicclsm extension
```shell
make CC=/home/gcc-15.2.0/install/bin/riscv64-unknown-linux-gnu-gcc \
CXX=/home/gcc-15.2.0/install/bin/riscv64-unknown-linux-gnu-g++ \
MOREFLAGS="-march=rv64imafdcv_zicbom_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zawrs_zfa_zfh_zfhmin_zca_zcb_zcd_zba_zbb_zbc_zbs_zve32f_zve32x_zve64d_zve64f_zve64x_zvfh_zvfhmin_sscofpmf_sstc_svinval_svnapot_svpbmt_zicclsm \
 -fpermissive -static -g -L/home/gcc-15.2.0/install/lib" \
 DONT_BUILD_TORNADO=1 -j64
```
Test speed
<img width="714" height="272" alt="image" src="https://github.com/user-attachments/assets/dbe28ce9-4fbd-404b-af3c-2fb49c2159a4" />

