### PR TITLE
Quickly branch on stream's end

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2084,30 +2084,30 @@ LZ4_decompress_generic(
             length = token >> ML_BITS;  /* literal length */
             DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
+            if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) { goto safe_literal_copy_early; }
+
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                size_t const addl = read_variable_length(&ip, iend, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
                 }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                cpy = op+length;
+                if (unlikely((uptrval)(cpy)<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
 
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
-                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
-                LZ4_wildCopy32(op, ip, op+length);
-                ip += length; op += length;
-            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
-                /* We don't need to check oend, since we check it once for each loop below */
+                if ((cpy>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
+                LZ4_wildCopy32(op, ip, cpy);
+                ip += length; op = cpy;
+            } else {
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                 /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
                 LZ4_memcpy(op, ip, 16);
                 ip += length; op += length;
-            } else {
-                goto safe_literal_copy;
             }
 
             /* get offset */
@@ -2256,6 +2256,10 @@ LZ4_decompress_generic(
                 goto _copy_match;
             }
 
+#if LZ4_FAST_DEC_LOOP
+        safe_literal_copy_early:
+#endif
+
             /* decode literal length */
             if (length == RUN_MASK) {
                 size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
@@ -2265,11 +2269,12 @@ LZ4_decompress_generic(
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
             }
 
+            /* copy literals */
+            cpy = op+length;
+
 #if LZ4_FAST_DEC_LOOP
         safe_literal_copy:
 #endif
-            /* copy literals */
-            cpy = op+length;
 
             LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
             if ((cpy>oend-MFLIMIT) || (ip+length>iend-(2+1+LASTLITERALS))) {


### PR DESCRIPTION
Idea is to hoist stream's end branching logic:

if (ip > iend-(16 + 1/*max lit + offset + nextToken*/)) { cpy = op+length; goto safe_literal_copy; }

The if clause can be determined before reading the input stream, thus the CPU should be able to decide on branching before loading the next token.

Benchmarking on Silesia using Neoverse-V2 shows noticeable decompressing speed improvements:

Before:

  #dickens           :  3612.0 MB/s
  #mozilla           :  4429.2 MB/s
  #mr                :  4651.1 MB/s
  #nci               :  6352.6 MB/s
  #osdb              :  4379.9 MB/s
  #reymont           :  3148.0 MB/s
  #samba             :  4856.7 MB/s
  #sao               :  7059.6 MB/s
  #webster           :  3913.7 MB/s
  #xml               :  5082.2 MB/s
  #x-ray             :  16059.6 MB/s

After:

  #dickens           :  3842.3 MB/s ----> +6%
  #mozilla           :  4580.8 MB/s ----> +3%
  #mr                :  4930.7 MB/s ----> +6%
  #nci               :  6516.1 MB/s ----> +3%
  #osdb              :  4522.2 MB/s ----> +3%
  #reymont           :  3344.3 MB/s ----> +6%
  #samba             :  5066.3 MB/s ----> +4%
  #sao               :  7175.5 MB/s ----> +2%
  #webster           :  4134.1 MB/s ----> +6%
  #xml               :  5326.1 MB/s ----> +5%
  #x-ray             :  16424.5 MB/s ---> +2%