### PR TITLE
fix: reject negative dictSize in decompression API functions

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2585,6 +2585,7 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
 int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
 {
     LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
+    if (dictSize < 0) return 0;
     lz4sd->prefixSize = (size_t)dictSize;
     if (dictSize) {
         assert(dictionary != NULL);
@@ -2714,6 +2715,7 @@ Advanced decoding functions :
 
 int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressedSize, int maxOutputSize, const char* dictStart, int dictSize)
 {
+    if (dictSize < 0) return -1;
     if (dictSize==0)
         return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
     if (dictStart+dictSize == dest) {
@@ -2729,6 +2731,7 @@ int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressed
 
 int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity, const char* dictStart, int dictSize)
 {
+    if (dictSize < 0) return -1;
     if (dictSize==0)
         return LZ4_decompress_safe_partial(source, dest, compressedSize, targetOutputSize, dstCapacity);
     if (dictStart+dictSize == dest) {
@@ -2744,6 +2747,7 @@ int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int co
 
 int LZ4_decompress_fast_usingDict(const char* source, char* dest, int originalSize, const char* dictStart, int dictSize)
 {
+    if (dictSize < 0) return -1;
     if (dictSize==0 || dictStart+dictSize == dest)
         return LZ4_decompress_unsafe_generic(
                         (const BYTE*)source, (BYTE*)dest, originalSize,


### PR DESCRIPTION
## Summary

The `_usingDict()` decompression functions accept `int dictSize` but cast it to `size_t` without validating it is non-negative. A negative `dictSize` wraps to a large `size_t` value, which causes the offset bounds check in `LZ4_decompress_generic()` to be completely bypassed (the comparison `dictSize < 64KB` evaluates to false for the wrapped value). This allows crafted compressed data to specify match offsets that read from arbitrary heap memory.

## Affected functions

- `LZ4_decompress_safe_usingDict` (line 2715)
- `LZ4_decompress_safe_partial_usingDict` (line 2730)
- `LZ4_decompress_fast_usingDict` (line 2745)
- `LZ4_setStreamDecode` (line 2585)

## Fix

Added `if (dictSize < 0) return -1;` (or `return 0` for `LZ4_setStreamDecode`) before any `(size_t)dictSize` cast. The existing `assert(dictSize >= 0)` only fires in debug builds.

## Not affected

`LZ4F_decompress()` (frame API) already clamps `dictSize` before passing to the block API.

## Testing

All existing tests pass (`make check` + `make -C tests test-lz4`).