### PR TITLE
Update datagen to return error if usage is not expected

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -238,6 +238,10 @@ test-lz4-skippable: lz4
 	@echo "\n ---- test lz4 with skippable frames ----"
 	./test-lz4-skippable.sh
 
+test-datagen-invalid-input: datagen
+	@echo "\n ---- test datagen fails correctly on invalid input ----"
+	$(DATAGEN) -g1234l && exit 1 || true
+
 test-lz4-basic: lz4 datagen unlz4 lz4cat
 	@echo "\n ---- test lz4 basic compression/decompression ----"
 	./test-lz4-basic.sh
@@ -264,9 +268,9 @@ test-lz4-opt-parser: lz4 datagen
 	@echo "\n ---- test opt-parser ----"
 	./test-lz4-opt-parser.sh
 
-test-lz4-essentials : lz4 datagen test-lz4-basic test-lz4-multiple test-lz4-multiple-legacy \
-                      test-lz4-frame-concatenation test-lz4-testmode \
-                      test-lz4-contentSize test-lz4-dict
+test-lz4-essentials : lz4 datagen test-datagen-invalid-input test-lz4-basic test-lz4-multiple \
+                      test-lz4-multiple-legacy test-lz4-frame-concatenation \
+                      test-lz4-testmode test-lz4-contentSize test-lz4-dict
 
 test-lz4: lz4 datagen test-lz4-essentials test-lz4-opt-parser \
           test-lz4-sparse test-lz4-hugefile test-lz4-dict \

--- a/tests/datagencli.c
+++ b/tests/datagencli.c
@@ -135,7 +135,8 @@ int main(int argc, char** argv)
                     argument++;
                     break;
                 default:
-                    return usage(programName);
+                    usage(programName);
+                    return 1; /* Return error if usage is unexpected */
                 }
             }
         }  /* if (*argument=='-') */


### PR DESCRIPTION
Update datagen so test failures that stem from datagen (See #1672)  do not silently fail. 

New:
```
...
+ datagen -g2186l
Compressible data generator
Usage :
      datagen [size] [args]

Arguments :
 -g#    : generate # data (default:65536)
 -s#    : Select seed (default:0)
 -P#    : Select compressibility in % (range [0-100])
 -h     : display help and exit
Special values :
 -P0    : generate incompressible noise
 -P100  : generate sparse files
+ remove
+ rm tmp-dict tmp-dict-2186l tmp-dict-data-128KB tmp-dict-sample-0 tmp-dict-sample-16m tmp-dict-sample-32k
make: *** [Makefile:247: test-lz4-dict] Error 1
```

Original silent error:
```
...
+ datagen -g1766l
Compressible data generator
Usage :
      datagen [size] [args]

Arguments :
 -g#    : generate # data (default:65536)
 -s#    : Select seed (default:0)
 -P#    : Select compressibility in % (range [0-100])
 -h     : display help and exit
Special values :
 -P0    : generate incompressible noise
 -P100  : generate sparse files
+ dd if=tmp-dict-1766l of=tmp-dict-1766l-tail bs=1 count=65536 skip=0
0+0 records in
0+0 records out
0 bytes copied, 0.000991407 s, 0.0 kB/s
+ lz4 -dD tmp-dict-1766l-tail
+ diff - tmp-dict-data-128KB
+ lz4 -D stdin tmp-dict-data-128KB -c
+ lz4 -dD tmp-dict-1766l
+ diff - tmp-dict-data-128KB
+ lz4 -D stdin tmp-dict-data-128KB -c
```