### PR TITLE
Optimize handling of overlapping matches

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2202,7 +2202,7 @@ LZ4_decompress_generic(
             cpy = op + length;
 
             assert((op <= oend) && (oend-op >= 32));
-            if (unlikely(offset<16)) {
+            if (unlikely(offset<16) && length > offset) {
                 LZ4_memcpy_using_offset(op, match, cpy, offset);
             } else {
                 LZ4_wildCopy32(op, match, cpy);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2202,8 +2202,13 @@ LZ4_decompress_generic(
             cpy = op + length;
 
             assert((op <= oend) && (oend-op >= 32));
-            if (unlikely(offset<16) && length > offset) {
-                LZ4_memcpy_using_offset(op, match, cpy, offset);
+            if (unlikely(offset<16)) {
+                if (length > offset){
+                    LZ4_memcpy_using_offset(op, match, cpy, offset);
+                }else{
+                    /* no overlap possible use simple memcpy*/
+                    LZ4_memcpy(op, match, length);
+                }
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2202,13 +2202,11 @@ LZ4_decompress_generic(
             cpy = op + length;
 
             assert((op <= oend) && (oend-op >= 32));
-            if (unlikely(offset<16)) {
-                if (length > offset){
-                    LZ4_memcpy_using_offset(op, match, cpy, offset);
-                }else{
-                    /* no overlap possible use simple memcpy*/
-                    LZ4_memcpy(op, match, length);
-                }
+            if (unlikely(offset<16) && length > offset) {
+                LZ4_memcpy_using_offset(op, match, cpy, offset);
+            } else if (unlikely(offset<16)){
+                /* no overlap possible use simple memcpy*/
+                LZ4_memcpy(op, match, length);
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }


### PR DESCRIPTION
Add `length > offset` check to the `offset < 16` condition when copying match within block. This allows using the fast LZ4_wildCopy32 path when there's no overlap (length <= offset), avoiding the slower LZ4_memcpy_using_offset. Thanks @Cyan4973 for optimization idea 

Benchmarking results using `./lz4 -b -S ~/silesia/*` (reran 4-6 times and took the best result)
Last column represents percentage difference with original 

With memmove statement:
```
if (unlikely(offset<16) && length > offset) {
    LZ4_memcpy_using_offset(op, match, cpy, offset);
} else if (unlikely(offset<16)){
    LZ4_memmove(op, match, 16);
} else {
    LZ4_wildCopy32(op, match, cpy);
}
```
```
gcc 11.5.0
 1#dickens           :  10192446 ->   6428742 (1.585), 362.8 MB/s, 3465.5 MB/s, +0.47%
 1#mozilla           :  51220480 ->  26435667 (1.938), 605.6 MB/s, 3262.8 MB/s, +0.26%
 1#mr                :   9970564 ->   5440937 (1.833), 608.2 MB/s, 3681.0 MB/s, +0.10%
 1#nci               :  33553445 ->   5533040 (6.064), 945.3 MB/s, 4736.6 MB/s, +0.45%
 1#ooffice           :   6152192 ->   4338918 (1.418), 528.8 MB/s, 2899.7 MB/s, +0.40%
 1#osdb              :  10085684 ->   5256666 (1.919), 562.9 MB/s, 3114.9 MB/s, +0.63%
 1#reymont           :   6627202 ->   3181387 (2.083), 346.0 MB/s, 3061.8 MB/s, -0.06%
 1#samba             :  21606400 ->   7716839 (2.800), 588.7 MB/s, 3795.1 MB/s, -0.34%
 1#sao               :   7251944 ->   6790273 (1.068), 612.0 MB/s, 4187.5 MB/s, +0.61%
 1#webster           :  41458703 ->  20139988 (2.059), 403.2 MB/s, 3272.4 MB/s, +0.17%
 1#xml               :   5345280 ->   1227495 (4.355), 732.6 MB/s, 3532.5 MB/s, -1.13%
 1#x-ray             :   8474240 ->   8390195 (1.010),1663.2 MB/s, 12155.3 MB/s, -0.52%

 clang v19.1.2
 1#dickens           :  10192446 ->   6428742 (1.585), 375.5 MB/s, 3458.1 MB/s, +0.27%
 1#mozilla           :  51220480 ->  26435667 (1.938), 631.5 MB/s, 3290.9 MB/s, -0.27%
 1#mr                :   9970564 ->   5440937 (1.833), 631.0 MB/s, 3725.4 MB/s, -0.21%
 1#nci               :  33553445 ->   5533040 (6.064), 955.2 MB/s, 4904.1 MB/s, -1.27%
 1#ooffice           :   6152192 ->   4338918 (1.418), 569.7 MB/s, 3007.7 MB/s, -0.25%
 1#osdb              :  10085684 ->   5256666 (1.919), 608.9 MB/s, 3258.1 MB/s, +0.02%
 1#reymont           :   6627202 ->   3181387 (2.083), 343.9 MB/s, 3038.9 MB/s, -0.89%
 1#samba             :  21606400 ->   7716839 (2.800), 597.5 MB/s, 3834.1 MB/s, -1.01%
 1#sao               :   7251944 ->   6790273 (1.068), 693.6 MB/s, 4250.5 MB/s, +0.07%
 1#webster           :  41458703 ->  20139988 (2.059), 415.9 MB/s, 3276.8 MB/s, -0.34%
 1#xml               :   5345280 ->   1227495 (4.355), 754.6 MB/s, 3621.6 MB/s, -0.19%
 1#x-ray             :   8474240 ->   8390195 (1.010),1907.2 MB/s, 12585.7 MB/s, +0.03%
```

With memcpy and var length:
```
if (unlikely(offset<16) && length > offset) {
    LZ4_memcpy_using_offset(op, match, cpy, offset);
} else if (unlikely(offset<16)){
    /* no overlap possible use simple memcpy*/
    LZ4_memcpy(op, match, length);
} else {
    LZ4_wildCopy32(op, match, cpy);
}
```
```
gcc 11.5.0
 1#dickens           :  10192446 ->   6428742 (1.585), 361.5 MB/s, 3455.3 MB/s, +0.11%
 1#mozilla           :  51220480 ->  26435667 (1.938), 607.5 MB/s, 3188.0 MB/s, +0.58%
 1#mr                :   9970564 ->   5440937 (1.833), 604.9 MB/s, 3629.8 MB/s, -0.44%
 1#nci               :  33553445 ->   5533040 (6.064), 949.2 MB/s, 4588.9 MB/s, +0.86%
 1#ooffice           :   6152192 ->   4338918 (1.418), 526.1 MB/s, 2840.6 MB/s, -0.11%
 1#osdb              :  10085684 ->   5256666 (1.919), 560.7 MB/s, 3130.9 MB/s, +0.23%
 1#reymont           :   6627202 ->   3181387 (2.083), 345.8 MB/s, 3030.5 MB/s, -0.12%
 1#samba             :  21606400 ->   7716839 (2.800), 590.8 MB/s, 3729.7 MB/s, +0.02%
 1#sao               :   7251944 ->   6790273 (1.068), 612.4 MB/s, 4073.9 MB/s, +0.67%
 1#webster           :  41458703 ->  20139988 (2.059), 401.4 MB/s, 3212.9 MB/s, -0.27%
 1#xml               :   5345280 ->   1227495 (4.355), 734.0 MB/s, 3415.7 MB/s, -0.94%
 1#x-ray             :   8474240 ->   8390195 (1.010),1670.0 MB/s, 11900.1 MB/s, -0.11%

 clang v19.1.2
 1#dickens           :  10192446 ->   6428742 (1.585), 375.9 MB/s, 3464.8 MB/s, +0.37%
 1#mozilla           :  51220480 ->  26435667 (1.938), 635.4 MB/s, 3311.7 MB/s, +0.35%
 1#mr                :   9970564 ->   5440937 (1.833), 634.3 MB/s, 3725.1 MB/s, +0.32%
 1#nci               :  33553445 ->   5533040 (6.064), 966.4 MB/s, 4872.6 MB/s, -0.11%
 1#ooffice           :   6152192 ->   4338918 (1.418), 571.1 MB/s, 2980.7 MB/s, +0.00%
 1#osdb              :  10085684 ->   5256666 (1.919), 609.0 MB/s, 3184.3 MB/s, +0.03%
 1#reymont           :   6627202 ->   3181387 (2.083), 345.4 MB/s, 3036.8 MB/s, -0.46%
 1#samba             :  21606400 ->   7716839 (2.800), 603.1 MB/s, 3831.9 MB/s, -0.08%
 1#sao               :   7251944 ->   6790273 (1.068), 692.6 MB/s, 4348.8 MB/s, -0.07%
 1#webster           :  41458703 ->  20139988 (2.059), 414.4 MB/s, 3290.9 MB/s, -0.69%
 1#xml               :   5345280 ->   1227495 (4.355), 748.4 MB/s, 3538.8 MB/s, -1.01%
 1#x-ray             :   8474240 ->   8390195 (1.010),1904.1 MB/s, 12545.2 MB/s, -0.14%

```
With memcpy and static length:
```
if (unlikely(offset<16) && length > offset) {
    LZ4_memcpy_using_offset(op, match, cpy, offset);
} else if (unlikely(offset<16)){
    LZ4_memcpy(op, match, 4);
    LZ4_memcpy(op + 4, match + 4, 4);
    LZ4_memcpy(op + 8, match + 8, 4);
    LZ4_memcpy(op + 12, match + 12, 4);
} else {
    LZ4_wildCopy32(op, match, cpy);
}
```
```
gcc 11.5.0
 1#dickens           :  10192446 ->   6428742 (1.585), 359.1 MB/s, 3452.1 MB/s, -0.55%
 1#mozilla           :  51220480 ->  26435667 (1.938), 607.2 MB/s, 3211.5 MB/s, +0.53%
 1#mr                :   9970564 ->   5440937 (1.833), 605.2 MB/s, 3631.4 MB/s, -0.39%
 1#nci               :  33553445 ->   5533040 (6.064), 958.8 MB/s, 4583.5 MB/s, +1.88%
 1#ooffice           :   6152192 ->   4338918 (1.418), 528.9 MB/s, 2810.4 MB/s, +0.42%
 1#osdb              :  10085684 ->   5256666 (1.919), 562.9 MB/s, 3086.4 MB/s, +0.63%
 1#reymont           :   6627202 ->   3181387 (2.083), 349.1 MB/s, 3038.0 MB/s, +0.84%
 1#samba             :  21606400 ->   7716839 (2.800), 595.4 MB/s, 3721.6 MB/s, +0.80%
 1#sao               :   7251944 ->   6790273 (1.068), 607.1 MB/s, 4141.1 MB/s, -0.20%
 1#webster           :  41458703 ->  20139988 (2.059), 406.3 MB/s, 3219.9 MB/s, +0.94%
 1#xml               :   5345280 ->   1227495 (4.355), 744.6 MB/s, 3454.5 MB/s, +0.49%
 1#x-ray             :   8474240 ->   8390195 (1.010),1666.9 MB/s, 12160.2 MB/s, -0.30%

 clang v19.1.2
 1#dickens           :  10192446 ->   6428742 (1.585), 375.1 MB/s, 3449.5 MB/s, +0.16%
 1#mozilla           :  51220480 ->  26435667 (1.938), 635.2 MB/s, 3336.7 MB/s, +0.32%
 1#mr                :   9970564 ->   5440937 (1.833), 631.3 MB/s, 3721.9 MB/s, -0.16%
 1#nci               :  33553445 ->   5533040 (6.064), 961.6 MB/s, 4946.9 MB/s, -0.61%
 1#ooffice           :   6152192 ->   4338918 (1.418), 570.7 MB/s, 2933.1 MB/s, -0.07%
 1#osdb              :  10085684 ->   5256666 (1.919), 609.0 MB/s, 3240.9 MB/s, +0.03%
 1#reymont           :   6627202 ->   3181387 (2.083), 347.1 MB/s, 3039.5 MB/s, +0.03%
 1#samba             :  21606400 ->   7716839 (2.800), 604.2 MB/s, 3859.0 MB/s, +0.10%
 1#sao               :   7251944 ->   6790273 (1.068), 696.8 MB/s, 4322.5 MB/s, +0.53%
 1#webster           :  41458703 ->  20139988 (2.059), 417.1 MB/s, 3284.3 MB/s, -0.05%
 1#xml               :   5345280 ->   1227495 (4.355), 758.4 MB/s, 3630.3 MB/s, +0.32%
 1#x-ray             :   8474240 ->   8390195 (1.010),1898.2 MB/s, 12591.5 MB/s, -0.45%

```
Original for reference:
```
gcc 11.5.0
 1#dickens           :  10192446 ->   6428742 (1.585), 361.1 MB/s, 3463.1 MB/s
 1#mozilla           :  51220480 ->  26435667 (1.938), 604.0 MB/s, 3251.1 MB/s
 1#mr                :   9970564 ->   5440937 (1.833), 607.6 MB/s, 3686.2 MB/s
 1#nci               :  33553445 ->   5533040 (6.064), 941.1 MB/s, 4672.0 MB/s
 1#ooffice           :   6152192 ->   4338918 (1.418), 526.7 MB/s, 2905.0 MB/s
 1#osdb              :  10085684 ->   5256666 (1.919), 559.4 MB/s, 3130.7 MB/s
 1#reymont           :   6627202 ->   3181387 (2.083), 346.2 MB/s, 3057.8 MB/s
 1#samba             :  21606400 ->   7716839 (2.800), 590.7 MB/s, 3769.0 MB/s
 1#sao               :   7251944 ->   6790273 (1.068), 608.3 MB/s, 4199.1 MB/s
 1#webster           :  41458703 ->  20139988 (2.059), 402.5 MB/s, 3236.2 MB/s
 1#xml               :   5345280 ->   1227495 (4.355), 741.0 MB/s, 3488.2 MB/s
 1#x-ray             :   8474240 ->   8390195 (1.010),1671.9 MB/s, 12230.1 MB/s

 clang v19.1.2
 1#dickens           :  10192446 ->   6428742 (1.585), 374.5 MB/s, 3448.5 MB/s
 1#mozilla           :  51220480 ->  26435667 (1.938), 633.2 MB/s, 3334.8 MB/s
 1#mr                :   9970564 ->   5440937 (1.833), 632.3 MB/s, 3729.3 MB/s
 1#nci               :  33553445 ->   5533040 (6.064), 967.5 MB/s, 4942.3 MB/s
 1#ooffice           :   6152192 ->   4338918 (1.418), 571.1 MB/s, 2995.2 MB/s
 1#osdb              :  10085684 ->   5256666 (1.919), 608.8 MB/s, 3236.5 MB/s
 1#reymont           :   6627202 ->   3181387 (2.083), 347.0 MB/s, 3048.4 MB/s
 1#samba             :  21606400 ->   7716839 (2.800), 603.6 MB/s, 3867.2 MB/s
 1#sao               :   7251944 ->   6790273 (1.068), 693.1 MB/s, 4314.4 MB/s
 1#webster           :  41458703 ->  20139988 (2.059), 417.3 MB/s, 3264.0 MB/s
 1#xml               :   5345280 ->   1227495 (4.355), 756.0 MB/s, 3611.6 MB/s
 1#x-ray             :   8474240 ->   8390195 (1.010),1906.7 MB/s, 12539.6 MB/s
```

I don't really so any consistent meaningful performance gains here and not too sure if added complexity is worth it, lemme know if I should try anything else :) 