### PR TITLE
Enable LZ4_FAST_DEC_LOOP for RISC-V

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -481,6 +481,8 @@ static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
 #    define LZ4_FAST_DEC_LOOP 1
 #  elif defined(__aarch64__)
 #    define LZ4_FAST_DEC_LOOP 1
+#  elif defined(__riscv) && (__riscv_xlen == 64)
+#    define LZ4_FAST_DEC_LOOP 1
 #  else
 #    define LZ4_FAST_DEC_LOOP 0
 #  endif


### PR DESCRIPTION
### Description
This PR enables `LZ4_FAST_DEC_LOOP` for the **64-bit RISC-V architecture** (`__riscv` with `__riscv_xlen == 64`).

Modern RISC-V cores are increasingly capable of handling unaligned memory accesses and 32-byte copies efficiently. Enabling the fast decode loop provides a modest but consistent performance improvement for decompression on these platforms.

### Test Environment
* **Hardware:** SpacemiT K1-X RISC-V Board
* **OS:** 64-bit Linux (Debian)
* **Compiler:** GCC 13.2.0
* **Benchmark Tool:** `lzbench 2.1` (`-t0,0 -i5,5 -elz4`)
* **Dataset:** `silesia.tar`

### Benchmark Results

| | Avg. Compress | Avg. Decompress |
|:---|:---|:---|
| **Before** | 80.1 MB/s | 633 MB/s |
| **After** | 80.5 MB/s | 639.5 MB/s |
| **Delta** | +0.5% | **+1.0%** |

### Conclusion
Decompression speed improves by approximately **+1.0%** (~+6.5 MB/s) on RV64, with no measurable regression in compression speed or output ratio.