### PR TITLE
target reference their dependencies by their full path

### DIFF
--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -168,12 +168,9 @@ endef # addTargetCxxObject
 
 # Create targets for individual object files
 C_SRCDIRS += .
-vpath %.c $(C_SRCDIRS)
 CXX_SRCDIRS += .
-vpath %.cpp $(CXX_SRCDIRS)
-vpath %.cc $(CXX_SRCDIRS)
 ASM_SRCDIRS += .
-vpath %.S $(ASM_SRCDIRS)
+
 
 # If C_SRCDIRS, CXX_SRCDIRS and ASM_SRCDIRS are not defined, use C_SRCS, CXX_SRCS and ASM_SRCS
 C_SRCS   ?= $(foreach dir,$(C_SRCDIRS),$(wildcard $(dir)/*.c))

--- a/build/make/multiconf.make
+++ b/build/make/multiconf.make
@@ -99,6 +99,26 @@ MKDIR ?= mkdir
 LN ?= ln
 
 # --------------------------------------------------------------------------------------------
+# Path sanitization helpers
+# --------------------------------------------------------------------------------------------
+# Object files may originate from sources that sit outside of the current
+# directory (for example "../lib/foo.c").  Building such objects directly under
+# $(CACHE_ROOT) would escape the cache directory because of the "../" segments.
+# The following helpers normalize these paths into a cache-safe representation
+# while keeping enough structure to avoid collisions between same-named files
+# that live in different directories.  In particular, each "../" segment turns
+# into "__/", absolute paths gain a "__root__/" prefix, and `./` prefixes are
+# stripped.
+
+mcm_norm_slashes = $(subst \,/,$(1))
+mcm_escape_colon = $(subst :,_,$(1))
+mcm_strip_leading_dot = $(patsubst ./%,%,$(1))
+mcm_escape_parent = $(subst ../,__/,$(1))
+mcm_prefix_absolute = $(if $(filter /%,$(1)),$(patsubst /%,__root__/%,$(1)),$(1))
+mcm_sanitize = $(call mcm_prefix_absolute,$(call mcm_escape_parent,$(call mcm_strip_leading_dot,$(call mcm_escape_colon,$(call mcm_norm_slashes,$(1))))))
+mcm_sanitize_list = $(foreach f,$(strip $(1)),$(call mcm_sanitize,$(f)))
+
+# --------------------------------------------------------------------------------------------
 # The following macros are used to create object files in the cache directory.
 # The object files are named after the source file, but with a different path.
 
@@ -116,30 +136,33 @@ $(CACHE_ROOT)/%/. :
 define addTargetAsmObject  # targetName, addlDeps
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2))))
 
-.PRECIOUS: $$(CACHE_ROOT)/%/$(1)
-$$(CACHE_ROOT)/%/$(1) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
+.PRECIOUS: $$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1))
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $(1:.o=.S) $(2) | $$(CACHE_ROOT)/%/.
+	@$$(MKDIR) -p $$(@D)
 	@echo AS $$@
-	$$(CC) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(1:.o=.d) -c $$< -o $$@
+	$$(CC) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(call mcm_sanitize,$(1:.o=.d)) -c $$< -o $$@
 
 endef # addTargetAsmObject
 
 define addTargetCObject  # targetName, addlDeps
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2)))) #debug print
 
-.PRECIOUS: $$(CACHE_ROOT)/%/$(1)
-$$(CACHE_ROOT)/%/$(1) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
+.PRECIOUS: $$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1))
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $(1:.o=.c) $(2) | $$(CACHE_ROOT)/%/.
+	@$$(MKDIR) -p $$(@D)
 	@echo CC $$@
-	$$(CC) $$(CPPFLAGS) $$(CFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(1:.o=.d) -c $$< -o $$@
+	$$(CC) $$(CPPFLAGS) $$(CFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(call mcm_sanitize,$(1:.o=.d)) -c $$< -o $$@
 
 endef # addTargetCObject
 
 define addTargetCxxObject  # targetName, suffix, addlDeps
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3))))
 
-.PRECIOUS: $$(CACHE_ROOT)/%/$(1)
-$$(CACHE_ROOT)/%/$(1) : $(1:.o=.$(2)) $(3) | $$(CACHE_ROOT)/%/.
+.PRECIOUS: $$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1))
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $(1:.o=.$(2)) $(3) | $$(CACHE_ROOT)/%/.
+	@$$(MKDIR) -p $$(@D)
 	@echo CXX $$@
-	$$(CXX) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(1:.o=.d) -c $$< -o $$@
+	$$(CXX) $$(CPPFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) $$(CACHE_ROOT)/$$*/$(call mcm_sanitize,$(1:.o=.d)) -c $$< -o $$@
 
 endef # addTargetCxxObject
 
@@ -153,11 +176,11 @@ ASM_SRCDIRS += .
 vpath %.S $(ASM_SRCDIRS)
 
 # If C_SRCDIRS, CXX_SRCDIRS and ASM_SRCDIRS are not defined, use C_SRCS, CXX_SRCS and ASM_SRCS
-C_SRCS   ?= $(notdir $(foreach dir,$(C_SRCDIRS),$(wildcard $(dir)/*.c)))
-CPP_SRCS ?= $(notdir $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cpp)))
-CC_SRCS  ?= $(notdir $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cc)))
+C_SRCS   ?= $(foreach dir,$(C_SRCDIRS),$(wildcard $(dir)/*.c))
+CPP_SRCS ?= $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cpp))
+CC_SRCS  ?= $(foreach dir,$(CXX_SRCDIRS),$(wildcard $(dir)/*.cc))
 CXX_SRCS ?= $(CPP_SRCS) $(CC_SRCS)
-ASM_SRCS ?= $(notdir $(foreach dir,$(ASM_SRCDIRS),$(wildcard $(dir)/*.S)))
+ASM_SRCS ?= $(foreach dir,$(ASM_SRCDIRS),$(wildcard $(dir)/*.S))
 
 # If C_SRCS, CXX_SRCS and ASM_SRCS are not defined, use C_OBJS, CXX_OBJS and ASM_OBJS
 C_OBJS   ?= $(patsubst %.c,%.o,$(C_SRCS))
@@ -181,7 +204,7 @@ define static_library  # targetName, targetDeps, addlDeps, addRecipe, hashComple
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
 MCM_ALL_BINS += $(1)
 
-$$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $$(addprefix $$(CACHE_ROOT)/%/,$(call mcm_sanitize_list,$(2))) $(3)
 	@echo AR $$@
 	$$(AR) $$(ARFLAGS) $$@ $$^
 	$(4)
@@ -199,7 +222,7 @@ define c_dynamic_library  # targetName, targetDeps, addlDeps, addRecipe, hashCom
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5))))
 MCM_ALL_BINS += $(1)
 
-$$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $$(addprefix $$(CACHE_ROOT)/%/,$(call mcm_sanitize_list,$(2))) $(3)
 	@echo LD $$@
 	$$(CC) $$(CPPFLAGS) $$(CFLAGS) $$(LDFLAGS) -shared -o $$@ $$^ $$(LDLIBS)
 	$(4)
@@ -217,7 +240,7 @@ define program_base  # targetName, targetDeps, addlDeps, addRecipe, hashCompleme
 $$(if $$(filter 2,$$(V)),$$(info $$(call $(0),$(1),$(2),$(3),$(4),$(5),$(6),$(7))))
 MCM_ALL_BINS += $(1)
 
-$$(CACHE_ROOT)/%/$(1) : $$(addprefix $$(CACHE_ROOT)/%/,$(2)) $(3)
+$$(CACHE_ROOT)/%/$(call mcm_sanitize,$(1)) : $$(addprefix $$(CACHE_ROOT)/%/,$(call mcm_sanitize_list,$(2))) $(3)
 	@echo LD $$@
 	$$($(6)) $$(CPPFLAGS) $$($(7)) $$^ -o $$@ $$(LDFLAGS) $$(LDLIBS)
 	$(4)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -39,7 +39,7 @@ TESTFILE_SMALL= .gitignore
 LZ4DIR     = ../programs
 LZ4        = $(LZ4DIR)/lz4
 LIBLZ4DIR  = ../lib
-LIBLZ4SRCS = $(notdir $(wildcard $(LIBLZ4DIR)/*.c))
+LIBLZ4SRCS = $(wildcard $(LIBLZ4DIR)/*.c)
 LIBLZ4OBJS = $(LIBLZ4SRCS:.c=.o)
 SLIBLZ4   := liblz4.a
 

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -97,7 +97,7 @@ all: lz4 lz4-nomt lz4c unlz4 lz4cat
 all32: CFLAGS+=-m32
 all32: all
 
-LZ4_OBJS := $(notdir $(OBJFILES))
+LZ4_OBJS := $(OBJFILES)
 
 ifeq ($(WINBASED),yes)
 lz4-exe.rc: lz4-exe.rc.in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,6 +55,9 @@ TEST_FILES   := COPYING
 FUZZER_TIME  := -T90s
 NB_LOOPS     ?= -i1
 
+LIB_CORE_OBJS  := $(addprefix $(LIBDIR)/,lz4.o lz4hc.o xxhash.o)
+LIB_FRAME_OBJS := $(addprefix $(LIBDIR)/,lz4.o lz4hc.o lz4frame.o xxhash.o)
+
 .PHONY: default
 default: all
 
@@ -86,7 +89,7 @@ lz4c32:  # create a 32-bits version for 32/64 interop tests
 
 fullbench : DEBUGLEVEL=0
 fullbench : CPPFLAGS += -DNDEBUG
-$(eval $(call c_program,fullbench,fullbench.o lz4.o lz4hc.o lz4frame.o xxhash.o))
+$(eval $(call c_program,fullbench,fullbench.o $(LIB_FRAME_OBJS)))
 
 .PHONY: $(LIBDIR)/liblz4.a
 $(LIBDIR)/liblz4.a:
@@ -114,25 +117,25 @@ fullbench-wmalloc: CPPFLAGS += -DLZ4_USER_MEMORY_FUNCTIONS
 fullbench-wmalloc: fullbench
 
 fuzzer:
-$(eval $(call c_program_shared_o,fuzzer,lz4.o lz4hc.o xxhash.o fuzzer.o))
+$(eval $(call c_program_shared_o,fuzzer,$(LIB_CORE_OBJS) fuzzer.o))
 
 frametest:
-$(eval $(call c_program_shared_o,frametest,lz4frame.o lz4.o lz4hc.o xxhash.o frametest.o))
+$(eval $(call c_program_shared_o,frametest,$(LIB_FRAME_OBJS) frametest.o))
 
 roundTripTest:
-$(eval $(call c_program_shared_o,roundTripTest,lz4.o lz4hc.o xxhash.o roundTripTest.o))
+$(eval $(call c_program_shared_o,roundTripTest,$(LIB_CORE_OBJS) roundTripTest.o))
 
 datagen: CPPFLAGS+=-DNDEBUG
-$(eval $(call c_program,datagen,datagen.o lorem.o loremOut.o datagencli.o))
+$(eval $(call c_program,datagen,datagen.o $(PRGDIR)/lorem.o loremOut.o datagencli.o))
 
 checkFrame:
-$(eval $(call c_program_shared_o,checkFrame,lz4.o lz4hc.o xxhash.o lz4frame.o checkFrame.o))
+$(eval $(call c_program_shared_o,checkFrame,$(LIB_FRAME_OBJS) checkFrame.o))
 
 decompress-partial:
-$(eval $(call c_program_shared_o,decompress-partial,lz4.o decompress-partial.o))
+$(eval $(call c_program_shared_o,decompress-partial,$(LIBDIR)/lz4.o decompress-partial.o))
 
 decompress-partial-usingDict:
-$(eval $(call c_program_shared_o,decompress-partial-usingDict,lz4.o decompress-partial-usingDict.o))
+$(eval $(call c_program_shared_o,decompress-partial-usingDict,$(LIBDIR)/lz4.o decompress-partial-usingDict.o))
 
 .PHONY: clean
 clean: clean_cache


### PR DESCRIPTION
Relative or absolute, depending on how their directories are supplied to `multiconf.make`.
This makes it possible to have multiple units with the same name but in different directories.
drops `vpath` which is no longer useful.