### PR TITLE
Introduce LZ4_wildCopy64 for aarch64

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -511,6 +511,20 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     LZ4_wildCopy8(dstPtr, srcPtr, dstEnd);
 }
 
+
+#ifdef __aarch64__
+/* customized variant of memcpy, which can overwrite up to 64 bytes beyond dstEnd */
+LZ4_FORCE_INLINE void
+LZ4_wildCopy64(void* dstPtr, const void* srcPtr, void* dstEnd)
+{
+    BYTE* d = (BYTE*)dstPtr;
+    const BYTE* s = (const BYTE*)srcPtr;
+    BYTE* const e = (BYTE*)dstEnd;
+
+    do { LZ4_memcpy(d,s,64); d+=64; s+=64; } while (d<e);
+}
+#endif
+
 /* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
  * this version copies two times 16 bytes (instead of one time 32 bytes)
  * because it must be compatible with offsets >= 16. */
@@ -2097,8 +2111,13 @@ LZ4_decompress_generic(
 
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
+              #ifdef __aarch64__
+                if ((op+length>oend-64) || (ip+length>iend-64)) { goto safe_literal_copy; }
+                LZ4_wildCopy64(op, ip, op+length);
+              #else
                 if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
                 LZ4_wildCopy32(op, ip, op+length);
+              #endif
                 ip += length; op += length;
             } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
                 /* We don't need to check oend, since we check it once for each loop below */
@@ -2194,9 +2213,13 @@ LZ4_decompress_generic(
             /* copy match within block */
             cpy = op + length;
 
-            assert((op <= oend) && (oend-op >= 32));
+            assert((op <= oend) && (oend-op >= 64));
             if (unlikely(offset<16)) {
                 LZ4_memcpy_using_offset(op, match, cpy, offset);
+    #ifdef __aarch64__
+            } else if (offset >= 64) {
+                LZ4_wildCopy64(op, match, cpy);
+    #endif
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }


### PR DESCRIPTION
Leveraging that FASTLOOP_SAFE_DISTANCE is 64, we are introducing LZ4_wildCopy64, which copies 64 bytes at a time. This is specially fast on aarch64 due to compiling using the ldp instruction.

We see noticeable performance improvements on decompression speed when tested using Neoverse-V2. Below measurements are the median of 3 runs.

Before:

  #dickens           :  3589.4 MB/s
  #mozilla           :  4313.6 MB/s
  #mr                :  4443.0 MB/s
  #nci               :  6199.0 MB/s
  #osdb              :  4345.9 MB/s
  #reymont           :  3160.8 MB/s
  #samba             :  4726.0 MB/s
  #sao               :  5939.5 MB/s
  #webster           :  3872.3 MB/s
  #xml               :  4818.1 MB/s
  #x-ray             :  14264.5 MB/s

After:

  #dickens           :  3612.0 MB/s ----> +1%
  #mozilla           :  4429.2 MB/s ----> +3%
  #mr                :  4651.1 MB/s ----> +5%
  #nci               :  6352.6 MB/s ----> +2%
  #osdb              :  4379.9 MB/s ----> +1%
  #reymont           :  3148.0 MB/s ----> -1%
  #samba             :  4856.7 MB/s ----> +3%
  #sao               :  7059.6 MB/s ----> +19%
  #webster           :  3913.7 MB/s ----> +1%
  #xml               :  5082.2 MB/s ----> +5%
  #x-ray             :  16059.6 MB/s ----> +13%