### PR TITLE
AArch64: Enable LZ4_FAST_DEC_LOOP for Android

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -480,14 +480,7 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
 #    define LZ4_FAST_DEC_LOOP 1
 #  elif defined(__aarch64__)
-#    if defined(__clang__) && defined(__ANDROID__)
-     /* On Android aarch64, we disable this optimization for clang because
-      * on certain mobile chipsets, performance is reduced with clang. For
-      * more information refer to https://github.com/lz4/lz4/pull/707 */
-#      define LZ4_FAST_DEC_LOOP 0
-#    else
-#      define LZ4_FAST_DEC_LOOP 1
-#    endif
+#    define LZ4_FAST_DEC_LOOP 1
 #  else
 #    define LZ4_FAST_DEC_LOOP 0
 #  endif


### PR DESCRIPTION
This change removes the Android/Clang-specific disablement of the AArch64 fast decode loop.
Based on current testing, the fast decode loop is a net performance win (with minor regressions in specific cases) on modern Android AArch64 systems, and the original rationale for disabling it no longer appears to hold.

We tested with **Silesia Corpus** on the default fast level (-1) and on two HC leveles (-2, -3) as well. Results on `silesia.tar` are also included in the commit message.

Regressions are mostly on:
- `dickens` with **Cortex-A55**, **Cortex-A720**, **Cortex-A725**, **Cortex-X3**, **Cortex-X4**.
- `ooffice` with **Cortex-A55**.
- `raymont` with **Cortex-X4**.
- `sao` with  **Cortex-A55**, **Cortex-X2**.

Detailed results on various Cortex CPUs:

<details closed>
<summary>Cortex-A55</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  0.9896x |   0.9935x |   0.9946x |   1.0011x |   0.9944x|
|-2#dickens:|  0.9970x |   0.9831x |   0.9906x |   0.9958x |   0.9994x|
|-3#dickens:|  0.9922x |   1.0048x |   0.9936x |   0.9930x |   0.9962x|
|-1#mozilla:|  1.0103x |   1.0128x |   1.0106x |   1.0030x |   1.0137x|
|-2#mozilla:|  1.0068x |   1.0046x |   1.0095x |   1.0006x |   1.0082x|
|-3#mozilla:|  1.0084x |   1.0092x |   1.0096x |   1.0040x |   1.0104x|
|-1#mr:     |  1.0054x |   0.9976x |   0.9981x |   0.9848x |   0.9993x|
|-2#mr:     |  1.0004x |   1.0077x |   0.9993x |   1.0066x |   1.0090x|
|-3#mr:     |  0.9963x |   0.9967x |   0.9963x |   0.9928x |   0.9993x|
|-1#nci:    |  1.0585x |   1.0603x |   1.0631x |   1.0482x |   1.0619x|
|-2#nci:    |  1.0583x |   1.0586x |   1.0607x |   1.0502x |   1.0616x|
|-3#nci:    |  1.0689x |   1.0697x |   1.0734x |   1.0602x |   1.0734x|
|-1#ooffice:|  1.0813x |   1.0390x |   1.0272x |   1.0085x |   0.9911x|
|-2#ooffice:|  1.0344x |   1.0033x |   1.0042x |   1.0251x |   1.0073x|
|-3#ooffice:|  0.9987x |   0.9798x |   0.9822x |   0.9961x |   0.9989x|
|-1#osdb:   |  1.0515x |   1.0475x |   1.0475x |   1.0214x |   1.0312x|
|-2#osdb:   |  1.0313x |   1.0349x |   1.0407x |   1.0312x |   1.0251x|
|-3#osdb:   |  1.0501x |   1.0447x |   1.0439x |   1.0248x |   1.0336x|
|-1#reymont:|  1.0068x |   1.0284x |   0.9981x |   0.9906x |   1.0302x|
|-2#reymont:|  1.0083x |   0.9990x |   0.9838x |   1.0016x |   1.0202x|
|-3#reymont:|  1.0183x |   1.0402x |   1.0097x |   1.0088x |   0.9888x|
|-1#samba:  |  1.0256x |   1.0255x |   1.0214x |   1.0181x |   1.0265x|
|-2#samba:  |  1.0246x |   1.0256x |   1.0251x |   1.0099x |   1.0328x|
|-3#samba:  |  1.0316x |   1.0289x |   1.0276x |   1.0197x |   1.0287x|
|-1#sao:    |  1.0033x |   1.0040x |   1.0066x |   0.9946x |   1.0038x|
|-2#sao:    |  0.9939x |   0.9946x |   0.9953x |   0.9871x |   0.9962x|
|-3#sao:    |  0.9779x |   0.9779x |   0.9787x |   0.9735x |   0.9763x|
|-1#webster:|  1.0166x |   1.0130x |   1.0119x |   1.0104x |   1.0113x|
|-2#webster:|  1.0167x |   1.0159x |   1.0132x |   1.0124x |   1.0164x|
|-3#webster:|  1.0248x |   1.0225x |   1.0215x |   1.0141x |   1.0241x|
|-1#x-ray:  |  0.9955x |   0.9992x |   0.9940x |   0.9939x |   1.0171x|
|-2#x-ray:  |  1.0154x |   1.0166x |   1.0272x |   1.0008x |   1.0187x|
|-3#x-ray:  |  1.0105x |   1.0098x |   1.0100x |   1.0033x |   1.0123x|
|-1#xml:    |  1.0779x |   1.0704x |   1.0757x |   1.0507x |   1.0756x|
|-2#xml:    |  1.0824x |   1.0775x |   1.0698x |   1.0567x |   1.0729x|
|-3#xml:    |  1.0883x |   1.0854x |   1.0877x |   1.0651x |   1.0839x|
</details>

<details closed>
<summary>Cortex-A510</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0652x |   1.0440x |   1.0322x |   1.0253x |   1.0229x|
|-2#dickens:|  1.0115x |   1.0235x |   1.0105x |   1.0237x |   1.0293x|
|-3#dickens:|  1.0017x |   1.0413x |   1.0223x |   1.0275x |   1.0149x|
|-1#mozilla:|  1.0259x |   1.0940x |   1.0576x |   1.0712x |   1.0436x|
|-2#mozilla:|  1.0141x |   1.0742x |   1.0492x |   1.0555x |   1.0489x|
|-3#mozilla:|  0.9975x |   1.1160x |   1.0438x |   1.0220x |   1.0496x|
|-1#mr:     |  1.0538x |   1.0767x |   1.0872x |   1.0785x |   1.0574x|
|-2#mr:     |  1.0399x |   1.0458x |   1.0460x |   1.0570x |   1.0495x|
|-3#mr:     |  1.0484x |   1.0536x |   1.0494x |   1.0439x |   1.0697x|
|-1#nci:    |  0.9847x |   1.0796x |   1.0672x |   1.0462x |   1.1797x|
|-2#nci:    |  1.1686x |   1.1308x |   1.1097x |   1.1027x |   0.9929x|
|-3#nci:    |  1.0613x |   1.0402x |   1.1024x |   1.1430x |   1.0555x|
|-1#ooffice:|  1.0381x |   1.1424x |   1.1626x |   1.1463x |   1.1064x|
|-2#ooffice:|  1.0141x |   1.0350x |   1.0502x |   1.0454x |   1.0362x|
|-3#ooffice:|  1.0067x |   1.0305x |   1.0364x |   1.0345x |   1.0332x|
|-1#osdb:   |  1.0213x |   1.1649x |   1.1194x |   1.1407x |   1.1328x|
|-2#osdb:   |  1.0019x |   1.0769x |   1.0147x |   1.0157x |   1.0242x|
|-3#osdb:   |  1.0060x |   1.0294x |   1.0444x |   1.0341x |   1.0823x|
|-1#reymont:|  1.0152x |   1.0251x |   1.0259x |   1.0271x |   1.0259x|
|-2#reymont:|  1.0082x |   1.0263x |   1.0255x |   1.0287x |   1.0276x|
|-3#reymont:|  1.0203x |   1.0279x |   1.0328x |   1.0333x |   1.0296x|
|-1#samba:  |  1.0200x |   1.0480x |   1.0601x |   1.0857x |   1.0549x|
|-2#samba:  |  1.0035x |   1.0609x |   1.0022x |   1.0353x |   1.0255x|
|-3#samba:  |  1.0131x |   1.0325x |   1.0542x |   1.0497x |   1.0595x|
|-1#sao:    |  1.2437x |   1.2591x |   1.3066x |   1.2029x |   1.3127x|
|-2#sao:    |  1.1029x |   1.1329x |   1.1666x |   1.1575x |   1.1116x|
|-3#sao:    |  1.0687x |   1.1101x |   1.1247x |   1.0788x |   1.0655x|
|-1#webster:|  0.9395x |   1.0383x |   1.0602x |   1.0524x |   1.0533x|
|-2#webster:|  1.0135x |   1.0185x |   1.0499x |   1.0440x |   1.0494x|
|-3#webster:|  0.9887x |   1.0498x |   1.0414x |   1.0386x |   1.0283x|
|-1#x-ray:  |  1.0904x |   1.0924x |   1.0963x |   1.0360x |   1.1030x|
|-2#x-ray:  |  1.0824x |   1.0937x |   1.0687x |   1.1434x |   1.1097x|
|-3#x-ray:  |  1.0730x |   1.0497x |   1.0769x |   1.0478x |   1.0726x|
|-1#xml:    |  1.0423x |   1.0798x |   1.0848x |   1.0802x |   1.1101x|
|-2#xml:    |  1.0400x |   1.0709x |   1.0751x |   1.0814x |   1.0603x|
|-3#xml:    |  1.0654x |   1.1090x |   1.1032x |   1.1098x |   1.0810x|
</details>

<details closed>
<summary>Cortex-A520</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0807x |   1.0862x |   1.0848x |   1.0822x |   1.0821x|
|-2#dickens:|  1.0689x |   1.0702x |   1.0695x |   1.0691x |   1.0696x|
|-3#dickens:|  1.0700x |   1.0695x |   1.0680x |   1.0681x |   1.0686x|
|-1#mozilla:|  1.0812x |   1.1061x |   1.1036x |   1.0965x |   1.0866x|
|-2#mozilla:|  1.0654x |   1.0807x |   1.0711x |   1.0683x |   1.0640x|
|-3#mozilla:|  1.0683x |   1.0690x |   1.0727x |   1.0601x |   1.0644x|
|-1#mr:     |  1.0800x |   1.1013x |   1.1006x |   1.0945x |   1.0934x|
|-2#mr:     |  1.0777x |   1.0876x |   1.0843x |   1.0826x |   1.0864x|
|-3#mr:     |  1.0669x |   1.0752x |   1.0770x |   1.0732x |   1.0764x|
|-1#nci:    |  1.0032x |   1.0433x |   1.0279x |   1.0200x |   0.9947x|
|-2#nci:    |  1.0337x |   1.0407x |   1.0496x |   1.0261x |   1.0187x|
|-3#nci:    |  1.0322x |   1.0323x |   1.0315x |   1.0113x |   1.0227x|
|-1#ooffice:|  1.1340x |   1.1866x |   1.1899x |   1.1698x |   1.1531x|
|-2#ooffice:|  1.0672x |   1.0797x |   1.0875x |   1.0777x |   1.0773x|
|-3#ooffice:|  1.0661x |   1.0775x |   1.0775x |   1.0703x |   1.0732x|
|-1#osdb:   |  1.1174x |   1.1680x |   1.1647x |   1.1431x |   1.1134x|
|-2#osdb:   |  1.0368x |   1.0564x |   1.0569x |   1.0493x |   1.0307x|
|-3#osdb:   |  1.0306x |   1.0520x |   1.0483x |   1.0525x |   1.0293x|
|-1#reymont:|  1.0731x |   1.0719x |   1.0717x |   1.0684x |   1.0704x|
|-2#reymont:|  1.0669x |   1.0728x |   1.0716x |   1.0678x |   1.0673x|
|-3#reymont:|  1.0670x |   1.0736x |   1.0709x |   1.0671x |   1.0624x|
|-1#samba:  |  1.0571x |   1.0627x |   1.0702x |   1.0871x |   1.0579x|
|-2#samba:  |  1.0558x |   1.0845x |   1.0559x |   1.0563x |   1.0518x|
|-3#samba:  |  1.0539x |   1.0510x |   1.0557x |   1.0403x |   1.0492x|
|-1#sao:    |  1.2957x |   1.2885x |   1.2819x |   1.2538x |   1.2649x|
|-2#sao:    |  1.1195x |   1.1533x |   1.1535x |   1.1403x |   1.1094x|
|-3#sao:    |  1.0886x |   1.1199x |   1.1220x |   1.1076x |   1.0868x|
|-1#webster:|  1.0858x |   1.0920x |   1.0895x |   1.0814x |   1.0732x|
|-2#webster:|  1.0664x |   1.0699x |   1.0720x |   1.0650x |   1.0629x|
|-3#webster:|  1.0618x |   1.0691x |   1.0689x |   1.0569x |   1.0595x|
|-1#x-ray:  |  1.0909x |   1.0867x |   1.0831x |   1.0754x |   1.0783x|
|-2#x-ray:  |  1.1387x |   1.1422x |   1.1543x |   1.1277x |   1.1257x|
|-3#x-ray:  |  1.1165x |   1.1323x |   1.1310x |   1.1165x |   1.1122x|
|-1#xml:    |  1.0470x |   1.0583x |   1.0577x |   1.0481x |   1.0422x|
|-2#xml:    |  1.0442x |   1.0541x |   1.0452x |   1.0423x |   1.0382x|
|-3#xml:    |  1.0410x |   1.0473x |   1.0454x |   1.0446x |   1.0381x|
</details>

<details closed>
<summary>Cortex-A76</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0544x |   1.0488x |   1.0480x |   1.0491x |   1.0287x|
|-2#dickens:|  1.0232x |   1.0200x |   1.0199x |   1.0218x |   1.0207x|
|-3#dickens:|  1.0275x |   1.0237x |   1.0237x |   1.0246x |   1.0232x|
|-1#mozilla:|  1.1280x |   1.1326x |   1.1331x |   1.1261x |   1.1200x|
|-2#mozilla:|  1.0877x |   1.0853x |   1.0932x |   1.0890x |   1.0869x|
|-3#mozilla:|  1.1023x |   1.0987x |   1.1018x |   1.1005x |   1.0993x|
|-1#mr:     |  1.1035x |   1.0953x |   1.0923x |   1.0829x |   1.0853x|
|-2#mr:     |  1.0554x |   1.0503x |   1.0522x |   1.0491x |   1.0485x|
|-3#mr:     |  1.0554x |   1.0556x |   1.0517x |   1.0470x |   1.0521x|
|-1#nci:    |  1.1662x |   1.1679x |   1.1666x |   1.1741x |   1.1627x|
|-2#nci:    |  1.1550x |   1.1538x |   1.1535x |   1.1637x |   1.1502x|
|-3#nci:    |  1.2156x |   1.2272x |   1.2266x |   1.2407x |   1.2259x|
|-1#ooffice:|  1.2157x |   1.2119x |   1.2086x |   1.1843x |   1.1712x|
|-2#ooffice:|  1.0796x |   1.0729x |   1.0738x |   1.0682x |   1.0669x|
|-3#ooffice:|  1.0718x |   1.0640x |   1.0610x |   1.0627x |   1.0636x|
|-1#osdb:   |  1.2061x |   1.2072x |   1.2063x |   1.1964x |   1.1951x|
|-2#osdb:   |  1.0897x |   1.0918x |   1.0940x |   1.0922x |   1.0943x|
|-3#osdb:   |  1.0962x |   1.0943x |   1.0964x |   1.0954x |   1.1015x|
|-1#reymont:|  1.0462x |   1.0343x |   1.0367x |   1.0423x |   1.0423x|
|-2#reymont:|  1.0527x |   1.0442x |   1.0448x |   1.0470x |   1.0518x|
|-3#reymont:|  1.0791x |   1.0666x |   1.0642x |   1.0672x |   1.0775x|
|-1#samba:  |  1.1221x |   1.1317x |   1.1175x |   1.1373x |   1.1354x|
|-2#samba:  |  1.0968x |   1.1044x |   1.0923x |   1.0987x |   1.1006x|
|-3#samba:  |  1.1324x |   1.1306x |   1.1324x |   1.1392x |   1.1421x|
|-1#sao:    |  1.4136x |   1.3954x |   1.3985x |   1.3894x |   1.3352x|
|-2#sao:    |  1.1806x |   1.1594x |   1.1537x |   1.1349x |   1.1030x|
|-3#sao:    |  1.1750x |   1.1407x |   1.1541x |   1.1250x |   1.1013x|
|-1#webster:|  1.1151x |   1.0980x |   1.0991x |   1.0984x |   1.0996x|
|-2#webster:|  1.0875x |   1.0785x |   1.0717x |   1.0818x |   1.0872x|
|-3#webster:|  1.1084x |   1.0964x |   1.0958x |   1.1039x |   1.1030x|
|-1#x-ray:  |  1.0465x |   1.0405x |   1.0356x |   1.0319x |   0.9624x|
|-2#x-ray:  |  1.1767x |   1.1576x |   1.1520x |   1.1376x |   1.1201x|
|-3#x-ray:  |  1.1235x |   1.1568x |   1.1314x |   1.1201x |   1.0801x|
|-1#xml:    |  1.1872x |   1.1975x |   1.1895x |   1.2028x |   1.1916x|
|-2#xml:    |  1.1857x |   1.1846x |   1.1915x |   1.2054x |   1.1994x|
|-3#xml:    |  1.2219x |   1.2358x |   1.2262x |   1.2534x |   1.2403x|
</details>

<details closed>
<summary>Cortex-A78</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0254x |   1.0374x |   1.0382x |   1.0276x |   1.0210x|
|-2#dickens:|  0.9949x |   1.0119x |   1.0034x |   0.9924x |   0.9991x|
|-3#dickens:|  1.0050x |   1.0102x |   1.0076x |   1.0030x |   1.0041x|
|-1#mozilla:|  1.1363x |   1.1480x |   1.1514x |   1.1420x |   1.1378x|
|-2#mozilla:|  1.0964x |   1.1006x |   1.1032x |   1.0983x |   1.0944x|
|-3#mozilla:|  1.1011x |   1.1109x |   1.1128x |   1.1084x |   1.1057x|
|-1#mr:     |  1.1124x |   1.1202x |   1.1212x |   1.1107x |   1.1097x|
|-2#mr:     |  1.0629x |   1.0683x |   1.0797x |   1.0789x |   1.0670x|
|-3#mr:     |  1.0501x |   1.0543x |   1.0543x |   1.0520x |   1.0422x|
|-1#nci:    |  1.1520x |   1.1758x |   1.1791x |   1.1715x |   1.1753x|
|-2#nci:    |  1.1589x |   1.1642x |   1.1709x |   1.1757x |   1.1817x|
|-3#nci:    |  1.1914x |   1.2449x |   1.2482x |   1.2385x |   1.2369x|
|-1#ooffice:|  1.2285x |   1.2448x |   1.2434x |   1.2356x |   1.2287x|
|-2#ooffice:|  1.0601x |   1.0704x |   1.0708x |   1.0606x |   1.0589x|
|-3#ooffice:|  1.0575x |   1.0639x |   1.0635x |   1.0559x |   1.0586x|
|-1#osdb:   |  1.2371x |   1.2256x |   1.2268x |   1.2221x |   1.2170x|
|-2#osdb:   |  1.1426x |   1.1399x |   1.1500x |   1.1411x |   1.1562x|
|-3#osdb:   |  1.1616x |   1.1523x |   1.1540x |   1.1568x |   1.1600x|
|-1#reymont:|  1.0266x |   1.0301x |   1.0311x |   1.0223x |   1.0235x|
|-2#reymont:|  1.0371x |   1.0393x |   1.0363x |   1.0287x |   1.0297x|
|-3#reymont:|  1.0694x |   1.0596x |   1.0610x |   1.0698x |   1.0631x|
|-1#samba:  |  1.1230x |   1.1457x |   1.1416x |   1.1450x |   1.1357x|
|-2#samba:  |  1.1110x |   1.1298x |   1.1300x |   1.1294x |   1.1213x|
|-3#samba:  |  1.1241x |   1.1473x |   1.1437x |   1.1446x |   1.1384x|
|-1#sao:    |  1.3452x |   1.3681x |   1.3684x |   1.3519x |   1.3665x|
|-2#sao:    |  1.1132x |   1.1028x |   1.1034x |   1.0926x |   1.1097x|
|-3#sao:    |  1.0497x |   1.0494x |   1.0465x |   1.0347x |   1.0646x|
|-1#webster:|  1.1066x |   1.1015x |   1.1020x |   1.1020x |   1.0918x|
|-2#webster:|  1.0793x |   1.0715x |   1.0733x |   1.0710x |   1.0745x|
|-3#webster:|  1.0982x |   1.0957x |   1.0945x |   1.0959x |   1.0932x|
|-1#x-ray:  |  1.0765x |   1.1329x |   1.1247x |   1.0914x |   1.0887x|
|-2#x-ray:  |  1.1834x |   1.1985x |   1.1940x |   1.1881x |   1.1856x|
|-3#x-ray:  |  1.1460x |   1.1506x |   1.1473x |   1.1240x |   1.1427x|
|-1#xml:    |  1.2144x |   1.2457x |   1.2457x |   1.2467x |   1.2441x|
|-2#xml:    |  1.2189x |   1.2607x |   1.2634x |   1.2601x |   1.2605x|
|-3#xml:    |  1.2474x |   1.3289x |   1.3287x |   1.3265x |   1.3288x|
</details>

<details closed>
<summary>Cortex-A710</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0356x |   1.0411x |   1.0468x |   1.0284x |   1.0363x|
|-2#dickens:|  1.0152x |   1.0119x |   1.0147x |   1.0060x |   1.0131x|
|-3#dickens:|  1.0154x |   1.0103x |   1.0139x |   1.0057x |   1.0143x|
|-1#mozilla:|  1.1445x |   1.1526x |   1.1547x |   1.1465x |   1.1511x|
|-2#mozilla:|  1.1002x |   1.1058x |   1.1075x |   1.0992x |   1.1051x|
|-3#mozilla:|  1.1118x |   1.1162x |   1.1184x |   1.1145x |   1.1144x|
|-1#mr:     |  1.1375x |   1.1388x |   1.1436x |   1.1315x |   1.1357x|
|-2#mr:     |  1.0852x |   1.0867x |   1.0916x |   1.0820x |   1.0891x|
|-3#mr:     |  1.0595x |   1.0594x |   1.0656x |   1.0574x |   1.0627x|
|-1#nci:    |  1.1581x |   1.1733x |   1.1722x |   1.1666x |   1.1810x|
|-2#nci:    |  1.1656x |   1.1774x |   1.1760x |   1.1750x |   1.1832x|
|-3#nci:    |  1.1897x |   1.2279x |   1.2258x |   1.2247x |   1.2366x|
|-1#ooffice:|  1.1928x |   1.2038x |   1.2015x |   1.1907x |   1.1978x|
|-2#ooffice:|  1.0610x |   1.0690x |   1.0678x |   1.0563x |   1.0663x|
|-3#ooffice:|  1.0565x |   1.0614x |   1.0597x |   1.0504x |   1.0574x|
|-1#osdb:   |  1.2234x |   1.2036x |   1.2047x |   1.2066x |   1.2065x|
|-2#osdb:   |  1.1225x |   1.1225x |   1.1208x |   1.1174x |   1.1269x|
|-3#osdb:   |  1.1202x |   1.1186x |   1.1162x |   1.1199x |   1.1212x|
|-1#reymont:|  1.0346x |   1.0401x |   1.0382x |   1.0296x |   1.0369x|
|-2#reymont:|  1.0356x |   1.0431x |   1.0441x |   1.0343x |   1.0411x|
|-3#reymont:|  1.0576x |   1.0644x |   1.0636x |   1.0591x |   1.0644x|
|-1#samba:  |  1.1258x |   1.1409x |   1.1423x |   1.1373x |   1.1402x|
|-2#samba:  |  1.1128x |   1.1242x |   1.1253x |   1.1199x |   1.1240x|
|-3#samba:  |  1.1314x |   1.1435x |   1.1444x |   1.1407x |   1.1452x|
|-1#sao:    |  1.3818x |   1.3807x |   1.3822x |   1.3880x |   1.3741x|
|-2#sao:    |  1.1083x |   1.1029x |   1.1057x |   1.0969x |   1.1207x|
|-3#sao:    |  1.0464x |   1.0402x |   1.0359x |   1.0195x |   1.0346x|
|-1#webster:|  1.1173x |   1.1186x |   1.1202x |   1.1116x |   1.1139x|
|-2#webster:|  1.0851x |   1.0841x |   1.0825x |   1.0794x |   1.0802x|
|-3#webster:|  1.1078x |   1.1022x |   1.1014x |   1.1009x |   1.1003x|
|-1#x-ray:  |  1.1004x |   1.0940x |   1.0911x |   1.0923x |   1.0892x|
|-2#x-ray:  |  1.1735x |   1.1783x |   1.1799x |   1.1764x |   1.1815x|
|-3#x-ray:  |  1.1407x |   1.1531x |   1.1388x |   1.1300x |   1.1326x|
|-1#xml:    |  1.1743x |   1.1818x |   1.1852x |   1.1843x |   1.1891x|
|-2#xml:    |  1.1735x |   1.1953x |   1.1960x |   1.1925x |   1.1967x|
|-3#xml:    |  1.1991x |   1.2407x |   1.2393x |   1.2320x |   1.2413x|
</details>

<details closed>
<summary>Cortex-A715</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0277x |   0.9961x |   1.0148x |   1.0076x |   1.0320x|
|-2#dickens:|  1.0049x |   0.9882x |   0.9809x |   0.9863x |   0.9998x|
|-3#dickens:|  1.0099x |   0.9869x |   0.9847x |   0.9915x |   1.0032x|
|-1#mozilla:|  1.2080x |   1.1390x |   1.1804x |   1.1665x |   1.1510x|
|-2#mozilla:|  1.1084x |   1.1108x |   1.1147x |   1.0865x |   1.1333x|
|-3#mozilla:|  1.1117x |   1.1221x |   1.1043x |   1.1109x |   1.1218x|
|-1#mr:     |  1.1330x |   1.1197x |   1.1217x |   1.1184x |   1.1180x|
|-2#mr:     |  1.0881x |   1.0729x |   1.0806x |   1.0707x |   1.0898x|
|-3#mr:     |  1.0599x |   1.0438x |   1.0519x |   1.0392x |   1.0558x|
|-1#nci:    |  1.2033x |   1.1765x |   1.2462x |   1.1957x |   1.2129x|
|-2#nci:    |  1.2358x |   1.3209x |   1.2068x |   1.3204x |   1.2299x|
|-3#nci:    |  1.2789x |   1.4187x |   1.3454x |   1.3700x |   1.3801x|
|-1#ooffice:|  1.2419x |   1.2335x |   1.2333x |   1.2384x |   1.2344x|
|-2#ooffice:|  1.0595x |   1.0430x |   1.0430x |   1.0524x |   1.0597x|
|-3#ooffice:|  1.0591x |   1.0376x |   1.0380x |   1.0451x |   1.0613x|
|-1#osdb:   |  1.2113x |   1.2122x |   1.2200x |   1.2339x |   1.2427x|
|-2#osdb:   |  1.1241x |   1.1224x |   1.1235x |   1.1549x |   1.1501x|
|-3#osdb:   |  1.1558x |   1.1457x |   1.1460x |   1.1635x |   1.1692x|
|-1#reymont:|  1.0222x |   1.0061x |   1.0031x |   1.0066x |   1.0256x|
|-2#reymont:|  1.0350x |   1.0134x |   1.0116x |   1.0140x |   1.0317x|
|-3#reymont:|  1.0612x |   1.0408x |   1.0381x |   1.0458x |   1.0552x|
|-1#samba:  |  1.1900x |   1.1299x |   1.1629x |   1.1223x |   1.2186x|
|-2#samba:  |  1.1374x |   1.1434x |   1.1106x |   1.1214x |   1.1270x|
|-3#samba:  |  1.0933x |   1.0959x |   1.1360x |   1.1479x |   1.2018x|
|-1#sao:    |  1.4868x |   1.4925x |   1.4941x |   1.4446x |   1.4769x|
|-2#sao:    |  1.1351x |   1.1066x |   1.0959x |   1.1109x |   1.1129x|
|-3#sao:    |  1.0782x |   1.0465x |   1.0477x |   1.0647x |   1.0726x|
|-1#webster:|  1.1032x |   1.0813x |   1.0758x |   1.0837x |   1.0525x|
|-2#webster:|  1.0864x |   1.0894x |   1.0356x |   1.0856x |   1.0961x|
|-3#webster:|  1.1271x |   1.0866x |   1.1368x |   1.1117x |   1.2275x|
|-1#x-ray:  |  1.1753x |   1.1882x |   1.1990x |   1.1744x |   1.1737x|
|-2#x-ray:  |  1.2399x |   1.2272x |   1.2294x |   1.2241x |   1.2281x|
|-3#x-ray:  |  1.1704x |   1.1634x |   1.1609x |   1.1683x |   1.1628x|
|-1#xml:    |  1.1892x |   1.2010x |   1.2008x |   1.2027x |   1.2216x|
|-2#xml:    |  1.1986x |   1.2175x |   1.2137x |   1.2213x |   1.2369x|
|-3#xml:    |  1.2361x |   1.2859x |   1.2838x |   1.2930x |   1.3157x|
</details>

<details closed>
<summary>Cortex-A720</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0190x |   1.0017x |   1.0095x |   1.0074x |   1.0218x|
|-2#dickens:|  0.9684x |   0.9762x |   0.9773x |   0.9801x |   0.9927x|
|-3#dickens:|  0.9719x |   0.9780x |   0.9804x |   0.9837x |   0.9966x|
|-1#mozilla:|  1.1286x |   1.0775x |   1.1253x |   1.1353x |   1.1555x|
|-2#mozilla:|  1.0817x |   1.0816x |   1.0728x |   1.0741x |   1.0864x|
|-3#mozilla:|  1.0965x |   1.0864x |   1.0886x |   1.0967x |   1.1002x|
|-1#mr:     |  1.1346x |   1.1338x |   1.1285x |   1.1291x |   1.1428x|
|-2#mr:     |  1.0721x |   1.0727x |   1.0732x |   1.0643x |   1.0803x|
|-3#mr:     |  1.0435x |   1.0398x |   1.0433x |   1.0376x |   1.0517x|
|-1#nci:    |  1.2650x |   1.2699x |   1.2424x |   1.2390x |   1.2903x|
|-2#nci:    |  1.2305x |   1.2079x |   1.2043x |   1.2152x |   1.2245x|
|-3#nci:    |  1.2195x |   1.3019x |   1.3217x |   1.3010x |   1.3100x|
|-1#ooffice:|  1.2365x |   1.2260x |   1.2266x |   1.2328x |   1.2281x|
|-2#ooffice:|  1.0526x |   1.0409x |   1.0407x |   1.0451x |   1.0556x|
|-3#ooffice:|  1.0470x |   1.0344x |   1.0340x |   1.0406x |   1.0521x|
|-1#osdb:   |  1.2114x |   1.2201x |   1.2198x |   1.2313x |   1.2413x|
|-2#osdb:   |  1.1197x |   1.1260x |   1.1264x |   1.1464x |   1.1527x|
|-3#osdb:   |  1.1459x |   1.1507x |   1.1488x |   1.1716x |   1.1698x|
|-1#reymont:|  1.0062x |   1.0006x |   1.0007x |   1.0038x |   1.0183x|
|-2#reymont:|  1.0101x |   1.0106x |   1.0100x |   1.0139x |   1.0273x|
|-3#reymont:|  1.0482x |   1.0376x |   1.0396x |   1.0422x |   1.0540x|
|-1#samba:  |  1.1365x |   1.0966x |   1.0722x |   1.1760x |   1.2008x|
|-2#samba:  |  1.1039x |   1.1092x |   1.1018x |   1.1094x |   1.1141x|
|-3#samba:  |  1.1163x |   1.1291x |   1.1236x |   1.1335x |   1.1513x|
|-1#sao:    |  1.4905x |   1.5280x |   1.5265x |   1.4508x |   1.5127x|
|-2#sao:    |  1.1369x |   1.1024x |   1.1054x |   1.1127x |   1.1080x|
|-3#sao:    |  1.0803x |   1.0587x |   1.0569x |   1.0601x |   1.0630x|
|-1#webster:|  1.1241x |   1.0712x |   1.0710x |   1.1017x |   1.0954x|
|-2#webster:|  1.0772x |   1.0503x |   1.0499x |   1.0483x |   1.0751x|
|-3#webster:|  1.1216x |   1.0845x |   1.0839x |   1.0937x |   1.1133x|
|-1#x-ray:  |  1.1607x |   1.1884x |   1.1862x |   1.1651x |   1.1712x|
|-2#x-ray:  |  1.2278x |   1.2244x |   1.2234x |   1.2213x |   1.2271x|
|-3#x-ray:  |  1.1590x |   1.1529x |   1.1545x |   1.1539x |   1.1575x|
|-1#xml:    |  1.1850x |   1.2004x |   1.1999x |   1.2064x |   1.2260x|
|-2#xml:    |  1.1822x |   1.2173x |   1.2164x |   1.2185x |   1.2398x|
|-3#xml:    |  1.2478x |   1.2952x |   1.2946x |   1.2959x |   1.3198x|
</details>

<details closed>
<summary>Cortex-A725</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0188x |   0.9948x |   0.9939x |   1.0167x |   1.0265x|
|-2#dickens:|  0.9747x |   0.9688x |   0.9689x |   0.9857x |   0.9946x|
|-3#dickens:|  0.9762x |   0.9724x |   0.9726x |   0.9921x |   1.0066x|
|-1#mozilla:|  1.1554x |   1.1471x |   1.1366x |   1.1554x |   1.1561x|
|-2#mozilla:|  1.0971x |   1.0847x |   1.0871x |   1.0927x |   1.1053x|
|-3#mozilla:|  1.1184x |   1.0987x |   1.0993x |   1.1100x |   1.1231x|
|-1#mr:     |  1.1303x |   1.1149x |   1.1137x |   1.1243x |   1.1303x|
|-2#mr:     |  1.0699x |   1.0590x |   1.0614x |   1.0734x |   1.0805x|
|-3#mr:     |  1.0404x |   1.0336x |   1.0373x |   1.0491x |   1.0499x|
|-1#nci:    |  1.1878x |   1.2257x |   1.2250x |   1.2330x |   1.2401x|
|-2#nci:    |  1.1999x |   1.2193x |   1.2261x |   1.2389x |   1.2449x|
|-3#nci:    |  1.2565x |   1.3322x |   1.3285x |   1.3406x |   1.3508x|
|-1#ooffice:|  1.2412x |   1.2233x |   1.2207x |   1.2351x |   1.2364x|
|-2#ooffice:|  1.0546x |   1.0373x |   1.0333x |   1.0535x |   1.0620x|
|-3#ooffice:|  1.0445x |   1.0315x |   1.0284x |   1.0453x |   1.0539x|
|-1#osdb:   |  1.1957x |   1.2084x |   1.2049x |   1.2267x |   1.2340x|
|-2#osdb:   |  1.1118x |   1.1212x |   1.1180x |   1.1418x |   1.1535x|
|-3#osdb:   |  1.1397x |   1.1456x |   1.1443x |   1.1749x |   1.1691x|
|-1#reymont:|  1.0038x |   0.9896x |   0.9975x |   1.0037x |   1.0216x|
|-2#reymont:|  1.0087x |   1.0078x |   1.0044x |   1.0131x |   1.0259x|
|-3#reymont:|  1.0487x |   1.0311x |   1.0304x |   1.0483x |   1.0546x|
|-1#samba:  |  1.1364x |   1.1285x |   1.1324x |   1.1475x |   1.1566x|
|-2#samba:  |  1.1201x |   1.1097x |   1.1063x |   1.1280x |   1.1420x|
|-3#samba:  |  1.1458x |   1.1429x |   1.1372x |   1.1561x |   1.1655x|
|-1#sao:    |  1.4724x |   1.5162x |   1.5078x |   1.4401x |   1.4905x|
|-2#sao:    |  1.1259x |   1.1051x |   1.1033x |   1.1095x |   1.1012x|
|-3#sao:    |  1.0741x |   1.0552x |   1.0550x |   1.0566x |   1.0569x|
|-1#webster:|  1.1091x |   1.0779x |   1.0820x |   1.1011x |   1.1137x|
|-2#webster:|  1.0793x |   1.0441x |   1.0444x |   1.0555x |   1.0765x|
|-3#webster:|  1.1263x |   1.0838x |   1.0853x |   1.1028x |   1.1136x|
|-1#x-ray:  |  1.0910x |   1.1260x |   1.1075x |   1.1034x |   1.1044x|
|-2#x-ray:  |  1.2294x |   1.2256x |   1.2231x |   1.2205x |   1.2221x|
|-3#x-ray:  |  1.1534x |   1.1441x |   1.1411x |   1.1546x |   1.1549x|
|-1#xml:    |  1.1837x |   1.1970x |   1.1974x |   1.2096x |   1.2294x|
|-2#xml:    |  1.1861x |   1.2125x |   1.2156x |   1.2221x |   1.2430x|
|-3#xml:    |  1.2454x |   1.2955x |   1.2999x |   1.3018x |   1.3222x|
</details>

<details closed>
<summary>Cortex-X1</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0492x |   1.0505x |   1.0511x |   1.0499x |   1.0343x|
|-2#dickens:|  1.0323x |   1.0188x |   1.0200x |   1.0275x |   1.0092x|
|-3#dickens:|  1.0281x |   1.0184x |   1.0279x |   1.0274x |   1.0144x|
|-1#mozilla:|  1.1505x |   1.1584x |   1.1580x |   1.1556x |   1.1532x|
|-2#mozilla:|  1.1018x |   1.1079x |   1.1069x |   1.1073x |   1.1027x|
|-3#mozilla:|  1.1083x |   1.1153x |   1.1182x |   1.1150x |   1.1129x|
|-1#mr:     |  1.1152x |   1.1199x |   1.1187x |   1.1167x |   1.1097x|
|-2#mr:     |  1.0920x |   1.0936x |   1.0944x |   1.0953x |   1.0825x|
|-3#mr:     |  1.0701x |   1.0670x |   1.0768x |   1.0777x |   1.0582x|
|-1#nci:    |  1.1771x |   1.2041x |   1.2042x |   1.1978x |   1.2075x|
|-2#nci:    |  1.1789x |   1.2073x |   1.2073x |   1.2010x |   1.2053x|
|-3#nci:    |  1.2049x |   1.2650x |   1.2648x |   1.2570x |   1.2697x|
|-1#ooffice:|  1.2504x |   1.2654x |   1.2631x |   1.2523x |   1.2552x|
|-2#ooffice:|  1.0705x |   1.0763x |   1.0749x |   1.0743x |   1.0690x|
|-3#ooffice:|  1.0696x |   1.0746x |   1.0698x |   1.0755x |   1.0676x|
|-1#osdb:   |  1.2211x |   1.2161x |   1.2133x |   1.2111x |   1.2116x|
|-2#osdb:   |  1.1405x |   1.1499x |   1.1533x |   1.1505x |   1.1422x|
|-3#osdb:   |  1.1606x |   1.1646x |   1.1642x |   1.1558x |   1.1544x|
|-1#reymont:|  1.0481x |   1.0442x |   1.0444x |   1.0475x |   1.0325x|
|-2#reymont:|  1.0527x |   1.0503x |   1.0528x |   1.0538x |   1.0411x|
|-3#reymont:|  1.0796x |   1.0784x |   1.0809x |   1.0787x |   1.0647x|
|-1#samba:  |  1.1306x |   1.1551x |   1.1537x |   1.1575x |   1.1483x|
|-2#samba:  |  1.1178x |   1.1409x |   1.1408x |   1.1434x |   1.1345x|
|-3#samba:  |  1.1383x |   1.1637x |   1.1627x |   1.1614x |   1.1578x|
|-1#sao:    |  1.3823x |   1.3915x |   1.3908x |   1.3968x |   1.3778x|
|-2#sao:    |  1.1022x |   1.1049x |   1.1049x |   1.0848x |   1.1217x|
|-3#sao:    |  1.0498x |   1.0412x |   1.0409x |   1.0265x |   1.0680x|
|-1#webster:|  1.1257x |   1.1219x |   1.1217x |   1.1231x |   1.1065x|
|-2#webster:|  1.0964x |   1.0863x |   1.0869x |   1.0923x |   1.0771x|
|-3#webster:|  1.1052x |   1.0993x |   1.1064x |   1.1076x |   1.0951x|
|-1#x-ray:  |  1.1036x |   1.0915x |   1.0969x |   1.1102x |   1.0920x|
|-2#x-ray:  |  1.2013x |   1.2104x |   1.2109x |   1.2031x |   1.1973x|
|-3#x-ray:  |  1.1617x |   1.1581x |   1.1558x |   1.1573x |   1.1435x|
|-1#xml:    |  1.2077x |   1.2491x |   1.2470x |   1.2486x |   1.2465x|
|-2#xml:    |  1.2150x |   1.2633x |   1.2650x |   1.2638x |   1.2648x|
|-3#xml:    |  1.2508x |   1.3401x |   1.3400x |   1.3375x |   1.3349x|
</details>

<details closed>
<summary>Cortex-X2</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0369x |   1.0388x |   1.0387x |   1.0417x |   1.0293x|
|-2#dickens:|  1.0192x |   1.0132x |   1.0130x |   1.0132x |   1.0008x|
|-3#dickens:|  1.0201x |   1.0095x |   1.0106x |   1.0150x |   1.0045x|
|-1#mozilla:|  1.1426x |   1.1523x |   1.1521x |   1.1537x |   1.1506x|
|-2#mozilla:|  1.1010x |   1.1058x |   1.1034x |   1.1094x |   1.1009x|
|-3#mozilla:|  1.1080x |   1.1155x |   1.1147x |   1.1206x |   1.0996x|
|-1#mr:     |  1.1338x |   1.1118x |   1.1080x |   1.1313x |   1.1261x|
|-2#mr:     |  1.0895x |   1.0913x |   1.0916x |   1.0886x |   1.0856x|
|-3#mr:     |  1.0528x |   1.0384x |   1.0870x |   1.0568x |   1.0493x|
|-1#nci:    |  1.1367x |   1.1655x |   1.1623x |   1.1592x |   1.1659x|
|-2#nci:    |  1.1511x |   1.1731x |   1.1730x |   1.1542x |   1.1564x|
|-3#nci:    |  1.1599x |   1.2126x |   1.2068x |   1.2032x |   1.2095x|
|-1#ooffice:|  1.2088x |   1.2163x |   1.2162x |   1.2080x |   1.2126x|
|-2#ooffice:|  1.0641x |   1.0650x |   1.0627x |   1.0681x |   1.0583x|
|-3#ooffice:|  1.0616x |   1.0587x |   1.0589x |   1.0612x |   1.0517x|
|-1#osdb:   |  1.2198x |   1.2065x |   1.2059x |   1.1983x |   1.2042x|
|-2#osdb:   |  1.1223x |   1.1291x |   1.1265x |   1.1239x |   1.1185x|
|-3#osdb:   |  1.1321x |   1.1436x |   1.1471x |   1.1390x |   1.1381x|
|-1#reymont:|  1.0367x |   1.0328x |   1.0327x |   1.0354x |   1.0236x|
|-2#reymont:|  1.0427x |   1.0436x |   1.0426x |   1.0443x |   1.0327x|
|-3#reymont:|  1.0679x |   1.0632x |   1.0572x |   1.0639x |   1.0569x|
|-1#samba:  |  1.1230x |   1.1432x |   1.1435x |   1.1475x |   1.1353x|
|-2#samba:  |  1.1098x |   1.1247x |   1.1254x |   1.1308x |   1.1171x|
|-3#samba:  |  1.1254x |   1.1525x |   1.1492x |   1.1412x |   1.1383x|
|-1#sao:    |  1.3612x |   1.3708x |   1.3705x |   1.3771x |   1.3690x|
|-2#sao:    |  1.0920x |   1.0804x |   1.0839x |   1.0848x |   1.1077x|
|-3#sao:    |  0.9962x |   0.9793x |   0.9738x |   0.9844x |   1.0044x|
|-1#webster:|  1.1222x |   1.1230x |   1.1225x |   1.1235x |   1.1140x|
|-2#webster:|  1.0944x |   1.0902x |   1.0931x |   1.0943x |   1.0773x|
|-3#webster:|  1.1174x |   1.1157x |   1.1175x |   1.1169x |   1.0941x|
|-1#x-ray:  |  1.1026x |   1.0964x |   1.1007x |   1.0857x |   1.0950x|
|-2#x-ray:  |  1.1956x |   1.2012x |   1.1982x |   1.1977x |   1.2033x|
|-3#x-ray:  |  1.1517x |   1.1546x |   1.1478x |   1.1445x |   1.1490x|
|-1#xml:    |  1.1664x |   1.1927x |   1.1860x |   1.1916x |   1.1861x|
|-2#xml:    |  1.1452x |   1.1911x |   1.1928x |   1.1955x |   1.1860x|
|-3#xml:    |  1.1913x |   1.2464x |   1.2352x |   1.2407x |   1.2390x|
</details>

<details closed>
<summary>Cortex-X3</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  1.0116x |   1.0203x |   0.9860x |   1.0063x |   0.9887x|
|-2#dickens:|  0.9816x |   0.9828x |   0.9799x |   0.9782x |   0.9839x|
|-3#dickens:|  0.9863x |   0.9868x |   0.9860x |   0.9886x |   0.9813x|
|-1#mozilla:|  1.1242x |   1.1202x |   1.1654x |   1.1634x |   1.1055x|
|-2#mozilla:|  1.0831x |   1.0713x |   1.0867x |   1.0835x |   1.0782x|
|-3#mozilla:|  1.0946x |   1.1137x |   1.1083x |   1.1099x |   1.1058x|
|-1#mr:     |  1.1193x |   1.0565x |   1.0790x |   1.0706x |   0.9634x|
|-2#mr:     |  1.0678x |   1.0700x |   1.0687x |   1.0726x |   1.0557x|
|-3#mr:     |  1.0406x |   1.0417x |   1.0409x |   1.0437x |   1.0346x|
|-1#nci:    |  1.1582x |   1.1820x |   1.1506x |   1.1936x |   1.1812x|
|-2#nci:    |  1.1353x |   1.1738x |   1.1792x |   1.1750x |   1.1776x|
|-3#nci:    |  1.1896x |   1.2817x |   1.2640x |   1.2819x |   1.2854x|
|-1#ooffice:|  1.2047x |   1.2002x |   1.2077x |   1.1994x |   1.2004x|
|-2#ooffice:|  1.0418x |   1.0420x |   1.0566x |   1.0421x |   1.0421x|
|-3#ooffice:|  1.0480x |   1.0371x |   1.0379x |   1.0373x |   1.0318x|
|-1#osdb:   |  1.0889x |   1.1055x |   1.1213x |   1.0544x |   1.1511x|
|-2#osdb:   |  1.1067x |   1.1089x |   1.0992x |   1.1094x |   1.0991x|
|-3#osdb:   |  1.1286x |   1.1296x |   1.1283x |   1.1311x |   1.1191x|
|-1#reymont:|  0.9966x |   1.0090x |   1.0110x |   1.0117x |   1.0040x|
|-2#reymont:|  1.0096x |   1.0249x |   1.0183x |   1.0244x |   1.0069x|
|-3#reymont:|  1.0416x |   1.0475x |   1.0484x |   1.0428x |   1.0402x|
|-1#samba:  |  1.1045x |   1.1029x |   1.1245x |   1.1147x |   1.1149x|
|-2#samba:  |  1.0812x |   1.1148x |   1.1009x |   1.1030x |   1.0861x|
|-3#samba:  |  1.1112x |   1.1375x |   1.1568x |   1.1254x |   1.1275x|
|-1#sao:    |  1.2809x |   1.2907x |   1.2873x |   1.2960x |   1.6011x|
|-2#sao:    |  1.0931x |   1.0909x |   1.0933x |   1.0810x |   1.0838x|
|-3#sao:    |  1.0157x |   1.0440x |   1.0327x |   1.0378x |   1.0171x|
|-1#webster:|  1.0756x |   1.1161x |   1.0513x |   1.0704x |   1.0572x|
|-2#webster:|  1.0693x |   1.0639x |   1.0634x |   1.0602x |   1.0601x|
|-3#webster:|  1.0779x |   1.0919x |   1.0937x |   1.0953x |   1.0814x|
|-1#x-ray:  |  1.1391x |   1.1387x |   1.1406x |   1.1374x |   1.1609x|
|-2#x-ray:  |  1.2405x |   1.2288x |   1.2210x |   1.2193x |   1.2277x|
|-3#x-ray:  |  1.1476x |   1.1384x |   1.1449x |   1.1521x |   1.1483x|
|-1#xml:    |  1.1394x |   1.1838x |   1.1832x |   1.1879x |   1.1650x|
|-2#xml:    |  1.1390x |   1.1995x |   1.1958x |   1.1913x |   1.1799x|
|-3#xml:    |  1.1789x |   1.2798x |   1.2780x |   1.2822x |   1.2531x|
</details>

<details closed>
<summary>Cortex-X4</summary>

|           | Clang-17 |  Clang-18 |  Clang-19 |  Clang-20 |  Clang-21|
|---|---|---|---|---|---|
|-1#dickens:|  0.9722x |   0.9742x |   0.9701x |   0.9725x |   0.9941x|
|-2#dickens:|  0.9400x |   0.9413x |   0.9405x |   0.9413x |   0.9593x|
|-3#dickens:|  0.9452x |   0.9464x |   0.9455x |   0.9463x |   0.9616x|
|-1#mozilla:|  1.1048x |   1.1133x |   1.1109x |   1.1023x |   1.1172x|
|-2#mozilla:|  1.0610x |   1.0576x |   1.0713x |   1.0531x |   1.0707x|
|-3#mozilla:|  1.0922x |   1.0656x |   1.0778x |   1.0893x |   1.0831x|
|-1#mr:     |  1.1033x |   1.1079x |   1.1066x |   1.1010x |   1.1233x|
|-2#mr:     |  1.0233x |   1.0307x |   1.0270x |   1.0231x |   1.0443x|
|-3#mr:     |  0.9982x |   1.0069x |   1.0066x |   1.0036x |   1.0254x|
|-1#nci:    |  1.1235x |   1.1329x |   1.1393x |   1.1415x |   1.1460x|
|-2#nci:    |  1.1756x |   1.0920x |   1.1704x |   1.0816x |   1.1913x|
|-3#nci:    |  1.2411x |   1.1749x |   1.2412x |   1.2677x |   1.2659x|
|-1#ooffice:|  1.2193x |   1.2336x |   1.2427x |   1.2156x |   1.2432x|
|-2#ooffice:|  0.9980x |   1.0161x |   1.0292x |   0.9996x |   1.0219x|
|-3#ooffice:|  0.9898x |   1.0146x |   1.0147x |   1.0232x |   1.0140x|
|-1#osdb:   |  1.1613x |   1.1877x |   1.1875x |   1.1925x |   1.2004x|
|-2#osdb:   |  1.0684x |   1.0947x |   1.0941x |   1.1024x |   1.0967x|
|-3#osdb:   |  1.0976x |   1.1186x |   1.1191x |   1.1247x |   1.1202x|
|-1#reymont:|  0.9650x |   0.9616x |   0.9691x |   0.9704x |   0.9804x|
|-2#reymont:|  0.9742x |   0.9886x |   0.9947x |   0.9772x |   1.0011x|
|-3#reymont:|  1.0051x |   1.0255x |   1.0161x |   1.0228x |   1.0372x|
|-1#samba:  |  1.0819x |   1.0892x |   1.0910x |   1.0891x |   1.1056x|
|-2#samba:  |  1.0682x |   1.0852x |   1.0794x |   1.0776x |   1.0863x|
|-3#samba:  |  1.0883x |   1.0903x |   1.1058x |   1.0995x |   1.0867x|
|-1#sao:    |  1.4957x |   1.4796x |   1.4873x |   1.4769x |   1.5122x|
|-2#sao:    |  1.1061x |   1.0772x |   1.0869x |   1.1003x |   1.1546x|
|-3#sao:    |  1.0415x |   1.0381x |   1.0407x |   1.0407x |   1.0552x|
|-1#webster:|  1.0659x |   1.0633x |   1.0630x |   1.0564x |   1.0789x|
|-2#webster:|  1.0381x |   1.0342x |   1.0337x |   1.0287x |   1.0500x|
|-3#webster:|  1.0777x |   1.0886x |   1.0456x |   1.0165x |   1.0813x|
|-1#x-ray:  |  1.1180x |   1.1079x |   1.1054x |   1.1046x |   1.1959x|
|-2#x-ray:  |  1.1974x |   1.2111x |   1.2032x |   1.1931x |   1.2362x|
|-3#x-ray:  |  1.1239x |   1.1323x |   1.1284x |   1.1209x |   1.1506x|
|-1#xml:    |  1.1391x |   1.1969x |   1.1959x |   1.1984x |   1.1901x|
|-2#xml:    |  1.1307x |   1.2023x |   1.1980x |   1.2102x |   1.2215x|
|-3#xml:    |  1.1725x |   1.3038x |   1.3032x |   1.3083x |   1.3085x|
</details>
