### PR TITLE
reject truncated frames in --list by validating full reads

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -2608,8 +2608,7 @@ LZ4IO_skipBlocksData(FILE* finput,
     unsigned char blockInfo[LZ4F_BLOCK_HEADER_SIZE];
     unsigned long long totalBlocksSize = 0;
     for (;;) {
-        if (!fread(blockInfo, 1, LZ4F_BLOCK_HEADER_SIZE, finput)) {
-            if (feof(finput)) return totalBlocksSize;
+        if (fread(blockInfo, 1, LZ4F_BLOCK_HEADER_SIZE, finput) != LZ4F_BLOCK_HEADER_SIZE) {
             return 0;
         }
         totalBlocksSize += LZ4F_BLOCK_HEADER_SIZE;
@@ -2619,7 +2618,7 @@ LZ4IO_skipBlocksData(FILE* finput,
                 /* Reached EndMark */
                 if (contentChecksumFlag) {
                     /* Skip content checksum */
-                    if (UTIL_fseek(finput, LZ4F_CONTENT_CHECKSUM_SIZE, SEEK_CUR) != 0) {
+                    if (fread(blockInfo, 1, LZ4F_CONTENT_CHECKSUM_SIZE, finput) != LZ4F_CONTENT_CHECKSUM_SIZE) {
                         return 0;
                     }
                     totalBlocksSize += LZ4F_CONTENT_CHECKSUM_SIZE;


### PR DESCRIPTION
### Summary

Fixes an inconsistency where --list could incorrectly accept truncated or corrupted LZ4 frames as valid.

### Problem

\--list does not strictly validate input length:

*   Block headers may be accepted on partial reads
    
*   Frame content checksum is skipped using fseek(), which does not verify data presence
    

This allows truncated inputs to be reported as valid, while -t correctly rejects them.

### Fix

*   Require exact-length reads for:
    
    *   Block headers
        
    *   Frame content checksum
        
*   Replace fseek() with fread() to ensure bytes are actually present
    

### Result

*   \--list now rejects truncated/corrupted frames
    
*   Behavior is consistent with -t
    
*   No change for valid inputs
    

### Scope

*   Localized to LZ4IO\_skipBlocksData()
    
*   No API changes
    
*   No impact on valid workflows
    

### Validation

*   Verified with truncated inputs (default and --no-frame-crc)
    
*   Verified valid inputs remain unaffected