### PR TITLE
bench: align display when speed > 10000 MB/s

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -561,7 +561,7 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
             }
             markNb = (markNb+1) % NB_MARKS;
             ratio  = (double)totalRSize / (double)cSize;
-            OUTLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.3f),%6.1f MB/s, %6.1f MB/s\r",
+            OUTLEVEL(2, "%2s-%-17.17s :%10u ->%10u (%5.3f),%6.1f MB/s,%7.1f MB/s\r",
                     marks[markNb], displayName,
                     (U32)totalRSize, (U32)cSize, ratio,
                     ((double)totalRSize / (double)fastestC) * 1000,


### PR DESCRIPTION
as cpus get faster, it's now possible for some of them to reach speeds > 10000 MB/s on single core. Ensure that the display remains properly aligned in this case.