### PR TITLE
fix typedef redefinition warning in strict C90 mode

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -167,19 +167,21 @@ static int g_debuglog_enable = 1;
 /*-************************************
 *  Basic Types
 **************************************/
-#if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
-# include <stdint.h>
-  typedef  uint8_t BYTE;
-  typedef uint16_t U16;
-  typedef uint32_t U32;
-  typedef  int32_t S32;
-  typedef uint64_t U64;
-#else
-  typedef unsigned char       BYTE;
-  typedef unsigned short      U16;
-  typedef unsigned int        U32;
-  typedef   signed int        S32;
-  typedef unsigned long long  U64;
+#ifndef LZ4_SRC_INCLUDED
+# if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
+#   include <stdint.h>
+    typedef  uint8_t BYTE;
+    typedef uint16_t U16;
+    typedef uint32_t U32;
+    typedef  int32_t S32;
+    typedef uint64_t U64;
+# else
+    typedef unsigned char      BYTE;
+    typedef unsigned short     U16;
+    typedef unsigned int       U32;
+    typedef   signed int       S32;
+    typedef unsigned long long U64;
+# endif
 #endif
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -201,6 +201,8 @@ test32: test
 
 test-amalgamation: lz4_all.o
 
+lz4_all.o: CFLAGS += -Werror -std=c90
+
 CLEAN += lz4_all.c
 lz4_all.c: $(LIBDIR)/lz4.c $(LIBDIR)/lz4hc.c $(LIBDIR)/lz4frame.c
 	$(CAT) $^ > $@


### PR DESCRIPTION
when using amalgamated source code,
and make the test reactive to warnings (`-Werror`)