### PR TITLE
heap buffer overflow in suffix-based filename construction

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -951,6 +951,7 @@ int LZ4IO_compressMultipleFilenames_Legacy(
     for (i=0; i<ifntSize; i++) {
         unsigned long long processed = 0;
         size_t const ifnSize = strlen(inFileNamesTable[i]);
+        size_t neededSize;
         if (LZ4IO_isStdout(suffix)) {
             missed_files += LZ4IO_compressLegacy_internal(&processed,
                                     inFileNamesTable[i], stdoutmark,
@@ -959,9 +960,15 @@ int LZ4IO_compressMultipleFilenames_Legacy(
             continue;
         }
 
-        if (ofnSize <= ifnSize+suffixSize+1) {
+        if (ifnSize > ((size_t)-1) - suffixSize - 1) {
+            missed_files++;
+            continue;
+        }
+        neededSize = ifnSize + suffixSize + 1;
+
+        if (ofnSize < neededSize) {
             free(dstFileName);
-            ofnSize = ifnSize + 20;
+            ofnSize = neededSize;
             dstFileName = (char*)malloc(ofnSize);
             if (dstFileName==NULL) {
                 return ifntSize;
@@ -1551,6 +1558,7 @@ int LZ4IO_compressMultipleFilenames(
     for (i=0; i<ifntSize; i++) {
         unsigned long long processed;
         size_t const ifnSize = strlen(inFileNamesTable[i]);
+        size_t neededSize;
         if (LZ4IO_isStdout(suffix)) {
             missed_files += LZ4IO_compressFilename_extRess(&processed, &ress,
                                     inFileNamesTable[i], stdoutmark,
@@ -1558,10 +1566,17 @@ int LZ4IO_compressMultipleFilenames(
             totalProcessed += processed;
             continue;
         }
+
+        if (ifnSize > ((size_t)-1) - suffixSize - 1) {
+            missed_files++;
+            continue;
+        }
+        neededSize = ifnSize + suffixSize + 1;
+
         /* suffix != stdout => compress into a file => generate its name */
-        if (ofnSize <= ifnSize+suffixSize+1) {
+        if (ofnSize < neededSize) {
             free(dstFileName);
-            ofnSize = ifnSize + 20;
+            ofnSize = neededSize;
             dstFileName = (char*)malloc(ofnSize);
             if (dstFileName==NULL) {
                 LZ4IO_freeCResources(ress);


### PR DESCRIPTION
## Summary

Fix a heap buffer overflow in `lz4io` multi-file compression when constructing destination filenames with a suffix.

---

## Problem

The destination buffer is resized using a fixed heuristic:

ofnSize = ifnSize + 20;

But the actual required size is:

required = ifnSize + suffixSize + 1;

Since suffix is provided by the caller and not length-restricted, large values can exceed the allocated buffer, leading to overflow during:

strcpy(dstFileName, input);
strcat(dstFileName, suffix);

---

## Reproduction

Calling LZ4IO_compressMultipleFilenames() with a long suffix (e.g. 5000 bytes) causes a crash before this change.

---

## Fix

Compute exact required size:

neededSize = ifnSize + suffixSize + 1;

Add overflow guard for size calculation
Allocate buffer based on neededSize

---

## Behaviour

No change for normal inputs.
Previously crashing inputs are now handled safely using existing missed_files logic.