### PR TITLE
reduced tests on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,6 @@ jobs:
     - run: pyenv global 3.14; CPPFLAGS=-I/usr/include/x86_64-linux-gnu make versionsTest && make clean
     - run: make test-install         && make clean
     - run: gcc -v; CFLAGS="-O2 -m32 -Werror" CPPFLAGS=-I/usr/include/x86_64-linux-gnu make check && make clean
-    - run: clang -v; make staticAnalyze && make clean
-    - run: make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc-static V=1       && make clean
-    - run: CFLAGS=-m64 LDFLAGS=-m64 make platformTest CC=powerpc-linux-gnu-gcc QEMU_SYS=qemu-ppc64-static V=1 && make clean
-    - run: make platformTest CC=arm-linux-gnueabi-gcc QEMU_SYS=qemu-arm-static V=1      && make clean
-    - run: make platformTest CC=aarch64-linux-gnu-gcc QEMU_SYS=qemu-aarch64-static V=1  && make clean
     # Teardown
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
     # Save test results


### PR DESCRIPTION
this is now the slowest single test in the suite,
removed some duplicated parts,
such as static analyzer, and qemu tests.