### PR TITLE
Compute branching condition earlier

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2082,6 +2082,7 @@ LZ4_decompress_generic(
             assert(ip < iend);
             token = *ip++;
             length = token >> ML_BITS;  /* literal length */
+            token &= ML_MASK;
             DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
             /* decode literal length */
@@ -2110,14 +2111,15 @@ LZ4_decompress_generic(
                 goto safe_literal_copy;
             }
 
+            /* get matchlength */
+            length = token;
+
             /* get offset */
             offset = LZ4_readLE16(ip); ip+=2;
             DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
             match = op - offset;
             assert(match <= op);  /* overflow check */
 
-            /* get matchlength */
-            length = token & ML_MASK;
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
@@ -2126,8 +2128,8 @@ LZ4_decompress_generic(
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
                 }
-                length += addl;
                 length += MINMATCH;
+                length += addl;
                 DEBUGLOG(7, "  long match length == %u", (unsigned)length);
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
@@ -2212,6 +2214,7 @@ LZ4_decompress_generic(
             assert(ip < iend);
             token = *ip++;
             length = token >> ML_BITS;  /* literal length */
+            token &= ML_MASK; /* match length */
             DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
             /* A two-stage shortcut for the most common case:
@@ -2232,7 +2235,7 @@ LZ4_decompress_generic(
 
                 /* The second stage: prepare for match copying, decode full info.
                  * If it doesn't work out, the info won't be wasted. */
-                length = token & ML_MASK; /* match length */
+                length = token; /* match length */
                 DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op-(BYTE*)dst), (unsigned)length, (unsigned)length + 4);
                 offset = LZ4_readLE16(ip); ip += 2;
                 match = op - offset;
@@ -2329,12 +2332,13 @@ LZ4_decompress_generic(
                 ip += length; op = cpy;
             }
 
+            /* get matchlength */
+            length = token;
+
             /* get offset */
             offset = LZ4_readLE16(ip); ip+=2;
             match = op - offset;
-
-            /* get matchlength */
-            length = token & ML_MASK;
+            
             DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
 
     _copy_match:


### PR DESCRIPTION
Token variable needs to be saved throughout literal computation. However, it is already on gp registers when we compute the initial literal length, so now we also compute the initial match length in parallel. Literal copy branches on its initial length, so now the CPU can know earlier whether to jump or not