### PR TITLE
Use 2-byte loads on LZ4_memcpy_using_offset_base

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -494,7 +494,7 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
         LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
-        assert(offset >= 2);
+        assert(offset != 1); // offset==0 only happens on testing
         LZ4_memcpy(dstPtr, srcPtr, 2);
         LZ4_memcpy(dstPtr + 2, srcPtr + 2, 2);
         srcPtr += inc32table[offset];

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -494,7 +494,7 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
         LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
-        assert(offset >= 3);
+        assert(offset >= 2);
         LZ4_memcpy(dstPtr, srcPtr, 2);
         LZ4_memcpy(dstPtr + 2, srcPtr + 2, 2);
         srcPtr += inc32table[offset];

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -494,10 +494,9 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
         LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
-        dstPtr[0] = srcPtr[0];
-        dstPtr[1] = srcPtr[1];
-        dstPtr[2] = srcPtr[2];
-        dstPtr[3] = srcPtr[3];
+        assert(offset >= 3);
+        LZ4_memcpy(dstPtr, srcPtr, 2);
+        LZ4_memcpy(dstPtr + 2, srcPtr + 2, 2);
         srcPtr += inc32table[offset];
         LZ4_memcpy(dstPtr+4, srcPtr, 4);
         srcPtr -= dec64table[offset];

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -494,7 +494,7 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
         LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
-        assert(offset != 1); // offset==0 only happens on testing
+        assert(offset != 1);   /* offset==0 happens on testing */
         LZ4_memcpy(dstPtr, srcPtr, 2);
         LZ4_memcpy(dstPtr + 2, srcPtr + 2, 2);
         srcPtr += inc32table[offset];


### PR DESCRIPTION
Change first bytes copy of LZ4_memcpy_using_offset_base to 2-byte memcpys. Idea is to use two 2-byte memory load/stores instruction pairs instead of four 1-byte loads/stores. It is safe because the function gets called only when offset is at least 3