### PR TITLE
Updated lz4hc documentation: LZ4_saveDictHC() expects valid arguments

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -1797,7 +1797,7 @@ int LZ4_saveDictHC (LZ4_streamHC_t* LZ4_streamHCPtr, char* safeBuffer, int dictS
     if (dictSize > 64 KB) dictSize = 64 KB;
     if (dictSize < 4) dictSize = 0;
     if (dictSize > prefixSize) dictSize = prefixSize;
-    if (safeBuffer == NULL) assert(dictSize == 0);
+    if (safeBuffer == NULL) assert(dictSize == 0); /* a NULL buffer with !0 size is invalid */
     if (dictSize > 0)
         LZ4_memmove(safeBuffer, streamPtr->end - dictSize, (size_t)dictSize);
     {   U32 const endIndex = (U32)(streamPtr->end - streamPtr->prefixStart) + streamPtr->dictLimit;

--- a/lib/lz4hc.h
+++ b/lib/lz4hc.h
@@ -175,6 +175,13 @@ LZ4LIB_API int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr
                                            const char* src, char* dst,
                                                  int* srcSizePtr, int targetDstSize);
 
+/*! LZ4_saveDictHC():
+ * save history content (up to 64 KB) into a user-provided buffer @param safeBuffer.
+ * @return value is the size of dictionary effectively saved (<= MIN(maxDictSize, 64 KB)).
+ * This function is always successful, and expects its arguments to be valid.
+ * To this end, let's remind that (NULL,0) is valid, 
+ * but (NULL,!0) is not, and will result in a segfault (or assert() depending on compilation mode).
+ */
 LZ4LIB_API int LZ4_saveDictHC (LZ4_streamHC_t* streamHCPtr, char* safeBuffer, int maxDictSize);
 
 


### PR DESCRIPTION
and a `(NULL, !0)` buffer is **not** valid.

closes #1655