### PR TITLE
CircleCI: Test using Python 3.14 instead of 3.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     - run: make -C tests test-frametest
     - run: make -C tests test-fuzzer && make clean
     - run: make -C lib all           && make clean
-    - run: pyenv global 3.4.4; CPPFLAGS=-I/usr/include/x86_64-linux-gnu make versionsTest && make clean
+    - run: pyenv global 3.14; CPPFLAGS=-I/usr/include/x86_64-linux-gnu make versionsTest && make clean
     - run: make test-install         && make clean
     - run: gcc -v; CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
     - run: clang -v; make staticAnalyze && make clean


### PR DESCRIPTION
* https://devguide.python.org/versions
* https://www.python.org/downloads/release/python-3140/