### PR TITLE
Improve decompression speed on aarch64

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -511,6 +511,20 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);
 }
 
+
+#ifdef __aarch64__
+/* customized variant of memcpy, which can overwrite up to 64 bytes beyond dstEnd */
+LZ4_FORCE_INLINE void
+LZ4_wildCopy64(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,64); d+=64; s+=64; } while (d<e);
+}
+#endif
+
 /* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
  * this version copies two times 16 bytes (instead of one time 32 bytes)
  * because it must be compatible with offsets >= 16. */
@@ -2097,8 +2111,13 @@ LZ4_decompress_generic(
 
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+              #ifdef __aarch64__
+                if ((cpy>oend-64) || (ip+length>iend-64)) { goto safe_literal_copy; }
+                LZ4_wildCopy64(op, ip, cpy);
+              #else
                 if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
                 LZ4_wildCopy32(op, ip, op+length);
+              #endif
                 ip += length; op += length;
             } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
                 /* We don't need to check oend, since we check it once for each loop below */
@@ -2194,9 +2213,13 @@ LZ4_decompress_generic(
             /* copy match within block */
             cpy = op + length;
 
-            assert((op <= oend) && (oend-op >= 32));
+            assert((op <= oend) && (oend-op >= 64));
             if (unlikely(offset<16)) {
                 LZ4_memcpy_using_offset(op, match, cpy, offset);
+    #ifdef __aarch64__
+            } else if (offset >= 64) {
+                LZ4_wildCopy64(op, match, cpy);
+    #endif
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -494,10 +494,9 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
         LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
-        dstPtr[0] = srcPtr[0];
-        dstPtr[1] = srcPtr[1];
-        dstPtr[2] = srcPtr[2];
-        dstPtr[3] = srcPtr[3];
+        assert(offset >= 3);
+        LZ4_memcpy(dstPtr, srcPtr, 2);
+        LZ4_memcpy(dstPtr + 2, srcPtr + 2, 2);
         srcPtr += inc32table[offset];
         LZ4_memcpy(dstPtr+4, srcPtr, 4);
         srcPtr -= dec64table[offset];

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2098,6 +2098,8 @@ LZ4_decompress_generic(
             length = token >> ML_BITS;  /* literal length */
             DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
+            if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) { cpy = op+length; goto safe_literal_copy; }
+
             /* decode literal length */
             if (length == RUN_MASK) {
                 size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
@@ -2119,14 +2121,11 @@ LZ4_decompress_generic(
                 LZ4_wildCopy32(op, ip, op+length);
               #endif
                 ip += length; op += length;
-            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
-                /* We don't need to check oend, since we check it once for each loop below */
+            } else {
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                 /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
                 LZ4_memcpy(op, ip, 16);
                 ip += length; op += length;
-            } else {
-                goto safe_literal_copy;
             }
 
             /* get offset */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2101,13 +2101,15 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) {
-                    DEBUGLOG(6, "error reading long literal length");
-                    goto _output_error;
-                }
-                length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                size_t s;
+                do {
+                    s = *ip++;
+                    if (unlikely(ip >= iend)) { goto _output_error; } /* overflow detection */
+                    length += s;
+                } while (s==255);
+                
+                cpy = op+length;
+                if (unlikely((uptrval)(cpy)<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
 
                 /* copy literals */
@@ -2116,10 +2118,10 @@ LZ4_decompress_generic(
                 if ((cpy>oend-64) || (ip+length>iend-64)) { goto safe_literal_copy; }
                 LZ4_wildCopy64(op, ip, cpy);
               #else
-                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
-                LZ4_wildCopy32(op, ip, op+length);
+                if ((cpy>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
+                LZ4_wildCopy32(op, ip, cpy);
               #endif
-                ip += length; op += length;
+                ip += length; op = cpy;
             } else {
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                 /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2095,6 +2095,7 @@ LZ4_decompress_generic(
             assert(ip < iend);
             token = *ip++;
             length = token >> ML_BITS;  /* literal length */
+            token &= ML_MASK;
             DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
             if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) { cpy = op+length; goto safe_literal_copy; }
@@ -2129,14 +2130,15 @@ LZ4_decompress_generic(
                 ip += length; op += length;
             }
 
+            /* get matchlength */
+            length = token;
+
             /* get offset */
             offset = LZ4_readLE16(ip); ip+=2;
             DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
             match = op - offset;
             assert(match <= op);  /* overflow check */
 
-            /* get matchlength */
-            length = token & ML_MASK;
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
@@ -2145,8 +2147,8 @@ LZ4_decompress_generic(
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
                 }
-                length += addl;
                 length += MINMATCH;
+                length += addl;
                 DEBUGLOG(7, "  long match length == %u", (unsigned)length);
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {


### PR DESCRIPTION
Incorporating 5 commits that results in about 10% higher decompression throughput

We observe the following results when testing the silesia corpus on a Neoverse-V2

Before:

  #dickens           :  3616.6 MB/s
  #mozilla           :  4300.6 MB/s
  #mr                :  4460.7 MB/s
  #nci               :  6226.2 MB/s
  #ooffice           :  4008.8 MB/s
  #osdb              :  4367.7 MB/s
  #reymont           :  3162.5 MB/s
  #samba             :  4721.0 MB/s
  #sao               :  5895.7 MB/s
  #webster           :  3876.9 MB/s
  #xml               :  4791.6 MB/s
  #x-ray             :  14229.6 MB/s

After:

  #dickens           :  3880.8 MB/s ----> +7% 
  #mozilla           :  4618.4 MB/s ----> +7%
  #mr                :  4931.9 MB/s ----> +11% 
  #nci               :  6538.4 MB/s ----> +5%
  #ooffice           :  4625.5 MB/s ----> +15%
  #osdb              :  4628.9 MB/s ----> +6%
  #reymont           :  3352.2 MB/s ----> +6%
  #samba             :  5069.3 MB/s ----> +7%
  #sao               :  7557.6 MB/s ----> +28%
  #webster           :  4155.6 MB/s ----> +7%
  #xml               :  5288.1 MB/s ----> +10%
  #x-ray             :  16739.8 MB/s ---> +18%