### PR TITLE
fix heap overflow in multi-file output filename construction

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -959,15 +959,25 @@ int LZ4IO_compressMultipleFilenames_Legacy(
             continue;
         }
 
-        if (ofnSize <= ifnSize+suffixSize+1) {
-            free(dstFileName);
-            ofnSize = ifnSize + 20;
-            dstFileName = (char*)malloc(ofnSize);
-            if (dstFileName==NULL) {
+        {   size_t neededSize;
+            if (ifnSize > (size_t)-1 - suffixSize - 1) {  /* size_t overflow */
+                free(dstFileName);
                 return ifntSize;
-        }   }
-        strcpy(dstFileName, inFileNamesTable[i]);
-        strcat(dstFileName, suffix);
+            }
+            neededSize = ifnSize + suffixSize + 1;
+            if (ofnSize < neededSize) {
+                char* const newDstFileName = (char*)realloc(dstFileName, neededSize);
+                if (newDstFileName == NULL) {
+                    free(dstFileName);
+                    return ifntSize;
+                }
+                dstFileName = newDstFileName;
+                ofnSize = neededSize;
+            }
+            memcpy(dstFileName, inFileNamesTable[i], ifnSize);
+            memcpy(dstFileName + ifnSize, suffix, suffixSize);
+            dstFileName[ifnSize + suffixSize] = '\0';
+        }
 
         missed_files += LZ4IO_compressLegacy_internal(&processed,
                                 inFileNamesTable[i], dstFileName,
@@ -1559,16 +1569,27 @@ int LZ4IO_compressMultipleFilenames(
             continue;
         }
         /* suffix != stdout => compress into a file => generate its name */
-        if (ofnSize <= ifnSize+suffixSize+1) {
-            free(dstFileName);
-            ofnSize = ifnSize + 20;
-            dstFileName = (char*)malloc(ofnSize);
-            if (dstFileName==NULL) {
+        {   size_t neededSize;
+            if (ifnSize > (size_t)-1 - suffixSize - 1) {  /* size_t overflow */
+                free(dstFileName);
                 LZ4IO_freeCResources(ress);
                 return ifntSize;
-        }   }
-        strcpy(dstFileName, inFileNamesTable[i]);
-        strcat(dstFileName, suffix);
+            }
+            neededSize = ifnSize + suffixSize + 1;
+            if (ofnSize < neededSize) {
+                char* const newDstFileName = (char*)realloc(dstFileName, neededSize);
+                if (newDstFileName == NULL) {
+                    free(dstFileName);
+                    LZ4IO_freeCResources(ress);
+                    return ifntSize;
+                }
+                dstFileName = newDstFileName;
+                ofnSize = neededSize;
+            }
+            memcpy(dstFileName, inFileNamesTable[i], ifnSize);
+            memcpy(dstFileName + ifnSize, suffix, suffixSize);
+            dstFileName[ifnSize + suffixSize] = '\0';
+        }
 
         missed_files += LZ4IO_compressFilename_extRess(&processed, &ress,
                                 inFileNamesTable[i], dstFileName,


### PR DESCRIPTION
## Description

This PR fixes a heap buffer overflow in the `lz4io` program layer when
constructing output filenames for multi-file compression.

The affected helpers concatenate an input filename with a caller-
provided suffix. Although the code checked whether the existing buffer
was large enough for `input + suffix + '\0'`, it then reallocated the
buffer to a fixed size (`ifnSize + 20`) regardless of the actual suffix
length. For sufficiently long suffixes, the subsequent
`strcpy()`/`strcat()` sequence could write past the end of the heap
allocation.

## Changes
- Compute the exact required buffer size:
  - `input_filename_length + suffix_length + 1`
- Add a `size_t` overflow check before allocation
- Allocate or reallocate the output filename buffer to the required size
- Replace unbounded `strcpy()`/`strcat()` with bounded `memcpy()`

## Impact
- Removes a heap buffer overflow in the multi-file compression path
- Prevents crashes and potential heap corruption when suffix values are
  attacker-controlled
- No behavior change for normal usage with short, fixed suffixes

## Testing
- Rebuilt the project after the change
- Manually verified that allocation sizes match subsequent writes and
  that arithmetic overflow is checked before allocation
