### PR TITLE
[ci] update FreeBSD image to 16

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ task:
   name: FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-2
+      image_family: freebsd-16-0-snap
   install_script: pkg install -y gmake
   script: |
     cc -v


### PR DESCRIPTION
since 14.2 is no longer supported by CirrusCI