### PR TITLE
avoid hang by using predicate-based wait in TPool_jobsCompleted

### DIFF
--- a/programs/threadpool.c
+++ b/programs/threadpool.c
@@ -204,7 +204,9 @@ void TPool_submitJob(TPool* pool, void (*job_function)(void*), void* arg)
 void TPool_jobsCompleted(TPool* pool)
 {
     assert(pool);
-    WaitForSingleObject(pool->allJobsCompleted, INFINITE);
+    while (InterlockedCompareExchange(&pool->nbPendingJobs, 0, 0) > 0) {
+        WaitForSingleObject(pool->allJobsCompleted, INFINITE);
+    }
 }
 
 #else


### PR DESCRIPTION
### Summary

Fix a hang in `TPool_jobsCompleted()` on Windows when no jobs are pending or when the function is called multiple times.

---

### Problem

`TPool_jobsCompleted()` waits unconditionally on an auto-reset event:

WaitForSingleObject(pool->allJobsCompleted, INFINITE);

This can block indefinitely when:

no jobs were submitted
the event signal was already consumed (e.g., repeated calls)

---

### Fix

Use predicate-based waiting by checking nbPendingJobs before blocking:

while (InterlockedCompareExchange(&pool->nbPendingJobs, 0, 0) > 0) {
    WaitForSingleObject(pool->allJobsCompleted, INFINITE);
}

---

### Impact

Prevents hang in empty pool and repeated-call scenarios
No behavior change for valid usage
Windows-only change