### PR TITLE
Fix output filename buffer size to use actual suffix length

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -961,7 +961,7 @@ int LZ4IO_compressMultipleFilenames_Legacy(
 
         if (ofnSize <= ifnSize+suffixSize+1) {
             free(dstFileName);
-            ofnSize = ifnSize + 20;
+            ofnSize = ifnSize + suffixSize + 1;
             dstFileName = (char*)malloc(ofnSize);
             if (dstFileName==NULL) {
                 return ifntSize;
@@ -1561,7 +1561,7 @@ int LZ4IO_compressMultipleFilenames(
         /* suffix != stdout => compress into a file => generate its name */
         if (ofnSize <= ifnSize+suffixSize+1) {
             free(dstFileName);
-            ofnSize = ifnSize + 20;
+            ofnSize = ifnSize + suffixSize + 1;
             dstFileName = (char*)malloc(ofnSize);
             if (dstFileName==NULL) {
                 LZ4IO_freeCResources(ress);
@@ -2538,7 +2538,7 @@ int LZ4IO_decompressMultipleFilenames(
         }
         if (ofnSize <= ifnSize-suffixSize+1) {
             free(outFileName);
-            ofnSize = ifnSize + 20;
+            ofnSize = ifnSize - suffixSize + 1;
             outFileName = (char*)malloc(ofnSize);
             if (outFileName==NULL) END_PROCESS(71, "Memory allocation error");
         }


### PR DESCRIPTION
The size check in `LZ4IO_compressFilename_Legacy_internal` (line 962) and `LZ4IO_compressMultipleFilenames` (line 1562) correctly tests `ofnSize <= ifnSize+suffixSize+1`, but the reallocation on the next line hardcodes `ifnSize + 20`. When the `suffix` parameter passed via the lz4io.h API is longer than 19 characters, the allocated buffer is too small for the subsequent `strcpy`+`strcat`, causing a heap buffer overflow.

The decompress path (line 2541) had the same hardcoded `+20`; updated to `ifnSize - suffixSize + 1` to match its corresponding check.

One-liner fix at three sites — each reallocation now uses the same expression as its adjacent size check.