### PR TITLE
Harden legacy LZ4 fast decompression against malformed input

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2029,7 +2029,10 @@ int LZ4_saveDict(LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 
 #  undef MIN
+#ifndef MIN
 #  define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
 
 /* variant for decompress_unsafe()
  * does not know end of input

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -57,7 +57,6 @@
  */
 #define LZ4_ACCELERATION_MAX 65537
 
-
 /*-************************************
 *  CPU Feature Detection
 **************************************/
@@ -75,10 +74,9 @@
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally */
-#  if defined(__GNUC__) && \
-  ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) \
-  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) \
-  || (defined(__riscv) && defined(__riscv_zicclsm)) )
+#  if defined(__GNUC__) && (defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || \
+                            defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) ||                           \
+                            defined(__ARM_ARCH_6T2__) || (defined(__riscv) && defined(__riscv_zicclsm)))
 #    define LZ4_FORCE_MEMORY_ACCESS 2
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || defined(__GNUC__) || defined(_MSC_VER)
 #    define LZ4_FORCE_MEMORY_ACCESS 1
@@ -89,12 +87,10 @@
  * LZ4_FORCE_SW_BITCOUNT
  * Define this parameter if your target system or compiler does not support hardware bit count
  */
-#if defined(_MSC_VER) && defined(_WIN32_WCE)   /* Visual Studio for WinCE doesn't support Hardware bit count */
-#  undef  LZ4_FORCE_SW_BITCOUNT  /* avoid double def */
+#if defined(_MSC_VER) && defined(_WIN32_WCE) /* Visual Studio for WinCE doesn't support Hardware bit count */
+#  undef LZ4_FORCE_SW_BITCOUNT /* avoid double def */
 #  define LZ4_FORCE_SW_BITCOUNT
 #endif
-
-
 
 /*-************************************
 *  Dependency
@@ -117,25 +113,28 @@
 #include "lz4.h"
 /* see also "memory routines" below */
 
-
 /*-************************************
 *  Compiler Options
 **************************************/
-#if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Visual Studio 2005+ */
-#  include <intrin.h>               /* only present in VS2005+ */
-#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
-#  pragma warning(disable : 6237)   /* disable: C6237: conditional expression is always 0 */
-#  pragma warning(disable : 6239)   /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
-#  pragma warning(disable : 6240)   /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
-#  pragma warning(disable : 6326)   /* disable: C6326: Potential comparison of a constant with another constant */
-#endif  /* _MSC_VER */
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) /* Visual Studio 2005+ */
+#  include <intrin.h> /* only present in VS2005+ */
+#  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
+#  pragma warning(disable : 6237) /* disable: C6237: conditional expression is always 0 */
+#  pragma warning( \
+      disable      \
+      : 6239) /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
+#  pragma warning( \
+      disable      \
+      : 6240) /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6326) /* disable: C6326: Potential comparison of a constant with another constant */
+#endif /* _MSC_VER */
 
 #ifndef LZ4_FORCE_INLINE
-#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
+#  if defined(_MSC_VER) && !defined(__clang__) /* MSVC */
 #    define LZ4_FORCE_INLINE static __forceinline
 #  else
-#    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#      if defined (__GNUC__) || defined (__clang__)
+#    if defined(__cplusplus) || defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* C99 */
+#      if defined(__GNUC__) || defined(__clang__)
 #        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
 #      else
 #        define LZ4_FORCE_INLINE static inline
@@ -143,7 +142,7 @@
 #    else
 #      define LZ4_FORCE_INLINE static
 #    endif /* __STDC_VERSION__ */
-#  endif  /* _MSC_VER */
+#  endif /* _MSC_VER */
 #endif /* LZ4_FORCE_INLINE */
 
 /* LZ4_FORCE_O2 and LZ4_FORCE_INLINE
@@ -161,32 +160,32 @@
  * of LZ4_wildCopy8 does not affect the compression speed.
  */
 #if defined(__PPC64__) && defined(__LITTLE_ENDIAN__) && defined(__GNUC__) && !defined(__clang__)
-#  define LZ4_FORCE_O2  __attribute__((optimize("O2")))
+#  define LZ4_FORCE_O2 __attribute__((optimize("O2")))
 #  undef LZ4_FORCE_INLINE
-#  define LZ4_FORCE_INLINE  static __inline __attribute__((optimize("O2"),always_inline))
+#  define LZ4_FORCE_INLINE static __inline __attribute__((optimize("O2"), always_inline))
 #else
 #  define LZ4_FORCE_O2
 #endif
 
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)
-#  define expect(expr,value)    (__builtin_expect ((expr),(value)) )
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || \
+    defined(__clang__)
+#  define expect(expr, value) (__builtin_expect((expr), (value)))
 #else
-#  define expect(expr,value)    (expr)
+#  define expect(expr, value) (expr)
 #endif
 
 #ifndef likely
-#define likely(expr)     expect((expr) != 0, 1)
+#  define likely(expr) expect((expr) != 0, 1)
 #endif
 #ifndef unlikely
-#define unlikely(expr)   expect((expr) != 0, 0)
+#  define unlikely(expr) expect((expr) != 0, 0)
 #endif
 
 /* Should the alignment test prove unreliable, for some reason,
  * it can be disabled by setting LZ4_ALIGN_TEST to 0 */
-#ifndef LZ4_ALIGN_TEST  /* can be externally provided */
-# define LZ4_ALIGN_TEST 1
+#ifndef LZ4_ALIGN_TEST /* can be externally provided */
+#  define LZ4_ALIGN_TEST 1
 #endif
-
 
 /*-************************************
 *  Memory routines
@@ -218,24 +217,23 @@
 void* LZ4_malloc(size_t s);
 void* LZ4_calloc(size_t n, size_t s);
 void  LZ4_free(void* p);
-# define ALLOC(s)          LZ4_malloc(s)
-# define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
-# define FREEMEM(p)        LZ4_free(p)
+#  define ALLOC(s)          LZ4_malloc(s)
+#  define ALLOC_AND_ZERO(s) LZ4_calloc(1, s)
+#  define FREEMEM(p)        LZ4_free(p)
 #else
-# include <stdlib.h>   /* malloc, calloc, free */
-# define ALLOC(s)          malloc(s)
-# define ALLOC_AND_ZERO(s) calloc(1,s)
-# define FREEMEM(p)        free(p)
+#  include <stdlib.h> /* malloc, calloc, free */
+#  define ALLOC(s)          malloc(s)
+#  define ALLOC_AND_ZERO(s) calloc(1, s)
+#  define FREEMEM(p)        free(p)
 #endif
 
-#if ! LZ4_FREESTANDING
-#  include <string.h>   /* memset, memcpy */
+#if !LZ4_FREESTANDING
+#  include <string.h> /* memset, memcpy */
 #endif
 #if !defined(LZ4_memset)
-#  define LZ4_memset(p,v,s) memset((p),(v),(s))
+#  define LZ4_memset(p, v, s) memset((p), (v), (s))
 #endif
-#define MEM_INIT(p,v,s)   LZ4_memset((p),(v),(s))
-
+#define MEM_INIT(p, v, s) LZ4_memset((p), (v), (s))
 
 /*-************************************
 *  Common Constants
@@ -243,31 +241,32 @@ void  LZ4_free(void* p);
 #define MINMATCH 4
 
 #define WILDCOPYLENGTH 8
-#define LASTLITERALS   5   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
-#define MFLIMIT       12   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
-#define MATCH_SAFEGUARD_DISTANCE  ((2*WILDCOPYLENGTH) - MINMATCH)   /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
+#define LASTLITERALS   5 /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MFLIMIT        12 /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MATCH_SAFEGUARD_DISTANCE \
+    ((2 * WILDCOPYLENGTH) -      \
+     MINMATCH) /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
 #define FASTLOOP_SAFE_DISTANCE 64
-static const int LZ4_minLength = (MFLIMIT+1);
+static const int LZ4_minLength = (MFLIMIT + 1);
 
-#define KB *(1 <<10)
-#define MB *(1 <<20)
-#define GB *(1U<<30)
+#define KB *(1 << 10)
+#define MB *(1 << 20)
+#define GB *(1U << 30)
 
 #define LZ4_DISTANCE_ABSOLUTE_MAX 65535
-#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX)   /* max supported by LZ4 format */
+#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX) /* max supported by LZ4 format */
 #  error "LZ4_DISTANCE_MAX is too big : must be <= 65535"
 #endif
 
 #define ML_BITS  4
-#define ML_MASK  ((1U<<ML_BITS)-1)
-#define RUN_BITS (8-ML_BITS)
-#define RUN_MASK ((1U<<RUN_BITS)-1)
-
+#define ML_MASK  ((1U << ML_BITS) - 1)
+#define RUN_BITS (8 - ML_BITS)
+#define RUN_MASK ((1U << RUN_BITS) - 1)
 
 /*-************************************
 *  Error detection
 **************************************/
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 1)
 #  include <assert.h>
 #else
 #  ifndef assert
@@ -275,63 +274,64 @@ static const int LZ4_minLength = (MFLIMIT+1);
 #  endif
 #endif
 
-#define LZ4_STATIC_ASSERT(c)   { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use after variable declarations */
+#define LZ4_STATIC_ASSERT(c)                           \
+    {                                                  \
+        enum { LZ4_static_assert = 1 / (int)(!!(c)) }; \
+    } /* use after variable declarations */
 
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
 #  include <stdio.h>
-   static int g_debuglog_enable = 1;
-#  define DEBUGLOG(l, ...) {                          \
-        if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
-            fprintf(stderr, __FILE__  " %i: ", __LINE__); \
-            fprintf(stderr, __VA_ARGS__);             \
-            fprintf(stderr, " \n");                   \
-    }   }
+static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...)                                 \
+      {                                                    \
+          if ((g_debuglog_enable) && (l <= LZ4_DEBUG)) {   \
+              fprintf(stderr, __FILE__ " %i: ", __LINE__); \
+              fprintf(stderr, __VA_ARGS__);                \
+              fprintf(stderr, " \n");                      \
+          }                                                \
+      }
 #else
-#  define DEBUGLOG(l, ...) {}    /* disabled */
+#  define DEBUGLOG(l, ...) \
+      {                    \
+      } /* disabled */
 #endif
 
 static int LZ4_isAligned(const void* ptr, size_t alignment)
 {
-    return ((size_t)ptr & (alignment -1)) == 0;
+    return ((size_t)ptr & (alignment - 1)) == 0;
 }
-
 
 /*-************************************
 *  Types
 **************************************/
 #include <limits.h>
-#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-# include <stdint.h>
-  typedef unsigned char BYTE; /*uint8_t not necessarily blessed to alias arbitrary type*/
-  typedef uint16_t      U16;
-  typedef uint32_t      U32;
-  typedef  int32_t      S32;
-  typedef uint64_t      U64;
-  typedef uintptr_t     uptrval;
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#  include <stdint.h>
+typedef unsigned char BYTE; /*uint8_t not necessarily blessed to alias arbitrary type*/
+typedef uint16_t      U16;
+typedef uint32_t      U32;
+typedef int32_t       S32;
+typedef uint64_t      U64;
+typedef uintptr_t     uptrval;
 #else
-# if UINT_MAX != 4294967295UL
-#   error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
-# endif
-  typedef unsigned char       BYTE;
-  typedef unsigned short      U16;
-  typedef unsigned int        U32;
-  typedef   signed int        S32;
-  typedef unsigned long long  U64;
-  typedef size_t              uptrval;   /* generally true, except OpenVMS-64 */
+#  if UINT_MAX != 4294967295UL
+#    error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
+#  endif
+typedef unsigned char      BYTE;
+typedef unsigned short     U16;
+typedef unsigned int       U32;
+typedef signed int         S32;
+typedef unsigned long long U64;
+typedef size_t             uptrval;   /* generally true, except OpenVMS-64 */
 #endif
 
 #if defined(__x86_64__)
-  typedef U64    reg_t;   /* 64-bits in x32 mode */
+typedef U64 reg_t; /* 64-bits in x32 mode */
 #else
-  typedef size_t reg_t;   /* 32-bits in x32 mode */
+typedef size_t reg_t;   /* 32-bits in x32 mode */
 #endif
 
-typedef enum {
-    notLimited = 0,
-    limitedOutput = 1,
-    fillOutput = 2
-} limitedOutput_directive;
-
+typedef enum { notLimited = 0, limitedOutput = 1, fillOutput = 2 } limitedOutput_directive;
 
 /*-************************************
 *  Reading and writing into memory
@@ -363,27 +363,49 @@ typedef enum {
 
 static unsigned LZ4_isLittleEndian(void)
 {
-    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental */
+    const union {
+        U32  u;
+        BYTE c[4];
+    } one = {1}; /* don't use static : performance detrimental */
+
     return one.c[0];
 }
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
-#define LZ4_PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#  define LZ4_PACK(__Declaration__) __Declaration__ __attribute__((__packed__))
 #elif defined(_MSC_VER)
-#define LZ4_PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
+#  define LZ4_PACK(__Declaration__) __pragma(pack(push, 1)) __Declaration__ __pragma(pack(pop))
 #endif
 
-#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 2)
 /* lie to the compiler about data alignment; use with caution */
 
-static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
-static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
-static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+static U16 LZ4_read16(const void* memPtr)
+{
+    return *(const U16*)memPtr;
+}
 
-static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
-static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+static U32 LZ4_read32(const void* memPtr)
+{
+    return *(const U32*)memPtr;
+}
 
-#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+static reg_t LZ4_read_ARCH(const void* memPtr)
+{
+    return *(const reg_t*)memPtr;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    *(U16*)memPtr = value;
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    *(U32*)memPtr = value;
+}
+
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 1)
 
 /* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
 /* currently only defined for gcc and icc */
@@ -391,28 +413,52 @@ LZ4_PACK(typedef struct { U16 u16; }) LZ4_unalign16;
 LZ4_PACK(typedef struct { U32 u32; }) LZ4_unalign32;
 LZ4_PACK(typedef struct { reg_t uArch; }) LZ4_unalignST;
 
-static U16 LZ4_read16(const void* ptr) { return ((const LZ4_unalign16*)ptr)->u16; }
-static U32 LZ4_read32(const void* ptr) { return ((const LZ4_unalign32*)ptr)->u32; }
-static reg_t LZ4_read_ARCH(const void* ptr) { return ((const LZ4_unalignST*)ptr)->uArch; }
+static U16 LZ4_read16(const void* ptr)
+{
+    return ((const LZ4_unalign16*)ptr)->u16;
+}
 
-static void LZ4_write16(void* memPtr, U16 value) { ((LZ4_unalign16*)memPtr)->u16 = value; }
-static void LZ4_write32(void* memPtr, U32 value) { ((LZ4_unalign32*)memPtr)->u32 = value; }
+static U32 LZ4_read32(const void* ptr)
+{
+    return ((const LZ4_unalign32*)ptr)->u32;
+}
 
-#else  /* safe and portable access using memcpy() */
+static reg_t LZ4_read_ARCH(const void* ptr)
+{
+    return ((const LZ4_unalignST*)ptr)->uArch;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    ((LZ4_unalign16*)memPtr)->u16 = value;
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    ((LZ4_unalign32*)memPtr)->u32 = value;
+}
+
+#else /* safe and portable access using memcpy() */
 
 static U16 LZ4_read16(const void* memPtr)
 {
-    U16 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    U16 val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static U32 LZ4_read32(const void* memPtr)
 {
-    U32 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    U32 val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static reg_t LZ4_read_ARCH(const void* memPtr)
 {
-    reg_t val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    reg_t val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static void LZ4_write16(void* memPtr, U16 value)
@@ -427,14 +473,13 @@ static void LZ4_write32(void* memPtr, U32 value)
 
 #endif /* LZ4_FORCE_MEMORY_ACCESS */
 
-
 static U16 LZ4_readLE16(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
         return LZ4_read16(memPtr);
     } else {
         const BYTE* p = (const BYTE*)memPtr;
-        return (U16)((U16)p[0] | (p[1]<<8));
+        return (U16)((U16)p[0] | (p[1] << 8));
     }
 }
 
@@ -445,7 +490,7 @@ static U32 LZ4_readLE32(const void* memPtr)
         return LZ4_read32(memPtr);
     } else {
         const BYTE* p = (const BYTE*)memPtr;
-        return (U32)p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24);
+        return (U32)p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
     }
 }
 #endif
@@ -456,8 +501,8 @@ static void LZ4_writeLE16(void* memPtr, U16 value)
         LZ4_write16(memPtr, value);
     } else {
         BYTE* p = (BYTE*)memPtr;
-        p[0] = (BYTE) value;
-        p[1] = (BYTE)(value>>8);
+        p[0]    = (BYTE)value;
+        p[1]    = (BYTE)(value >> 8);
     }
 }
 
@@ -465,16 +510,19 @@ static void LZ4_writeLE16(void* memPtr, U16 value)
 LZ4_FORCE_INLINE
 void LZ4_wildCopy8(void* dstPtr, const void* srcPtr, void* dstEnd)
 {
-    BYTE* d = (BYTE*)dstPtr;
+    BYTE*       d = (BYTE*)dstPtr;
     const BYTE* s = (const BYTE*)srcPtr;
     BYTE* const e = (BYTE*)dstEnd;
 
-    do { LZ4_memcpy(d,s,8); d+=8; s+=8; } while (d<e);
+    do {
+        LZ4_memcpy(d, s, 8);
+        d += 8;
+        s += 8;
+    } while (d < e);
 }
 
-static const unsigned inc32table[8] = {0, 1, 2,  1,  0,  4, 4, 4};
-static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
-
+static const unsigned inc32table[8] = {0, 1, 2, 1, 0, 4, 4, 4};
+static const int      dec64table[8] = {0, 0, 0, -1, -4, 1, 2, 3};
 
 #ifndef LZ4_FAST_DEC_LOOP
 #  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
@@ -493,13 +541,13 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
 {
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
-        LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
+        LZ4_write32(dstPtr, 0); /* silence an msan warning when offset==0 */
         dstPtr[0] = srcPtr[0];
         dstPtr[1] = srcPtr[1];
         dstPtr[2] = srcPtr[2];
         dstPtr[3] = srcPtr[3];
         srcPtr += inc32table[offset];
-        LZ4_memcpy(dstPtr+4, srcPtr, 4);
+        LZ4_memcpy(dstPtr + 4, srcPtr, 4);
         srcPtr -= dec64table[offset];
         dstPtr += 8;
     } else {
@@ -514,41 +562,44 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
 /* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
  * this version copies two times 16 bytes (instead of one time 32 bytes)
  * because it must be compatible with offsets >= 16. */
-LZ4_FORCE_INLINE void
-LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
+LZ4_FORCE_INLINE void LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
 {
-    BYTE* d = (BYTE*)dstPtr;
+    BYTE*       d = (BYTE*)dstPtr;
     const BYTE* s = (const BYTE*)srcPtr;
     BYTE* const e = (BYTE*)dstEnd;
 
-    do { LZ4_memcpy(d,s,16); LZ4_memcpy(d+16,s+16,16); d+=32; s+=32; } while (d<e);
+    do {
+        LZ4_memcpy(d, s, 16);
+        LZ4_memcpy(d + 16, s + 16, 16);
+        d += 32;
+        s += 32;
+    } while (d < e);
 }
 
 /* LZ4_memcpy_using_offset()  presumes :
  * - dstEnd >= dstPtr + MINMATCH
  * - there is at least 12 bytes available to write after dstEnd */
-LZ4_FORCE_INLINE void
-LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+LZ4_FORCE_INLINE void LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
 {
     BYTE v[8];
 
     assert(dstEnd >= dstPtr + MINMATCH);
 
-    switch(offset) {
+    switch (offset) {
     case 1:
         MEM_INIT(v, *srcPtr, 8);
         break;
     case 2:
         LZ4_memcpy(v, srcPtr, 2);
         LZ4_memcpy(&v[2], srcPtr, 2);
-#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
-#  pragma warning(push)
-#  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
-#endif
+#  if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#    pragma warning(push)
+#    pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
+#  endif
         LZ4_memcpy(&v[4], v, 4);
-#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
-#  pragma warning(pop)
-#endif
+#  if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#    pragma warning(pop)
+#  endif
         break;
     case 4:
         LZ4_memcpy(v, srcPtr, 4);
@@ -568,144 +619,160 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
 }
 #endif
 
-
 /*-************************************
 *  Common functions
 **************************************/
-static unsigned LZ4_NbCommonBytes (reg_t val)
+static unsigned LZ4_NbCommonBytes(reg_t val)
 {
     assert(val != 0);
     if (LZ4_isLittleEndian()) {
         if (sizeof(val) == 8) {
-#       if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
 /*-*************************************************************************************************
 * ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
 * The ARM64EC ABI does not support AVX/AVX2/AVX512 instructions, nor their relevant intrinsics
 * including _tzcnt_u64. Therefore, we need to neuter the _tzcnt_u64 code path for ARM64EC.
 ****************************************************************************************************/
-#         if defined(__clang__) && (__clang_major__ < 10)
+#  if defined(__clang__) && (__clang_major__ < 10)
             /* Avoid undefined clang-cl intrinsics issue.
              * See https://github.com/lz4/lz4/pull/1017 for details. */
             return (unsigned)__builtin_ia32_tzcnt_u64(val) >> 3;
-#         else
+#  else
             /* x64 CPUS without BMI support interpret `TZCNT` as `REP BSF` */
             return (unsigned)_tzcnt_u64(val) >> 3;
-#         endif
-#       elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#  endif
+#elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
             unsigned long r = 0;
             _BitScanForward64(&r, (U64)val);
             return (unsigned)r >> 3;
-#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_ctzll((U64)val) >> 3;
-#       else
+#else
             const U64 m = 0x0101010101010101ULL;
             val ^= val - 1;
             return (unsigned)(((U64)((val & (m - 1)) * m)) >> 56);
-#       endif
+#endif
         } else /* 32 bits */ {
-#       if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
             unsigned long r;
             _BitScanForward(&r, (U32)val);
             return (unsigned)r >> 3;
-#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_ctz((U32)val) >> 3;
-#       else
+#else
             const U32 m = 0x01010101;
             return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
-#       endif
+#endif
         }
-    } else   /* Big Endian CPU */ {
-        if (sizeof(val)==8) {
-#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+    } else /* Big Endian CPU */ {
+        if (sizeof(val) == 8) {
+#if (defined(__clang__) ||                                                                     \
+     (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_clzll((U64)val) >> 3;
-#       else
-#if 1
+#else
+#  if 1
             /* this method is probably faster,
              * but adds a 128 bytes lookup table */
             static const unsigned char ctz7_tab[128] = {
-                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
+                1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0,
+                2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0,
+                1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0,
+                3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
             };
             U64 const mask = 0x0101010101010101ULL;
-            U64 const t = (((val >> 8) - mask) | val) & mask;
+            U64 const t    = (((val >> 8) - mask) | val) & mask;
             return ctz7_tab[(t * 0x0080402010080402ULL) >> 57];
-#else
+#  else
             /* this method doesn't consume memory space like the previous one,
              * but it contains several branches,
              * that may end up slowing execution */
-            static const U32 by32 = sizeof(val)*4;  /* 32 on 64 bits (goal), 16 on 32 bits.
+            static const U32 by32 = sizeof(val) * 4;  /* 32 on 64 bits (goal), 16 on 32 bits.
             Just to avoid some static analyzer complaining about shift by 32 on 32-bits target.
             Note that this code path is never triggered in 32-bits mode. */
-            unsigned r;
-            if (!(val>>by32)) { r=4; } else { r=0; val>>=by32; }
-            if (!(val>>16)) { r+=2; val>>=8; } else { val>>=24; }
+            unsigned         r;
+            if (!(val >> by32)) {
+                r = 4;
+            } else {
+                r = 0;
+                val >>= by32;
+            }
+            if (!(val >> 16)) {
+                r += 2;
+                val >>= 8;
+            } else {
+                val >>= 24;
+            }
             r += (!val);
             return r;
+#  endif
 #endif
-#       endif
         } else /* 32 bits */ {
-#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#if (defined(__clang__) ||                                                                     \
+     (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_clz((U32)val) >> 3;
-#       else
+#else
             val >>= 8;
-            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
-              (val + 0x00FF0000)) >> 24;
+            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) | (val + 0x00FF0000)) >> 24;
             return (unsigned)val ^ 3;
-#       endif
+#endif
         }
     }
 }
 
-
 #define STEPSIZE sizeof(reg_t)
+
 LZ4_FORCE_INLINE
 unsigned LZ4_count(const BYTE* pIn, const BYTE* pMatch, const BYTE* pInLimit)
 {
     const BYTE* const pStart = pIn;
 
-    if (likely(pIn < pInLimit-(STEPSIZE-1))) {
-        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+    if (likely(pIn < pInLimit - (STEPSIZE - 1))) {
+        const reg_t diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
         if (!diff) {
-            pIn+=STEPSIZE; pMatch+=STEPSIZE;
+            pIn += STEPSIZE;
+            pMatch += STEPSIZE;
         } else {
             return LZ4_NbCommonBytes(diff);
-    }   }
+        }
+    }
 
-    while (likely(pIn < pInLimit-(STEPSIZE-1))) {
-        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
-        if (!diff) { pIn+=STEPSIZE; pMatch+=STEPSIZE; continue; }
+    while (likely(pIn < pInLimit - (STEPSIZE - 1))) {
+        const reg_t diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) {
+            pIn += STEPSIZE;
+            pMatch += STEPSIZE;
+            continue;
+        }
         pIn += LZ4_NbCommonBytes(diff);
         return (unsigned)(pIn - pStart);
     }
 
-    if ((STEPSIZE==8) && (pIn<(pInLimit-3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) { pIn+=4; pMatch+=4; }
-    if ((pIn<(pInLimit-1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) { pIn+=2; pMatch+=2; }
-    if ((pIn<pInLimit) && (*pMatch == *pIn)) pIn++;
+    if ((STEPSIZE == 8) && (pIn < (pInLimit - 3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) {
+        pIn += 4;
+        pMatch += 4;
+    }
+    if ((pIn < (pInLimit - 1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) {
+        pIn += 2;
+        pMatch += 2;
+    }
+    if ((pIn < pInLimit) && (*pMatch == *pIn)) pIn++;
     return (unsigned)(pIn - pStart);
 }
-
 
 #ifndef LZ4_COMMONDEFS_ONLY
 /*-************************************
 *  Local Constants
 **************************************/
-static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT-1));
-static const U32 LZ4_skipTrigger = 6;  /* Increase this value ==> compression run slower on incompressible data */
-
+static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT - 1));
+static const U32 LZ4_skipTrigger = 6; /* Increase this value ==> compression run slower on incompressible data */
 
 /*-************************************
 *  Local Structures and types
@@ -736,51 +803,70 @@ typedef enum { clearedTable = 0, byPtr, byU32, byU16 } tableType_t;
  *                   ->dictCtx->hashTable.
  */
 typedef enum { noDict = 0, withPrefix64k, usingExtDict, usingDictCtx } dict_directive;
-typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
 
+typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
 
 /*-************************************
 *  Local Utils
 **************************************/
-int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
-const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
-int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState(void) { return sizeof(LZ4_stream_t); }
+int LZ4_versionNumber(void)
+{
+    return LZ4_VERSION_NUMBER;
+}
 
+const char* LZ4_versionString(void)
+{
+    return LZ4_VERSION_STRING;
+}
+
+int LZ4_compressBound(int isize)
+{
+    return LZ4_COMPRESSBOUND(isize);
+}
+
+int LZ4_sizeofState(void)
+{
+    return sizeof(LZ4_stream_t);
+}
 
 /*-****************************************
 *  Internal Definitions, used only in Tests
 *******************************************/
-#if defined (__cplusplus)
+#  if defined(__cplusplus)
 extern "C" {
-#endif
+#  endif
 
-int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
+int LZ4_compress_forceExtDict(LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
 
-int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int maxOutputSize,
-                                     const void* dictStart, size_t dictSize);
-int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int targetOutputSize, int dstCapacity,
-                                     const void* dictStart, size_t dictSize);
-#if defined (__cplusplus)
+int LZ4_decompress_safe_forceExtDict(const char* source,
+                                     char*       dest,
+                                     int         compressedSize,
+                                     int         maxOutputSize,
+                                     const void* dictStart,
+                                     size_t      dictSize);
+int LZ4_decompress_safe_partial_forceExtDict(const char* source,
+                                             char*       dest,
+                                             int         compressedSize,
+                                             int         targetOutputSize,
+                                             int         dstCapacity,
+                                             const void* dictStart,
+                                             size_t      dictSize);
+#  if defined(__cplusplus)
 }
-#endif
+#  endif
 
 /*-******************************
 *  Compression functions
 ********************************/
-LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, const tableType_t tableType)
 {
-    if (tableType == byU16)
-        return ((sequence * 2654435761U) >> ((MINMATCH*8)-(LZ4_HASHLOG+1)));
-    else
-        return ((sequence * 2654435761U) >> ((MINMATCH*8)-LZ4_HASHLOG));
+    if (tableType == byU16) return (sequence * 2654435761U) >> ((MINMATCH * 8) - (LZ4_HASHLOG + 1));
+    else return (sequence * 2654435761U) >> ((MINMATCH * 8) - LZ4_HASHLOG);
 }
 
-LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, const tableType_t tableType)
 {
-    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
+    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG + 1 : LZ4_HASHLOG;
     if (LZ4_isLittleEndian()) {
         const U64 prime5bytes = 889523592379ULL;
         return (U32)(((sequence << 24) * prime5bytes) >> (64 - hashLog));
@@ -790,47 +876,72 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
     }
 }
 
-LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, const tableType_t tableType)
 {
-    if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+    if ((sizeof(reg_t) == 8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
 
-#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+#  ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
     return LZ4_hash4(LZ4_readLE32(p), tableType);
-#else
+#  else
     return LZ4_hash4(LZ4_read32(p), tableType);
-#endif
+#  endif
 }
 
-LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, const tableType_t tableType)
 {
-    switch (tableType)
-    {
+    switch (tableType) {
     default: /* fallthrough */
-    case clearedTable: { /* illegal! */ assert(0); return; }
-    case byPtr: { const BYTE** hashTable = (const BYTE**)tableBase; hashTable[h] = NULL; return; }
-    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = 0; return; }
-    case byU16: { U16* hashTable = (U16*) tableBase; hashTable[h] = 0; return; }
+    case clearedTable: { /* illegal! */
+        assert(0);
+        return;
+    }
+    case byPtr: {
+        const BYTE** hashTable = (const BYTE**)tableBase;
+        hashTable[h]           = NULL;
+        return;
+    }
+    case byU32: {
+        U32* hashTable = (U32*)tableBase;
+        hashTable[h]   = 0;
+        return;
+    }
+    case byU16: {
+        U16* hashTable = (U16*)tableBase;
+        hashTable[h]   = 0;
+        return;
+    }
     }
 }
 
-LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, const tableType_t tableType)
 {
-    switch (tableType)
-    {
+    switch (tableType) {
     default: /* fallthrough */
     case clearedTable: /* fallthrough */
-    case byPtr: { /* illegal! */ assert(0); return; }
-    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = idx; return; }
-    case byU16: { U16* hashTable = (U16*) tableBase; assert(idx < 65536); hashTable[h] = (U16)idx; return; }
+    case byPtr: { /* illegal! */
+        assert(0);
+        return;
+    }
+    case byU32: {
+        U32* hashTable = (U32*)tableBase;
+        hashTable[h]   = idx;
+        return;
+    }
+    case byU16: {
+        U16* hashTable = (U16*)tableBase;
+        assert(idx < 65536);
+        hashTable[h] = (U16)idx;
+        return;
+    }
     }
 }
 
 /* LZ4_putPosition*() : only used in byPtr mode */
-LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h,
-                                  void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h, void* tableBase, const tableType_t tableType)
 {
     const BYTE** const hashTable = (const BYTE**)tableBase;
-    assert(tableType == byPtr); (void)tableType;
+    assert(tableType == byPtr);
+    (void)tableType;
     hashTable[h] = p;
 }
 
@@ -850,52 +961,51 @@ LZ4_FORCE_INLINE U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_
 {
     LZ4_STATIC_ASSERT(LZ4_MEMORY_USAGE > 2);
     if (tableType == byU32) {
-        const U32* const hashTable = (const U32*) tableBase;
-        assert(h < (1U << (LZ4_MEMORY_USAGE-2)));
+        const U32* const hashTable = (const U32*)tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE - 2)));
         return hashTable[h];
     }
     if (tableType == byU16) {
-        const U16* const hashTable = (const U16*) tableBase;
-        assert(h < (1U << (LZ4_MEMORY_USAGE-1)));
+        const U16* const hashTable = (const U16*)tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE - 1)));
         return hashTable[h];
     }
-    assert(0); return 0;  /* forbidden case */
+    assert(0);
+    return 0; /* forbidden case */
 }
 
 static const BYTE* LZ4_getPositionOnHash(U32 h, const void* tableBase, tableType_t tableType)
 {
-    assert(tableType == byPtr); (void)tableType;
-    { const BYTE* const* hashTable = (const BYTE* const*) tableBase; return hashTable[h]; }
+    assert(tableType == byPtr);
+    (void)tableType;
+    {
+        const BYTE* const* hashTable = (const BYTE* const*)tableBase;
+        return hashTable[h];
+    }
 }
 
-LZ4_FORCE_INLINE const BYTE*
-LZ4_getPosition(const BYTE* p,
-                const void* tableBase, tableType_t tableType)
+LZ4_FORCE_INLINE const BYTE* LZ4_getPosition(const BYTE* p, const void* tableBase, tableType_t tableType)
 {
     U32 const h = LZ4_hashPosition(p, tableType);
     return LZ4_getPositionOnHash(h, tableBase, tableType);
 }
 
 LZ4_FORCE_INLINE void
-LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
-           const int inputSize,
-           const tableType_t tableType) {
+LZ4_prepareTable(LZ4_stream_t_internal* const cctx, const int inputSize, const tableType_t tableType)
+{
     /* If the table hasn't been used, it's guaranteed to be zeroed out, and is
      * therefore safe to use no matter what mode we're in. Otherwise, we figure
      * out if it's safe to leave as is or whether it needs to be reset.
      */
     if ((tableType_t)cctx->tableType != clearedTable) {
         assert(inputSize >= 0);
-        if ((tableType_t)cctx->tableType != tableType
-          || ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU)
-          || ((tableType == byU32) && cctx->currentOffset > 1 GB)
-          || tableType == byPtr
-          || inputSize >= 4 KB)
-        {
+        if ((tableType_t)cctx->tableType != tableType ||
+            ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU) ||
+            ((tableType == byU32) && cctx->currentOffset > 1 GB) || tableType == byPtr || inputSize >= 4 KB) {
             DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", (void*)cctx);
             MEM_INIT(cctx->hashTable, 0, LZ4_HASHTABLESIZE);
             cctx->currentOffset = 0;
-            cctx->tableType = (U32)clearedTable;
+            cctx->tableType     = (U32)clearedTable;
         } else {
             DEBUGLOG(4, "LZ4_prepareTable: Re-use hash table (no reset)");
         }
@@ -912,9 +1022,9 @@ LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
     }
 
     /* Finally, clear history */
-    cctx->dictCtx = NULL;
+    cctx->dictCtx    = NULL;
     cctx->dictionary = NULL;
-    cctx->dictSize = 0;
+    cctx->dictSize   = 0;
 }
 
 /** LZ4_compress_generic_validated() :
@@ -923,50 +1033,48 @@ LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
  *  - source != NULL
  *  - inputSize > 0
  */
-LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
-                 LZ4_stream_t_internal* const cctx,
-                 const char* const source,
-                 char* const dest,
-                 const int inputSize,
-                 int*  inputConsumed, /* only written when outputDirective == fillOutput */
-                 const int maxOutputSize,
-                 const limitedOutput_directive outputDirective,
-                 const tableType_t tableType,
-                 const dict_directive dictDirective,
-                 const dictIssue_directive dictIssue,
-                 const int acceleration)
+LZ4_FORCE_INLINE int
+LZ4_compress_generic_validated(LZ4_stream_t_internal* const cctx,
+                               const char* const            source,
+                               char* const                  dest,
+                               const int                    inputSize,
+                               int*      inputConsumed, /* only written when outputDirective == fillOutput */
+                               const int maxOutputSize,
+                               const limitedOutput_directive outputDirective,
+                               const tableType_t             tableType,
+                               const dict_directive          dictDirective,
+                               const dictIssue_directive     dictIssue,
+                               const int                     acceleration)
 {
-    int result;
+    int         result;
     const BYTE* ip = (const BYTE*)source;
 
-    U32 const startIndex = cctx->currentOffset;
-    const BYTE* base = (const BYTE*)source - startIndex;
+    U32 const   startIndex = cctx->currentOffset;
+    const BYTE* base       = (const BYTE*)source - startIndex;
     const BYTE* lowLimit;
 
-    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*) cctx->dictCtx;
-    const BYTE* const dictionary =
-        dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
-    const U32 dictSize =
-        dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
-    const U32 dictDelta =
-        (dictDirective == usingDictCtx) ? startIndex - dictCtx->currentOffset : 0;   /* make indexes in dictCtx comparable with indexes in current context */
+    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*)cctx->dictCtx;
+    const BYTE* const dictionary = dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
+    const U32         dictSize   = dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
+    const U32 dictDelta = (dictDirective == usingDictCtx)
+                              ? startIndex - dictCtx->currentOffset
+                              : 0; /* make indexes in dictCtx comparable with indexes in current context */
 
-    int const maybe_extMem = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
-    U32 const prefixIdxLimit = startIndex - dictSize;   /* used when dictDirective == dictSmall */
-    const BYTE* const dictEnd = dictionary ? dictionary + dictSize : dictionary;
-    const BYTE* anchor = (const BYTE*) source;
-    const BYTE* const iend = ip + inputSize;
+    const int         maybe_extMem   = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
+    U32 const         prefixIdxLimit = startIndex - dictSize; /* used when dictDirective == dictSmall */
+    const BYTE* const dictEnd        = dictionary ? dictionary + dictSize : dictionary;
+    const BYTE*       anchor         = (const BYTE*)source;
+    const BYTE* const iend           = ip + inputSize;
     const BYTE* const mflimitPlusOne = iend - MFLIMIT + 1;
-    const BYTE* const matchlimit = iend - LASTLITERALS;
+    const BYTE* const matchlimit     = iend - LASTLITERALS;
 
     /* the dictCtx currentOffset is indexed on the start of the dictionary,
      * while a dictionary in the current context precedes the currentOffset */
-    const BYTE* dictBase = (dictionary == NULL) ? NULL :
-                           (dictDirective == usingDictCtx) ?
-                            dictionary + dictSize - dictCtx->currentOffset :
-                            dictionary + dictSize - startIndex;
+    const BYTE* dictBase = (dictionary == NULL)              ? NULL
+                           : (dictDirective == usingDictCtx) ? dictionary + dictSize - dictCtx->currentOffset
+                                                             : dictionary + dictSize - startIndex;
 
-    BYTE* op = (BYTE*) dest;
+    BYTE*       op     = (BYTE*)dest;
     BYTE* const olimit = op + maxOutputSize;
 
     U32 offset = 0;
@@ -974,11 +1082,13 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
 
     DEBUGLOG(5, "LZ4_compress_generic_validated: srcSize=%i, tableType=%u", inputSize, tableType);
     assert(ip != NULL);
-    if (tableType == byU16) assert(inputSize<LZ4_64Klimit);  /* Size too large (not within 64K limit) */
-    if (tableType == byPtr) assert(dictDirective==noDict);   /* only supported use case with byPtr */
+    if (tableType == byU16) assert(inputSize < LZ4_64Klimit); /* Size too large (not within 64K limit) */
+    if (tableType == byPtr) assert(dictDirective == noDict); /* only supported use case with byPtr */
     /* If init conditions are not met, we don't have to mark stream
      * as having dirty context, since no action was taken yet */
-    if (outputDirective == fillOutput && maxOutputSize < 1) { return 0; } /* Impossible to store anything */
+    if (outputDirective == fillOutput && maxOutputSize < 1) {
+        return 0;
+    } /* Impossible to store anything */
     assert(acceleration >= 1);
 
     lowLimit = (const BYTE*)source - (dictDirective == withPrefix64k ? dictSize : 0);
@@ -987,7 +1097,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
     if (dictDirective == usingDictCtx) {
         /* Subsequent linked blocks can't use the dictionary. */
         /* Instead, they use the block we just compressed. */
-        cctx->dictCtx = NULL;
+        cctx->dictCtx  = NULL;
         cctx->dictSize = (U32)inputSize;
     } else {
         cctx->dictSize += (U32)inputSize;
@@ -995,53 +1105,55 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
     cctx->currentOffset += (U32)inputSize;
     cctx->tableType = (U32)tableType;
 
-    if (inputSize<LZ4_minLength) goto _last_literals;        /* Input too small, no compression (all literals) */
+    if (inputSize < LZ4_minLength) goto _last_literals; /* Input too small, no compression (all literals) */
 
     /* First Byte */
-    {   U32 const h = LZ4_hashPosition(ip, tableType);
+    {
+        U32 const h = LZ4_hashPosition(ip, tableType);
         if (tableType == byPtr) {
             LZ4_putPositionOnHash(ip, h, cctx->hashTable, byPtr);
         } else {
             LZ4_putIndexOnHash(startIndex, h, cctx->hashTable, tableType);
-    }   }
-    ip++; forwardH = LZ4_hashPosition(ip, tableType);
+        }
+    }
+    ip++;
+    forwardH = LZ4_hashPosition(ip, tableType);
 
     /* Main Loop */
-    for ( ; ; ) {
+    for (;;) {
         const BYTE* match;
-        BYTE* token;
+        BYTE*       token;
         const BYTE* filledIp;
 
         /* Find a match */
         if (tableType == byPtr) {
-            const BYTE* forwardIp = ip;
-            int step = 1;
-            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            const BYTE* forwardIp     = ip;
+            int         step          = 1;
+            int         searchMatchNb = acceleration << LZ4_skipTrigger;
             do {
                 U32 const h = forwardH;
-                ip = forwardIp;
+                ip          = forwardIp;
                 forwardIp += step;
                 step = (searchMatchNb++ >> LZ4_skipTrigger);
 
                 if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
                 assert(ip < mflimitPlusOne);
 
-                match = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
+                match    = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType);
 
-            } while ( (match+LZ4_DISTANCE_MAX < ip)
-                   || (LZ4_read32(match) != LZ4_read32(ip)) );
+            } while ((match + LZ4_DISTANCE_MAX < ip) || (LZ4_read32(match) != LZ4_read32(ip)));
 
-        } else {   /* byU32, byU16 */
+        } else { /* byU32, byU16 */
 
-            const BYTE* forwardIp = ip;
-            int step = 1;
-            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            const BYTE* forwardIp     = ip;
+            int         step          = 1;
+            int         searchMatchNb = acceleration << LZ4_skipTrigger;
             do {
-                U32 const h = forwardH;
-                U32 const current = (U32)(forwardIp - base);
-                U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+                U32 const h          = forwardH;
+                U32 const current    = (U32)(forwardIp - base);
+                U32       matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
                 assert(matchIndex <= current);
                 assert(forwardIp - base < (ptrdiff_t)(2 GB - 1));
                 ip = forwardIp;
@@ -1056,79 +1168,89 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                         /* there was no match, try the dictionary */
                         assert(tableType == byU32);
                         matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
-                        match = dictBase + matchIndex;
-                        matchIndex += dictDelta;   /* make dictCtx index comparable with current context */
+                        match      = dictBase + matchIndex;
+                        matchIndex += dictDelta; /* make dictCtx index comparable with current context */
                         lowLimit = dictionary;
                     } else {
-                        match = base + matchIndex;
+                        match    = base + matchIndex;
                         lowLimit = (const BYTE*)source;
                     }
                 } else if (dictDirective == usingExtDict) {
                     if (matchIndex < startIndex) {
-                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex, startIndex);
+                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex,
+                                 startIndex);
                         assert(startIndex - matchIndex >= MINMATCH);
                         assert(dictBase);
-                        match = dictBase + matchIndex;
+                        match    = dictBase + matchIndex;
                         lowLimit = dictionary;
                     } else {
-                        match = base + matchIndex;
+                        match    = base + matchIndex;
                         lowLimit = (const BYTE*)source;
                     }
-                } else {   /* single continuous memory segment */
+                } else { /* single continuous memory segment */
                     match = base + matchIndex;
                 }
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
 
                 DEBUGLOG(7, "candidate at pos=%u  (offset=%u \n", matchIndex, current - matchIndex);
-                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) { continue; }    /* match outside of valid area */
+                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) {
+                    continue;
+                } /* match outside of valid area */
                 assert(matchIndex < current);
-                if ( ((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX))
-                  && (matchIndex+LZ4_DISTANCE_MAX < current)) {
+                if (((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX)) &&
+                    (matchIndex + LZ4_DISTANCE_MAX < current)) {
                     continue;
                 } /* too far */
-                assert((current - matchIndex) <= LZ4_DISTANCE_MAX);  /* match now expected within distance */
+                assert((current - matchIndex) <= LZ4_DISTANCE_MAX); /* match now expected within distance */
 
                 if (LZ4_read32(match) == LZ4_read32(ip)) {
                     if (maybe_extMem) offset = current - matchIndex;
-                    break;   /* match found */
+                    break; /* match found */
                 }
 
-            } while(1);
+            } while (1);
         }
 
         /* Catch up */
         filledIp = ip;
         assert(ip > anchor); /* this is always true as ip has been advanced before entering the main loop */
         if ((match > lowLimit) && unlikely(ip[-1] == match[-1])) {
-            do { ip--; match--; } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
+            do {
+                ip--;
+                match--;
+            } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
         }
 
         /* Encode Literals */
-        {   unsigned const litLength = (unsigned)(ip - anchor);
-            token = op++;
-            if ((outputDirective == limitedOutput) &&  /* Check output buffer overflow */
-                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength/255) > olimit)) ) {
-                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+        {
+            const unsigned litLength = (unsigned)(ip - anchor);
+            token                    = op++;
+            if ((outputDirective == limitedOutput) && /* Check output buffer overflow */
+                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength / 255) > olimit))) {
+                return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
             }
             if ((outputDirective == fillOutput) &&
-                (unlikely(op + (litLength+240)/255 /* litlen */ + litLength /* literals */ + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit))) {
+                (unlikely(op + (litLength + 240) / 255 /* litlen */ + litLength /* literals */ +
+                              2 /* offset */ + 1 /* token */ + MFLIMIT -
+                              MINMATCH /* min last literals so last match is <= end - MFLIMIT */
+                          > olimit))) {
                 op--;
                 goto _last_literals;
             }
             if (litLength >= RUN_MASK) {
                 unsigned len = litLength - RUN_MASK;
-                *token = (RUN_MASK<<ML_BITS);
-                for(; len >= 255 ; len-=255) *op++ = 255;
+                *token       = (RUN_MASK << ML_BITS);
+                for (; len >= 255; len -= 255)
+                    *op++ = 255;
                 *op++ = (BYTE)len;
-            }
-            else *token = (BYTE)(litLength<<ML_BITS);
+            } else *token = (BYTE)(litLength << ML_BITS);
 
             /* Copy Literals */
-            LZ4_wildCopy8(op, anchor, op+litLength);
-            op+=litLength;
-            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
-                        (int)(anchor-(const BYTE*)source), litLength, (int)(ip-(const BYTE*)source));
+            LZ4_wildCopy8(op, anchor, op + litLength);
+            op += litLength;
+            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i", (int)(anchor - (const BYTE*)source),
+                     litLength, (int)(ip - (const BYTE*)source));
         }
 
 _next_match:
@@ -1141,50 +1263,55 @@ _next_match:
          */
 
         if ((outputDirective == fillOutput) &&
-            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit)) {
+            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ >
+             olimit)) {
             /* the match was too close to the end, rewind and go to last literals */
             op = token;
             goto _last_literals;
         }
 
         /* Encode Offset */
-        if (maybe_extMem) {   /* static test */
+        if (maybe_extMem) { /* static test */
             DEBUGLOG(6, "             with offset=%u  (ext if > %i)", offset, (int)(ip - (const BYTE*)source));
             assert(offset <= LZ4_DISTANCE_MAX && offset > 0);
-            LZ4_writeLE16(op, (U16)offset); op+=2;
-        } else  {
+            LZ4_writeLE16(op, (U16)offset);
+            op += 2;
+        } else {
             DEBUGLOG(6, "             with offset=%u  (same segment)", (U32)(ip - match));
-            assert(ip-match <= LZ4_DISTANCE_MAX);
-            LZ4_writeLE16(op, (U16)(ip - match)); op+=2;
+            assert(ip - match <= LZ4_DISTANCE_MAX);
+            LZ4_writeLE16(op, (U16)(ip - match));
+            op += 2;
         }
 
         /* Encode MatchLength */
-        {   unsigned matchCode;
+        {
+            unsigned matchCode;
 
-            if ( (dictDirective==usingExtDict || dictDirective==usingDictCtx)
-              && (lowLimit==dictionary) /* match within extDict */ ) {
-                const BYTE* limit = ip + (dictEnd-match);
+            if ((dictDirective == usingExtDict || dictDirective == usingDictCtx) &&
+                (lowLimit == dictionary) /* match within extDict */) {
+                const BYTE* limit = ip + (dictEnd - match);
                 assert(dictEnd > match);
                 if (limit > matchlimit) limit = matchlimit;
-                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, limit);
+                matchCode = LZ4_count(ip + MINMATCH, match + MINMATCH, limit);
                 ip += (size_t)matchCode + MINMATCH;
-                if (ip==limit) {
-                    unsigned const more = LZ4_count(limit, (const BYTE*)source, matchlimit);
+                if (ip == limit) {
+                    const unsigned more = LZ4_count(limit, (const BYTE*)source, matchlimit);
                     matchCode += more;
                     ip += more;
                 }
-                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode+MINMATCH);
+                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode + MINMATCH);
             } else {
-                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, matchlimit);
+                matchCode = LZ4_count(ip + MINMATCH, match + MINMATCH, matchlimit);
                 ip += (size_t)matchCode + MINMATCH;
-                DEBUGLOG(6, "             with matchLength=%u", matchCode+MINMATCH);
+                DEBUGLOG(6, "             with matchLength=%u", matchCode + MINMATCH);
             }
 
-            if ((outputDirective) &&    /* Check output buffer overflow */
-                (unlikely(op + (1 + LASTLITERALS) + (matchCode+240)/255 > olimit)) ) {
+            if ((outputDirective) && /* Check output buffer overflow */
+                (unlikely(op + (1 + LASTLITERALS) + (matchCode + 240) / 255 > olimit))) {
                 if (outputDirective == fillOutput) {
                     /* Match description too long : reduce it */
-                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ + ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
+                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ +
+                                       ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
                     ip -= matchCode - newMatchCode;
                     assert(newMatchCode < matchCode);
                     matchCode = newMatchCode;
@@ -1203,22 +1330,21 @@ _next_match:
                     }
                 } else {
                     assert(outputDirective == limitedOutput);
-                    return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                    return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
                 }
             }
             if (matchCode >= ML_MASK) {
                 *token += ML_MASK;
                 matchCode -= ML_MASK;
                 LZ4_write32(op, 0xFFFFFFFF);
-                while (matchCode >= 4*255) {
-                    op+=4;
+                while (matchCode >= 4 * 255) {
+                    op += 4;
                     LZ4_write32(op, 0xFFFFFFFF);
-                    matchCode -= 4*255;
+                    matchCode -= 4 * 255;
                 }
                 op += matchCode / 255;
                 *op++ = (BYTE)(matchCode % 255);
-            } else
-                *token += (BYTE)(matchCode);
+            } else *token += (BYTE)(matchCode);
         }
         /* Ensure we have enough space for the last literals. */
         assert(!(outputDirective == fillOutput && op + 1 + LASTLITERALS > olimit));
@@ -1229,95 +1355,101 @@ _next_match:
         if (ip >= mflimitPlusOne) break;
 
         /* Fill table */
-        {   U32 const h = LZ4_hashPosition(ip-2, tableType);
+        {
+            U32 const h = LZ4_hashPosition(ip - 2, tableType);
             if (tableType == byPtr) {
-                LZ4_putPositionOnHash(ip-2, h, cctx->hashTable, byPtr);
+                LZ4_putPositionOnHash(ip - 2, h, cctx->hashTable, byPtr);
             } else {
-                U32 const idx = (U32)((ip-2) - base);
+                U32 const idx = (U32)((ip - 2) - base);
                 LZ4_putIndexOnHash(idx, h, cctx->hashTable, tableType);
-        }   }
+            }
+        }
 
         /* Test next position */
         if (tableType == byPtr) {
-
             match = LZ4_getPosition(ip, cctx->hashTable, tableType);
             LZ4_putPosition(ip, cctx->hashTable, tableType);
-            if ( (match+LZ4_DISTANCE_MAX >= ip)
-              && (LZ4_read32(match) == LZ4_read32(ip)) )
-            { token=op++; *token=0; goto _next_match; }
+            if ((match + LZ4_DISTANCE_MAX >= ip) && (LZ4_read32(match) == LZ4_read32(ip))) {
+                token  = op++;
+                *token = 0;
+                goto _next_match;
+            }
 
-        } else {   /* byU32, byU16 */
+        } else { /* byU32, byU16 */
 
-            U32 const h = LZ4_hashPosition(ip, tableType);
-            U32 const current = (U32)(ip-base);
-            U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+            U32 const h          = LZ4_hashPosition(ip, tableType);
+            U32 const current    = (U32)(ip - base);
+            U32       matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
             assert(matchIndex < current);
             if (dictDirective == usingDictCtx) {
                 if (matchIndex < startIndex) {
                     /* there was no match, try the dictionary */
                     assert(tableType == byU32);
                     matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
-                    match = dictBase + matchIndex;
-                    lowLimit = dictionary;   /* required for match length counter */
+                    match      = dictBase + matchIndex;
+                    lowLimit   = dictionary; /* required for match length counter */
                     matchIndex += dictDelta;
                 } else {
-                    match = base + matchIndex;
-                    lowLimit = (const BYTE*)source;  /* required for match length counter */
+                    match    = base + matchIndex;
+                    lowLimit = (const BYTE*)source; /* required for match length counter */
                 }
-            } else if (dictDirective==usingExtDict) {
+            } else if (dictDirective == usingExtDict) {
                 if (matchIndex < startIndex) {
                     assert(dictBase);
-                    match = dictBase + matchIndex;
-                    lowLimit = dictionary;   /* required for match length counter */
+                    match    = dictBase + matchIndex;
+                    lowLimit = dictionary; /* required for match length counter */
                 } else {
-                    match = base + matchIndex;
-                    lowLimit = (const BYTE*)source;   /* required for match length counter */
+                    match    = base + matchIndex;
+                    lowLimit = (const BYTE*)source; /* required for match length counter */
                 }
-            } else {   /* single memory segment */
+            } else { /* single memory segment */
                 match = base + matchIndex;
             }
             LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
             assert(matchIndex < current);
-            if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
-              && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
-              && (LZ4_read32(match) == LZ4_read32(ip)) ) {
-                token=op++;
-                *token=0;
+            if (((dictIssue == dictSmall) ? (matchIndex >= prefixIdxLimit) : 1) &&
+                (((tableType == byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX))
+                     ? 1
+                     : (matchIndex + LZ4_DISTANCE_MAX >= current)) &&
+                (LZ4_read32(match) == LZ4_read32(ip))) {
+                token  = op++;
+                *token = 0;
                 if (maybe_extMem) offset = current - matchIndex;
-                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
-                            (int)(anchor-(const BYTE*)source), 0, (int)(ip-(const BYTE*)source));
+                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i", (int)(anchor - (const BYTE*)source),
+                         0, (int)(ip - (const BYTE*)source));
                 goto _next_match;
             }
         }
 
         /* Prepare next loop */
         forwardH = LZ4_hashPosition(++ip, tableType);
-
     }
 
 _last_literals:
     /* Encode Last Literals */
-    {   size_t lastRun = (size_t)(iend - anchor);
-        if ( (outputDirective) &&  /* Check output buffer overflow */
-            (op + lastRun + 1 + ((lastRun+255-RUN_MASK)/255) > olimit)) {
+    {
+        size_t lastRun = (size_t)(iend - anchor);
+        if ((outputDirective) && /* Check output buffer overflow */
+            (op + lastRun + 1 + ((lastRun + 255 - RUN_MASK) / 255) > olimit)) {
             if (outputDirective == fillOutput) {
                 /* adapt lastRun to fill 'dst' */
                 assert(olimit >= op);
-                lastRun  = (size_t)(olimit-op) - 1/*token*/;
-                lastRun -= (lastRun + 256 - RUN_MASK) / 256;  /*additional length tokens*/
+                lastRun = (size_t)(olimit - op) - 1 /*token*/;
+                lastRun -= (lastRun + 256 - RUN_MASK) / 256; /*additional length tokens*/
             } else {
                 assert(outputDirective == limitedOutput);
-                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
             }
         }
         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRun);
         if (lastRun >= RUN_MASK) {
             size_t accumulator = lastRun - RUN_MASK;
-            *op++ = RUN_MASK << ML_BITS;
-            for(; accumulator >= 255 ; accumulator-=255) *op++ = 255;
-            *op++ = (BYTE) accumulator;
+            *op++              = RUN_MASK << ML_BITS;
+            for (; accumulator >= 255; accumulator -= 255)
+                *op++ = 255;
+            *op++ = (BYTE)accumulator;
         } else {
-            *op++ = (BYTE)(lastRun<<ML_BITS);
+            *op++ = (BYTE)(lastRun << ML_BITS);
         }
         LZ4_memcpy(op, anchor, lastRun);
         ip = anchor + lastRun;
@@ -1325,7 +1457,7 @@ _last_literals:
     }
 
     if (outputDirective == fillOutput) {
-        *inputConsumed = (int) (((const char*)ip)-source);
+        *inputConsumed = (int)(((const char*)ip) - source);
     }
     result = (int)(((char*)op) - dest);
     assert(result > 0);
@@ -1337,63 +1469,74 @@ _last_literals:
  *  inlined, to ensure branches are decided at compilation time;
  *  takes care of src == (NULL, 0)
  *  and forward the rest to LZ4_compress_generic_validated */
-LZ4_FORCE_INLINE int LZ4_compress_generic(
-                 LZ4_stream_t_internal* const cctx,
-                 const char* const src,
-                 char* const dst,
-                 const int srcSize,
-                 int *inputConsumed, /* only written when outputDirective == fillOutput */
-                 const int dstCapacity,
-                 const limitedOutput_directive outputDirective,
-                 const tableType_t tableType,
-                 const dict_directive dictDirective,
-                 const dictIssue_directive dictIssue,
-                 const int acceleration)
+LZ4_FORCE_INLINE int LZ4_compress_generic(LZ4_stream_t_internal* const cctx,
+                                          const char* const            src,
+                                          char* const                  dst,
+                                          const int                    srcSize,
+                                          int* inputConsumed, /* only written when outputDirective == fillOutput */
+                                          const int                     dstCapacity,
+                                          const limitedOutput_directive outputDirective,
+                                          const tableType_t             tableType,
+                                          const dict_directive          dictDirective,
+                                          const dictIssue_directive     dictIssue,
+                                          const int                     acceleration)
 {
-    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i",
-                srcSize, dstCapacity);
+    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i", srcSize, dstCapacity);
 
-    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) { return 0; }  /* Unsupported srcSize, too large (or negative) */
-    if (srcSize == 0) {   /* src == NULL supported if srcSize == 0 */
-        if (outputDirective != notLimited && dstCapacity <= 0) return 0;  /* no output, can't write anything */
+    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) {
+        return 0;
+    } /* Unsupported srcSize, too large (or negative) */
+    if (srcSize == 0) { /* src == NULL supported if srcSize == 0 */
+        if (outputDirective != notLimited && dstCapacity <= 0) return 0; /* no output, can't write anything */
         DEBUGLOG(5, "Generating an empty block");
         assert(outputDirective == notLimited || dstCapacity >= 1);
         assert(dst != NULL);
         dst[0] = 0;
         if (outputDirective == fillOutput) {
-            assert (inputConsumed != NULL);
+            assert(inputConsumed != NULL);
             *inputConsumed = 0;
         }
         return 1;
     }
     assert(src != NULL);
 
-    return LZ4_compress_generic_validated(cctx, src, dst, srcSize,
-                inputConsumed, /* only written into if outputDirective == fillOutput */
-                dstCapacity, outputDirective,
-                tableType, dictDirective, dictIssue, acceleration);
+    return LZ4_compress_generic_validated(
+        cctx, src, dst, srcSize, inputConsumed, /* only written into if outputDirective == fillOutput */
+        dstCapacity, outputDirective, tableType, dictDirective, dictIssue, acceleration);
 }
 
-
-int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int acceleration)
+int LZ4_compress_fast_extState(void*       state,
+                               const char* source,
+                               char*       dest,
+                               int         inputSize,
+                               int         maxOutputSize,
+                               int         acceleration)
 {
-    LZ4_stream_t_internal* const ctx = & LZ4_initStream(state, sizeof(LZ4_stream_t)) -> internal_donotuse;
+    LZ4_stream_t_internal* const ctx = &LZ4_initStream(state, sizeof(LZ4_stream_t))->internal_donotuse;
     assert(ctx != NULL);
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
     if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
     if (maxOutputSize >= LZ4_compressBound(inputSize)) {
         if (inputSize < LZ4_64Klimit) {
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict,
+                                        noDictIssue, acceleration);
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)source > LZ4_DISTANCE_MAX))
+                                              ? byPtr
+                                              : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict,
+                                        noDictIssue, acceleration);
         }
     } else {
         if (inputSize < LZ4_64Klimit) {
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput,
+                                        byU16, noDict, noDictIssue, acceleration);
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)source > LZ4_DISTANCE_MAX))
+                                              ? byPtr
+                                              : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput,
+                                        tableType, noDict, noDictIssue, acceleration);
         }
     }
 }
@@ -1407,7 +1550,12 @@ int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int 
  * (see comment in lz4.h on LZ4_resetStream_fast() for a definition of
  * "correctly initialized").
  */
-int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration)
+int LZ4_compress_fast_extState_fastReset(void*       state,
+                                         const char* src,
+                                         char*       dst,
+                                         int         srcSize,
+                                         int         dstCapacity,
+                                         int         acceleration)
 {
     LZ4_stream_t_internal* const ctx = &((LZ4_stream_t*)state)->internal_donotuse;
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
@@ -1419,111 +1567,130 @@ int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst
             const tableType_t tableType = byU16;
             LZ4_prepareTable(ctx, srcSize, tableType);
             if (ctx->currentOffset) {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, dictSmall, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                            dictSmall, acceleration);
             } else {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                            noDictIssue, acceleration);
             }
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                      : byU32;
             LZ4_prepareTable(ctx, srcSize, tableType);
-            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                        noDictIssue, acceleration);
         }
     } else {
         if (srcSize < LZ4_64Klimit) {
             const tableType_t tableType = byU16;
             LZ4_prepareTable(ctx, srcSize, tableType);
             if (ctx->currentOffset) {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, dictSmall, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput,
+                                            tableType, noDict, dictSmall, acceleration);
             } else {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput,
+                                            tableType, noDict, noDictIssue, acceleration);
             }
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                      : byU32;
             LZ4_prepareTable(ctx, srcSize, tableType);
-            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType,
+                                        noDict, noDictIssue, acceleration);
         }
     }
 }
 
-
 int LZ4_compress_fast(const char* src, char* dest, int srcSize, int dstCapacity, int acceleration)
 {
     int result;
-#if (LZ4_HEAPMODE)
-    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+#  if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(
+        sizeof(LZ4_stream_t)); /* malloc-calloc always properly aligned */
     if (ctxPtr == NULL) return 0;
-#else
-    LZ4_stream_t ctx;
+#  else
+    LZ4_stream_t        ctx;
     LZ4_stream_t* const ctxPtr = &ctx;
-#endif
+#  endif
     result = LZ4_compress_fast_extState(ctxPtr, src, dest, srcSize, dstCapacity, acceleration);
 
-#if (LZ4_HEAPMODE)
+#  if (LZ4_HEAPMODE)
     FREEMEM(ctxPtr);
-#endif
+#  endif
     return result;
 }
-
 
 int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity)
 {
     return LZ4_compress_fast(src, dst, srcSize, dstCapacity, 1);
 }
 
-
 /* Note!: This function leaves the stream in an unclean/broken state!
  * It is not safe to subsequently use the same state with a _fastReset() or
  * _continue() call without resetting it. */
-static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state,
+                                                   const char*   src,
+                                                   char*         dst,
+                                                   int*          srcSizePtr,
+                                                   int           targetDstSize,
+                                                   int           acceleration)
 {
-    void* const s = LZ4_initStream(state, sizeof (*state));
-    assert(s != NULL); (void)s;
+    void* const s = LZ4_initStream(state, sizeof(*state));
+    assert(s != NULL);
+    (void)s;
 
-    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) { /* compression success is guaranteed */
         return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
     } else {
         if (*srcSizePtr < LZ4_64Klimit) {
-            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr,
+                                        targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
         } else {
-            tableType_t const addrMode = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
-    }   }
+            const tableType_t addrMode = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                     : byU32;
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr,
+                                        targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
+        }
+    }
 }
 
-int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+int LZ4_compress_destSize_extState(void*       state,
+                                   const char* src,
+                                   char*       dst,
+                                   int*        srcSizePtr,
+                                   int         targetDstSize,
+                                   int         acceleration)
 {
-    int const r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr, targetDstSize, acceleration);
+    const int r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr,
+                                                          targetDstSize, acceleration);
     /* clean the state on exit */
-    LZ4_initStream(state, sizeof (LZ4_stream_t));
+    LZ4_initStream(state, sizeof(LZ4_stream_t));
     return r;
 }
 
-
 int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize)
 {
-#if (LZ4_HEAPMODE)
-    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+#  if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t)); /* malloc-calloc always properly aligned */
     if (ctx == NULL) return 0;
-#else
-    LZ4_stream_t ctxBody;
+#  else
+    LZ4_stream_t        ctxBody;
     LZ4_stream_t* const ctx = &ctxBody;
-#endif
+#  endif
 
     int result = LZ4_compress_destSize_extState_internal(ctx, src, dst, srcSizePtr, targetDstSize, 1);
 
-#if (LZ4_HEAPMODE)
+#  if (LZ4_HEAPMODE)
     FREEMEM(ctx);
-#endif
+#  endif
     return result;
 }
-
-
 
 /*-******************************
 *  Streaming functions
 ********************************/
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
@@ -1533,23 +1700,31 @@ LZ4_stream_t* LZ4_createStream(void)
     LZ4_initStream(lz4s, sizeof(*lz4s));
     return lz4s;
 }
-#endif
+#  endif
 
 static size_t LZ4_stream_t_alignment(void)
 {
-#if LZ4_ALIGN_TEST
-    typedef struct { char c; LZ4_stream_t t; } t_a;
+#  if LZ4_ALIGN_TEST
+    typedef struct {
+        char         c;
+        LZ4_stream_t t;
+    } t_a;
+
     return sizeof(t_a) - sizeof(LZ4_stream_t);
-#else
+#  else
     return 1;  /* effectively disabled */
-#endif
+#  endif
 }
 
-LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
+LZ4_stream_t* LZ4_initStream(void* buffer, size_t size)
 {
     DEBUGLOG(5, "LZ4_initStream");
-    if (buffer == NULL) { return NULL; }
-    if (size < sizeof(LZ4_stream_t)) { return NULL; }
+    if (buffer == NULL) {
+        return NULL;
+    }
+    if (size < sizeof(LZ4_stream_t)) {
+        return NULL;
+    }
     if (!LZ4_isAligned(buffer, LZ4_stream_t_alignment())) return NULL;
     MEM_INIT(buffer, 0, sizeof(LZ4_stream_t_internal));
     return (LZ4_stream_t*)buffer;
@@ -1557,38 +1732,38 @@ LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
 
 /* resetStream is now deprecated,
  * prefer initStream() which is more general */
-void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
+void LZ4_resetStream(LZ4_stream_t* LZ4_stream)
 {
     DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", (void*)LZ4_stream);
     MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t_internal));
 }
 
-void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
+void LZ4_resetStream_fast(LZ4_stream_t* ctx)
+{
     LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
 }
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+int LZ4_freeStream(LZ4_stream_t* LZ4_stream)
 {
-    if (!LZ4_stream) return 0;   /* support free on NULL */
+    if (!LZ4_stream) return 0; /* support free on NULL */
     DEBUGLOG(5, "LZ4_freeStream %p", (void*)LZ4_stream);
     FREEMEM(LZ4_stream);
-    return (0);
+    return 0;
 }
-#endif
-
+#  endif
 
 typedef enum { _ld_fast, _ld_slow } LoadDict_mode_e;
-#define HASH_UNIT sizeof(reg_t)
-static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
-                    const char* dictionary, int dictSize,
-                    LoadDict_mode_e _ld)
+
+#  define HASH_UNIT sizeof(reg_t)
+
+static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize, LoadDict_mode_e _ld)
 {
-    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
-    const tableType_t tableType = byU32;
-    const BYTE* p = (const BYTE*)dictionary;
-    const BYTE* const dictEnd = p + dictSize;
-    U32 idx32;
+    LZ4_stream_t_internal* const dict      = &LZ4_dict->internal_donotuse;
+    const tableType_t            tableType = byU32;
+    const BYTE*                  p         = (const BYTE*)dictionary;
+    const BYTE* const            dictEnd   = p + dictSize;
+    U32                          idx32;
 
     DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, (void*)dictionary, (void*)LZ4_dict);
 
@@ -1612,29 +1787,31 @@ static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
 
     if ((dictEnd - p) > 64 KB) p = dictEnd - 64 KB;
     dict->dictionary = p;
-    dict->dictSize = (U32)(dictEnd - p);
-    dict->tableType = (U32)tableType;
-    idx32 = dict->currentOffset - dict->dictSize;
+    dict->dictSize   = (U32)(dictEnd - p);
+    dict->tableType  = (U32)tableType;
+    idx32            = dict->currentOffset - dict->dictSize;
 
-    while (p <= dictEnd-HASH_UNIT) {
+    while (p <= dictEnd - HASH_UNIT) {
         U32 const h = LZ4_hashPosition(p, tableType);
         /* Note: overwriting => favors positions end of dictionary */
         LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
-        p+=3; idx32+=3;
+        p += 3;
+        idx32 += 3;
     }
 
     if (_ld == _ld_slow) {
         /* Fill hash table with additional references, to improve compression capability */
-        p = dict->dictionary;
+        p     = dict->dictionary;
         idx32 = dict->currentOffset - dict->dictSize;
-        while (p <= dictEnd-HASH_UNIT) {
-            U32 const h = LZ4_hashPosition(p, tableType);
+        while (p <= dictEnd - HASH_UNIT) {
+            U32 const h     = LZ4_hashPosition(p, tableType);
             U32 const limit = dict->currentOffset - 64 KB;
             if (LZ4_getIndexOnHash(h, dict->hashTable, tableType) <= limit) {
                 /* Note: not overwriting => favors positions beginning of dictionary */
                 LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
             }
-            p++; idx32++;
+            p++;
+            idx32++;
         }
     }
 
@@ -1653,11 +1830,10 @@ int LZ4_loadDictSlow(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSiz
 
 void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream)
 {
-    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL :
-        &(dictionaryStream->internal_donotuse);
+    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL
+                                                                      : &(dictionaryStream->internal_donotuse);
 
-    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)",
-             (void*)workingStream, (void*)dictionaryStream,
+    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)", (void*)workingStream, (void*)dictionaryStream,
              dictCtx != NULL ? dictCtx->dictSize : 0);
 
     if (dictCtx != NULL) {
@@ -1679,18 +1855,18 @@ void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dict
     workingStream->internal_donotuse.dictCtx = dictCtx;
 }
 
-
 static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
 {
     assert(nextSize >= 0);
-    if (LZ4_dict->currentOffset + (unsigned)nextSize > 0x80000000) {   /* potential ptrdiff_t overflow (32-bits mode) */
+    if (LZ4_dict->currentOffset + (unsigned)nextSize >
+        0x80000000) { /* potential ptrdiff_t overflow (32-bits mode) */
         /* rescale hash table */
-        U32 const delta = LZ4_dict->currentOffset - 64 KB;
+        U32 const   delta   = LZ4_dict->currentOffset - 64 KB;
         const BYTE* dictEnd = LZ4_dict->dictionary + LZ4_dict->dictSize;
-        int i;
+        int         i;
         DEBUGLOG(4, "LZ4_renormDictT");
-        for (i=0; i<LZ4_HASH_SIZE_U32; i++) {
-            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i]=0;
+        for (i = 0; i < LZ4_HASH_SIZE_U32; i++) {
+            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i] = 0;
             else LZ4_dict->hashTable[i] -= delta;
         }
         LZ4_dict->currentOffset = 64 KB;
@@ -1699,37 +1875,40 @@ static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
     }
 }
 
-
-int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
-                                const char* source, char* dest,
-                                int inputSize, int maxOutputSize,
-                                int acceleration)
+int LZ4_compress_fast_continue(LZ4_stream_t* LZ4_stream,
+                               const char*   source,
+                               char*         dest,
+                               int           inputSize,
+                               int           maxOutputSize,
+                               int           acceleration)
 {
-    const tableType_t tableType = byU32;
+    const tableType_t            tableType = byU32;
     LZ4_stream_t_internal* const streamPtr = &LZ4_stream->internal_donotuse;
     const char* dictEnd = streamPtr->dictSize ? (const char*)streamPtr->dictionary + streamPtr->dictSize : NULL;
 
     DEBUGLOG(5, "LZ4_compress_fast_continue (inputSize=%i, dictSize=%u)", inputSize, streamPtr->dictSize);
 
-    LZ4_renormDictT(streamPtr, inputSize);   /* fix index overflow */
+    LZ4_renormDictT(streamPtr, inputSize); /* fix index overflow */
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
     if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
 
     /* invalidate tiny dictionaries */
-    if ( (streamPtr->dictSize < 4)     /* tiny dictionary : not enough for a hash */
-      && (dictEnd != source)           /* prefix mode */
-      && (inputSize > 0)               /* tolerance : don't lose history, in case next invocation would use prefix mode */
-      && (streamPtr->dictCtx == NULL)  /* usingDictCtx */
-      ) {
-        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, (void*)streamPtr->dictionary);
+    if ((streamPtr->dictSize < 4) /* tiny dictionary : not enough for a hash */
+        && (dictEnd != source) /* prefix mode */
+        && (inputSize > 0) /* tolerance : don't lose history, in case next invocation would use prefix mode */
+        && (streamPtr->dictCtx == NULL) /* usingDictCtx */
+    ) {
+        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize,
+                 (void*)streamPtr->dictionary);
         /* remove dictionary existence from history, to employ faster prefix mode */
-        streamPtr->dictSize = 0;
+        streamPtr->dictSize   = 0;
         streamPtr->dictionary = (const BYTE*)source;
-        dictEnd = source;
+        dictEnd               = source;
     }
 
     /* Check overlapping input/dictionary space */
-    {   const char* const sourceEnd = source + inputSize;
+    {
+        const char* const sourceEnd = source + inputSize;
         if ((sourceEnd > (const char*)streamPtr->dictionary) && (sourceEnd < dictEnd)) {
             streamPtr->dictSize = (U32)(dictEnd - sourceEnd);
             if (streamPtr->dictSize > 64 KB) streamPtr->dictSize = 64 KB;
@@ -1741,13 +1920,16 @@ int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
     /* prefix mode : source data follows dictionary */
     if (dictEnd == source) {
         if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset))
-            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                        limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
         else
-            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                        limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
     }
 
     /* external dictionary mode */
-    {   int result;
+    {
+        int result;
         if (streamPtr->dictCtx) {
             /* We depend here on the fact that dictCtx'es (produced by
              * LZ4_loadDict) guarantee that their tables contain no references
@@ -1761,44 +1943,51 @@ int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
                  * so that the compression loop is only looking into one table.
                  */
                 LZ4_memcpy(streamPtr, streamPtr->dictCtx, sizeof(*streamPtr));
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, noDictIssue,
+                                              acceleration);
             } else {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingDictCtx, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingDictCtx, noDictIssue,
+                                              acceleration);
             }
-        } else {  /* small data <= 4 KB */
+        } else { /* small data <= 4 KB */
             if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
             } else {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, noDictIssue,
+                                              acceleration);
             }
         }
         streamPtr->dictionary = (const BYTE*)source;
-        streamPtr->dictSize = (U32)inputSize;
+        streamPtr->dictSize   = (U32)inputSize;
         return result;
     }
 }
 
-
 /* Hidden debug function, to force-test external dictionary mode */
-int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
+int LZ4_compress_forceExtDict(LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
 {
     LZ4_stream_t_internal* const streamPtr = &LZ4_dict->internal_donotuse;
-    int result;
+    int                          result;
 
     LZ4_renormDictT(streamPtr, srcSize);
 
     if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
-        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, dictSmall, 1);
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32,
+                                      usingExtDict, dictSmall, 1);
     } else {
-        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, noDictIssue, 1);
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32,
+                                      usingExtDict, noDictIssue, 1);
     }
 
     streamPtr->dictionary = (const BYTE*)source;
-    streamPtr->dictSize = (U32)srcSize;
+    streamPtr->dictSize   = (U32)srcSize;
 
     return result;
 }
-
 
 /*! LZ4_saveDict() :
  *  If previously compressed data block is not guaranteed to remain available at its memory location,
@@ -1807,14 +1996,18 @@ int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char*
  *         one can therefore call LZ4_compress_fast_continue() right after.
  * @return : saved dictionary size in bytes (necessarily <= dictSize), or 0 if error.
  */
-int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
+int LZ4_saveDict(LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 {
     LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
 
     DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, (void*)safeBuffer);
 
-    if ((U32)dictSize > 64 KB) { dictSize = 64 KB; } /* useless to define a dictionary > 64 KB */
-    if ((U32)dictSize > dict->dictSize) { dictSize = (int)dict->dictSize; }
+    if ((U32)dictSize > 64 KB) {
+        dictSize = 64 KB;
+    } /* useless to define a dictionary > 64 KB */
+    if ((U32)dictSize > dict->dictSize) {
+        dictSize = (int)dict->dictSize;
+    }
 
     if (safeBuffer == NULL) assert(dictSize == 0);
     if (dictSize > 0) {
@@ -1824,12 +2017,10 @@ int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
     }
 
     dict->dictionary = (const BYTE*)safeBuffer;
-    dict->dictSize = (U32)dictSize;
+    dict->dictSize   = (U32)dictSize;
 
     return dictSize;
 }
-
-
 
 /*-*******************************
  *  Decompression functions
@@ -1837,9 +2028,8 @@ int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 
 typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 
-#undef MIN
-#define MIN(a,b)    ( (a) < (b) ? (a) : (b) )
-
+#  undef MIN
+#  define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /* variant for decompress_unsafe()
  * does not know end of input
@@ -1848,8 +2038,12 @@ typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 static size_t read_long_length_no_check(const BYTE** pp)
 {
     size_t b, l = 0;
-    do { b = **pp; (*pp)++; l += b; } while (b==255);
-    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l/255 + 1)
+    do {
+        b = **pp;
+        (*pp)++;
+        l += b;
+    } while (b == 255);
+    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l / 255 + 1)
     return l;
 }
 
@@ -1862,20 +2056,18 @@ static size_t read_long_length_no_check(const BYTE** pp)
  * Note : this variant is not optimized for speed, just for maintenance.
  *        the goal is to remove support of decompress_fast*() variants by v2.0
 **/
-LZ4_FORCE_INLINE int
-LZ4_decompress_unsafe_generic(
-                 const BYTE* const istart,
-                 BYTE* const ostart,
-                 int decompressedSize,
+LZ4_FORCE_INLINE int LZ4_decompress_unsafe_generic(const BYTE* const istart,
+                                                   BYTE* const       ostart,
+                                                   int               decompressedSize,
 
-                 size_t prefixSize,
-                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
-                 const size_t dictSize         /* note: =0 if dictStart==NULL */
-                 )
+                                                   size_t prefixSize,
+                                                   const BYTE* const dictStart, /* only if dict==usingExtDict */
+                                                   const size_t dictSize /* note: =0 if dictStart==NULL */
+)
 {
-    const BYTE* ip = istart;
-    BYTE* op = (BYTE*)ostart;
-    BYTE* const oend = ostart + decompressedSize;
+    const BYTE*       ip          = istart;
+    BYTE*             op          = (BYTE*)ostart;
+    BYTE* const       oend        = ostart + decompressedSize;
     const BYTE* const prefixStart = ostart - prefixSize;
 
     DEBUGLOG(5, "LZ4_decompress_unsafe_generic");
@@ -1886,37 +2078,41 @@ LZ4_decompress_unsafe_generic(
         unsigned token = *ip++;
 
         /* literals */
-        {   size_t ll = token >> ML_BITS;
-            if (ll==15) {
+        {
+            size_t ll = token >> ML_BITS;
+            if (ll == 15) {
                 /* long literal length */
                 ll += read_long_length_no_check(&ip);
             }
-            if ((size_t)(oend-op) < ll) return -1; /* output buffer overflow */
+            if ((size_t)(oend - op) < ll) return -1; /* output buffer overflow */
             LZ4_memmove(op, ip, ll); /* support in-place decompression */
             op += ll;
             ip += ll;
-            if ((size_t)(oend-op) < MFLIMIT) {
-                if (op==oend) break;  /* end of block */
-                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend-op);
+            if ((size_t)(oend - op) < MFLIMIT) {
+                if (op == oend) break; /* end of block */
+                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend - op);
                 /* incorrect end of block :
                  * last match must start at least MFLIMIT==12 bytes before end of output block */
                 return -1;
-        }   }
+            }
+        }
 
         /* match */
-        {   size_t ml = token & 15;
-            size_t const offset = LZ4_readLE16(ip);
-            ip+=2;
+        {
+            size_t       ml     = token & 15;
+            const size_t offset = LZ4_readLE16(ip);
+            ip += 2;
 
-            if (ml==15) {
+            if (ml == 15) {
                 /* long literal length */
                 ml += read_long_length_no_check(&ip);
             }
             ml += MINMATCH;
 
-            if ((size_t)(oend-op) < ml) return -1; /* output buffer overflow */
+            if ((size_t)(oend - op) < ml) return -1; /* output buffer overflow */
 
-            {   const BYTE* match = op - offset;
+            {
+                const BYTE* match = op - offset;
 
                 /* out of range */
                 if (offset > (size_t)(op - prefixStart) + dictSize) {
@@ -1927,9 +2123,9 @@ LZ4_decompress_unsafe_generic(
                 /* check special case : extDict */
                 if (offset > (size_t)(op - prefixStart)) {
                     /* extDict scenario */
-                    const BYTE* const dictEnd = dictStart + dictSize;
-                    const BYTE* extMatch = dictEnd - (offset - (size_t)(op-prefixStart));
-                    size_t const extml = (size_t)(dictEnd - extMatch);
+                    const BYTE* const dictEnd  = dictStart + dictSize;
+                    const BYTE*       extMatch = dictEnd - (offset - (size_t)(op - prefixStart));
+                    const size_t      extml    = (size_t)(dictEnd - extMatch);
                     if (extml > ml) {
                         /* match entirely within extDict */
                         LZ4_memmove(op, extMatch, ml);
@@ -1945,13 +2141,16 @@ LZ4_decompress_unsafe_generic(
                 }
 
                 /* match copy - slow variant, supporting overlap copy */
-                {   size_t u;
-                    for (u=0; u<ml; u++) {
+                {
+                    size_t u;
+                    for (u = 0; u < ml; u++) {
                         op[u] = match[u];
-            }   }   }
+                    }
+                }
+            }
             op += ml;
-            if ((size_t)(oend-op) < LASTLITERALS) {
-                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend-op);
+            if ((size_t)(oend - op) < LASTLITERALS) {
+                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend - op);
                 /* incorrect end of block :
                  * last match must stop at least LASTLITERALS==5 bytes before end of output block */
                 return -1;
@@ -1961,7 +2160,6 @@ LZ4_decompress_unsafe_generic(
     return (int)(ip - istart);
 }
 
-
 /* Read the variable-length literal or match length.
  *
  * @ip : input pointer
@@ -1969,27 +2167,26 @@ LZ4_decompress_unsafe_generic(
  * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
  * @error (output) - error code.  Must be set to 0 before call.
 **/
-typedef size_t Rvl_t;
+typedef size_t     Rvl_t;
 static const Rvl_t rvl_error = (Rvl_t)(-1);
-LZ4_FORCE_INLINE Rvl_t
-read_variable_length(const BYTE** ip, const BYTE* ilimit,
-                     int initial_check)
+
+LZ4_FORCE_INLINE Rvl_t read_variable_length(const BYTE** ip, const BYTE* ilimit, int initial_check)
 {
     Rvl_t s, length = 0;
     assert(ip != NULL);
-    assert(*ip !=  NULL);
+    assert(*ip != NULL);
     assert(ilimit != NULL);
-    if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
+    if (initial_check && unlikely((*ip) >= ilimit)) { /* read limit reached */
         return rvl_error;
     }
     s = **ip;
     (*ip)++;
     length += s;
-    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+    if (unlikely((*ip) > ilimit)) { /* read limit reached */
         return rvl_error;
     }
     /* accumulator overflow detection (32-bit mode only) */
-    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1) / 2))) {
         return rvl_error;
     }
     if (likely(s != 255)) return length;
@@ -1997,11 +2194,11 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
         s = **ip;
         (*ip)++;
         length += s;
-        if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+        if (unlikely((*ip) > ilimit)) { /* read limit reached */
             return rvl_error;
         }
         /* accumulator overflow detection (32-bit mode only) */
-        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1) / 2))) {
             return rvl_error;
         }
     } while (s == 255);
@@ -2016,59 +2213,61 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
  *  in order to remove useless branches during compilation optimization.
  */
 LZ4_FORCE_INLINE int
-LZ4_decompress_generic(
-                 const char* const src,
-                 char* const dst,
-                 int srcSize,
-                 int outputSize,         /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
+LZ4_decompress_generic(const char* const src,
+                       char* const       dst,
+                       int               srcSize,
+                       int outputSize, /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
 
-                 earlyEnd_directive partialDecoding,  /* full, partial */
-                 dict_directive dict,                 /* noDict, withPrefix64k, usingExtDict */
-                 const BYTE* const lowPrefix,  /* always <= dst, == dst when no prefix */
-                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
-                 const size_t dictSize         /* note : = 0 if noDict */
-                 )
+                       earlyEnd_directive partialDecoding, /* full, partial */
+                       dict_directive     dict, /* noDict, withPrefix64k, usingExtDict */
+                       const BYTE* const  lowPrefix, /* always <= dst, == dst when no prefix */
+                       const BYTE* const  dictStart, /* only if dict==usingExtDict */
+                       const size_t       dictSize /* note : = 0 if noDict */
+)
 {
-    if ((src == NULL) || (outputSize < 0)) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) {
+        return -1;
+    }
 
-    {   const BYTE* ip = (const BYTE*) src;
+    {
+        const BYTE*       ip   = (const BYTE*)src;
         const BYTE* const iend = ip + srcSize;
 
-        BYTE* op = (BYTE*) dst;
+        BYTE*       op   = (BYTE*)dst;
         BYTE* const oend = op + outputSize;
-        BYTE* cpy;
+        BYTE*       cpy;
 
         const BYTE* const dictEnd = (dictStart == NULL) ? NULL : dictStart + dictSize;
 
         const int checkOffset = (dictSize < (int)(64 KB));
-
 
         /* Set up the "end" pointers for the shortcut. */
         const BYTE* const shortiend = iend - 14 /*maxLL*/ - 2 /*offset*/;
         const BYTE* const shortoend = oend - 14 /*maxLL*/ - 18 /*maxML*/;
 
         const BYTE* match;
-        size_t offset;
-        unsigned token;
-        size_t length;
-
+        size_t      offset;
+        unsigned    token;
+        size_t      length;
 
         DEBUGLOG(5, "LZ4_decompress_generic (srcSize:%i, dstSize:%i)", srcSize, outputSize);
 
         /* Special cases */
         assert(lowPrefix <= op);
-        if (unlikely(outputSize==0)) {
+        if (unlikely(outputSize == 0)) {
             /* Empty output buffer */
             if (partialDecoding) return 0;
-            return ((srcSize==1) && (*ip==0)) ? 0 : -1;
+            return ((srcSize == 1) && (*ip == 0)) ? 0 : -1;
         }
-        if (unlikely(srcSize==0)) { return -1; }
+        if (unlikely(srcSize == 0)) {
+            return -1;
+        }
 
-    /* LZ4_FAST_DEC_LOOP:
+        /* LZ4_FAST_DEC_LOOP:
      * designed for modern OoO performance cpus,
      * where copying reliably 32-bytes is preferable to an unpredictable branch.
      * note : fast loop may show a regression for some client arm chips. */
-#if LZ4_FAST_DEC_LOOP
+#  if LZ4_FAST_DEC_LOOP
         if ((oend - op) < FASTLOOP_SAFE_DISTANCE) {
             DEBUGLOG(6, "move to safe decode loop");
             goto safe_decode;
@@ -2080,48 +2279,57 @@ LZ4_decompress_generic(
             /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
             assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
             assert(ip < iend);
-            token = *ip++;
-            length = token >> ML_BITS;  /* literal length */
-            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            token  = *ip++;
+            length = token >> ML_BITS; /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                const size_t addl = read_variable_length(&ip, iend - RUN_MASK, 1);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
                 }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
-                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)(op))) {
+                    goto _output_error;
+                } /* overflow detection */
+                if (unlikely((uptrval)(ip) + length < (uptrval)(ip))) {
+                    goto _output_error;
+                } /* overflow detection */
 
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
-                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
-                LZ4_wildCopy32(op, ip, op+length);
-                ip += length; op += length;
-            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
+                if ((op + length > oend - 32) || (ip + length > iend - 32)) {
+                    goto safe_literal_copy;
+                }
+                LZ4_wildCopy32(op, ip, op + length);
+                ip += length;
+                op += length;
+            } else if (ip <= iend - (16 + 1 /*max lit + offset + nextToken*/)) {
                 /* We don't need to check oend, since we check it once for each loop below */
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                 /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
                 LZ4_memcpy(op, ip, 16);
-                ip += length; op += length;
+                ip += length;
+                op += length;
             } else {
                 goto safe_literal_copy;
             }
 
             /* get offset */
-            offset = LZ4_readLE16(ip); ip+=2;
-            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
+            offset = LZ4_readLE16(ip);
+            ip += 2;
+            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op - (BYTE*)dst), (unsigned)offset);
             match = op - offset;
-            assert(match <= op);  /* overflow check */
+            assert(match <= op); /* overflow check */
 
             /* get matchlength */
             length = token & ML_MASK;
-            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
+            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length + MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                const size_t addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
@@ -2129,7 +2337,9 @@ LZ4_decompress_generic(
                 length += addl;
                 length += MINMATCH;
                 DEBUGLOG(7, "  long match length == %u", (unsigned)length);
-                if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)op)) {
+                    goto _output_error;
+                } /* overflow detection */
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
@@ -2148,71 +2358,77 @@ LZ4_decompress_generic(
                         assert(op + 18 <= oend);
 
                         LZ4_memcpy(op, match, 8);
-                        LZ4_memcpy(op+8, match+8, 8);
-                        LZ4_memcpy(op+16, match+16, 2);
+                        LZ4_memcpy(op + 8, match + 8, 8);
+                        LZ4_memcpy(op + 16, match + 16, 2);
                         op += length;
                         continue;
-            }   }   }
+                    }
+                }
+            }
 
-            if ( checkOffset && (unlikely(match + dictSize < lowPrefix)) ) {
-                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op-lowPrefix, op-match);
+            if (checkOffset && (unlikely(match + dictSize < lowPrefix))) {
+                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op - lowPrefix, op - match);
                 goto _output_error;
             }
             /* match starting within external dictionary */
-            if ((dict==usingExtDict) && (match < lowPrefix)) {
+            if ((dict == usingExtDict) && (match < lowPrefix)) {
                 assert(dictEnd != NULL);
-                if (unlikely(op+length > oend-LASTLITERALS)) {
+                if (unlikely(op + length > oend - LASTLITERALS)) {
                     if (partialDecoding) {
                         DEBUGLOG(7, "partialDecoding: dictionary match, close to dstEnd");
-                        length = MIN(length, (size_t)(oend-op));
+                        length = MIN(length, (size_t)(oend - op));
                     } else {
                         DEBUGLOG(6, "end-of-block condition violated")
                         goto _output_error;
-                }   }
+                    }
+                }
 
-                if (length <= (size_t)(lowPrefix-match)) {
+                if (length <= (size_t)(lowPrefix - match)) {
                     /* match fits entirely within external dictionary : just copy */
-                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    LZ4_memmove(op, dictEnd - (lowPrefix - match), length);
                     op += length;
                 } else {
                     /* match stretches into both external dictionary and current block */
-                    size_t const copySize = (size_t)(lowPrefix - match);
-                    size_t const restSize = length - copySize;
+                    const size_t copySize = (size_t)(lowPrefix - match);
+                    const size_t restSize = length - copySize;
                     LZ4_memcpy(op, dictEnd - copySize, copySize);
                     op += copySize;
-                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                    if (restSize > (size_t)(op - lowPrefix)) { /* overlap copy */
                         BYTE* const endOfMatch = op + restSize;
-                        const BYTE* copyFrom = lowPrefix;
-                        while (op < endOfMatch) { *op++ = *copyFrom++; }
+                        const BYTE* copyFrom   = lowPrefix;
+                        while (op < endOfMatch) {
+                            *op++ = *copyFrom++;
+                        }
                     } else {
                         LZ4_memcpy(op, lowPrefix, restSize);
                         op += restSize;
-                }   }
+                    }
+                }
                 continue;
             }
 
             /* copy match within block */
             cpy = op + length;
 
-            assert((op <= oend) && (oend-op >= 32));
-            if (unlikely(offset<16)) {
+            assert((op <= oend) && (oend - op >= 32));
+            if (unlikely(offset < 16)) {
                 LZ4_memcpy_using_offset(op, match, cpy, offset);
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }
 
-            op = cpy;   /* wildcopy correction */
+            op = cpy; /* wildcopy correction */
         }
-    safe_decode:
-#endif
+safe_decode:
+#  endif
 
         /* Main Loop : decode remaining sequences where output < FASTLOOP_SAFE_DISTANCE */
         DEBUGLOG(6, "using safe decode loop");
         while (1) {
             assert(ip < iend);
-            token = *ip++;
-            length = token >> ML_BITS;  /* literal length */
-            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            token  = *ip++;
+            length = token >> ML_BITS; /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
             /* A two-stage shortcut for the most common case:
              * 1) If the literal length is 0..14, and there is enough space,
@@ -2223,29 +2439,30 @@ LZ4_decompress_generic(
              * those 18 bytes earlier, upon entering the shortcut (in other words,
              * there is a combined check for both stages).
              */
-            if ( (length != RUN_MASK)
+            if ((length != RUN_MASK)
                 /* strictly "less than" on input, to re-enter the loop with at least one byte */
-              && likely((ip < shortiend) & (op <= shortoend)) ) {
+                && likely((ip < shortiend) & (op <= shortoend))) {
                 /* Copy the literals */
                 LZ4_memcpy(op, ip, 16);
-                op += length; ip += length;
+                op += length;
+                ip += length;
 
                 /* The second stage: prepare for match copying, decode full info.
                  * If it doesn't work out, the info won't be wasted. */
                 length = token & ML_MASK; /* match length */
-                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op-(BYTE*)dst), (unsigned)length, (unsigned)length + 4);
-                offset = LZ4_readLE16(ip); ip += 2;
+                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op - (BYTE*)dst),
+                         (unsigned)length, (unsigned)length + 4);
+                offset = LZ4_readLE16(ip);
+                ip += 2;
                 match = op - offset;
                 assert(match <= op); /* check overflow */
 
                 /* Do not deal with overlapping matches. */
-                if ( (length != ML_MASK)
-                  && (offset >= 8)
-                  && (dict==withPrefix64k || match >= lowPrefix) ) {
+                if ((length != ML_MASK) && (offset >= 8) && (dict == withPrefix64k || match >= lowPrefix)) {
                     /* Copy the match. */
                     LZ4_memcpy(op + 0, match + 0, 8);
                     LZ4_memcpy(op + 8, match + 8, 8);
-                    LZ4_memcpy(op +16, match +16, 2);
+                    LZ4_memcpy(op + 16, match + 16, 2);
                     op += length + MINMATCH;
                     /* Both stages worked, load the next token. */
                     continue;
@@ -2258,21 +2475,27 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) { goto _output_error; }
+                const size_t addl = read_variable_length(&ip, iend - RUN_MASK, 1);
+                if (addl == rvl_error) {
+                    goto _output_error;
+                }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
-                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)(op))) {
+                    goto _output_error;
+                } /* overflow detection */
+                if (unlikely((uptrval)(ip) + length < (uptrval)(ip))) {
+                    goto _output_error;
+                } /* overflow detection */
             }
 
-#if LZ4_FAST_DEC_LOOP
-        safe_literal_copy:
-#endif
+#  if LZ4_FAST_DEC_LOOP
+safe_literal_copy:
+#  endif
             /* copy literals */
-            cpy = op+length;
+            cpy = op + length;
 
             LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
-            if ((cpy>oend-MFLIMIT) || (ip+length>iend-(2+1+LASTLITERALS))) {
+            if ((cpy > oend - MFLIMIT) || (ip + length > iend - (2 + 1 + LASTLITERALS))) {
                 /* We've either hit the input parsing restriction or the output parsing restriction.
                  * In the normal scenario, decoding a full block, it must be the last sequence,
                  * otherwise it's an error (invalid input or dimensions).
@@ -2289,31 +2512,34 @@ LZ4_decompress_generic(
                     /* Finishing in the middle of a literals segment,
                      * due to lack of input.
                      */
-                    if (ip+length > iend) {
-                        length = (size_t)(iend-ip);
-                        cpy = op + length;
+                    if (ip + length > iend) {
+                        length = (size_t)(iend - ip);
+                        cpy    = op + length;
                     }
                     /* Finishing in the middle of a literals segment,
                      * due to lack of output space.
                      */
                     if (cpy > oend) {
                         cpy = oend;
-                        assert(op<=oend);
-                        length = (size_t)(oend-op);
+                        assert(op <= oend);
+                        length = (size_t)(oend - op);
                     }
                 } else {
-                     /* We must be on the last sequence (or invalid) because of the parsing limitations
+                    /* We must be on the last sequence (or invalid) because of the parsing limitations
                       * so check that we exactly consume the input and don't overrun the output buffer.
                       */
-                    if ((ip+length != iend) || (cpy > oend)) {
+                    if ((ip + length != iend) || (cpy > oend)) {
                         DEBUGLOG(5, "should have been last run of literals")
-                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", (void*)ip, (int)length, (void*)(ip+length), (void*)iend);
-                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", (void*)cpy, (void*)(oend-MFLIMIT));
-                        DEBUGLOG(5, "after writing %u bytes / %i bytes available", (unsigned)(op-(BYTE*)dst), outputSize);
+                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", (void*)ip, (int)length,
+                                 (void*)(ip + length), (void*)iend);
+                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", (void*)cpy, (void*)(oend - MFLIMIT));
+                        DEBUGLOG(5, "after writing %u bytes / %i bytes available",
+                                 (unsigned)(op - (BYTE*)dst), outputSize);
                         goto _output_error;
                     }
                 }
-                LZ4_memmove(op, ip, length);  /* supports overlapping memory regions, for in-place decompression scenarios */
+                LZ4_memmove(op, ip,
+                            length); /* supports overlapping memory regions, for in-place decompression scenarios */
                 ip += length;
                 op += length;
                 /* Necessarily EOF when !partialDecoding.
@@ -2321,61 +2547,69 @@ LZ4_decompress_generic(
                  * filled the output buffer or
                  * can't proceed with reading an offset for following match.
                  */
-                if (!partialDecoding || (cpy == oend) || (ip >= (iend-2))) {
+                if (!partialDecoding || (cpy == oend) || (ip >= (iend - 2))) {
                     break;
                 }
             } else {
-                LZ4_wildCopy8(op, ip, cpy);   /* can overwrite up to 8 bytes beyond cpy */
-                ip += length; op = cpy;
+                LZ4_wildCopy8(op, ip, cpy); /* can overwrite up to 8 bytes beyond cpy */
+                ip += length;
+                op = cpy;
             }
 
             /* get offset */
-            offset = LZ4_readLE16(ip); ip+=2;
+            offset = LZ4_readLE16(ip);
+            ip += 2;
             match = op - offset;
 
             /* get matchlength */
             length = token & ML_MASK;
-            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
-    _copy_match:
+_copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
-                if (addl == rvl_error) { goto _output_error; }
+                const size_t addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) {
+                    goto _output_error;
+                }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)op))
+                    goto _output_error; /* overflow detection */
             }
             length += MINMATCH;
 
-#if LZ4_FAST_DEC_LOOP
-        safe_match_copy:
-#endif
-            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) goto _output_error;   /* Error : offset outside buffers */
+#  if LZ4_FAST_DEC_LOOP
+safe_match_copy:
+#  endif
+            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix)))
+                goto _output_error; /* Error : offset outside buffers */
             /* match starting within external dictionary */
-            if ((dict==usingExtDict) && (match < lowPrefix)) {
+            if ((dict == usingExtDict) && (match < lowPrefix)) {
                 assert(dictEnd != NULL);
-                if (unlikely(op+length > oend-LASTLITERALS)) {
-                    if (partialDecoding) length = MIN(length, (size_t)(oend-op));
-                    else goto _output_error;   /* doesn't respect parsing restriction */
+                if (unlikely(op + length > oend - LASTLITERALS)) {
+                    if (partialDecoding) length = MIN(length, (size_t)(oend - op));
+                    else goto _output_error; /* doesn't respect parsing restriction */
                 }
 
-                if (length <= (size_t)(lowPrefix-match)) {
+                if (length <= (size_t)(lowPrefix - match)) {
                     /* match fits entirely within external dictionary : just copy */
-                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    LZ4_memmove(op, dictEnd - (lowPrefix - match), length);
                     op += length;
                 } else {
                     /* match stretches into both external dictionary and current block */
-                    size_t const copySize = (size_t)(lowPrefix - match);
-                    size_t const restSize = length - copySize;
+                    const size_t copySize = (size_t)(lowPrefix - match);
+                    const size_t restSize = length - copySize;
                     LZ4_memcpy(op, dictEnd - copySize, copySize);
                     op += copySize;
-                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                    if (restSize > (size_t)(op - lowPrefix)) { /* overlap copy */
                         BYTE* const endOfMatch = op + restSize;
-                        const BYTE* copyFrom = lowPrefix;
-                        while (op < endOfMatch) *op++ = *copyFrom++;
+                        const BYTE* copyFrom   = lowPrefix;
+                        while (op < endOfMatch)
+                            *op++ = *copyFrom++;
                     } else {
                         LZ4_memcpy(op, lowPrefix, restSize);
                         op += restSize;
-                }   }
+                    }
+                }
                 continue;
             }
             assert(match >= lowPrefix);
@@ -2384,29 +2618,33 @@ LZ4_decompress_generic(
             cpy = op + length;
 
             /* partialDecoding : may end anywhere within the block */
-            assert(op<=oend);
-            if (partialDecoding && (cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
-                size_t const mlen = MIN(length, (size_t)(oend-op));
+            assert(op <= oend);
+            if (partialDecoding && (cpy > oend - MATCH_SAFEGUARD_DISTANCE)) {
+                const size_t      mlen     = MIN(length, (size_t)(oend - op));
                 const BYTE* const matchEnd = match + mlen;
-                BYTE* const copyEnd = op + mlen;
-                if (matchEnd > op) {   /* overlap copy */
-                    while (op < copyEnd) { *op++ = *match++; }
+                BYTE* const       copyEnd  = op + mlen;
+                if (matchEnd > op) { /* overlap copy */
+                    while (op < copyEnd) {
+                        *op++ = *match++;
+                    }
                 } else {
                     LZ4_memcpy(op, match, mlen);
                 }
                 op = copyEnd;
-                if (op == oend) { break; }
+                if (op == oend) {
+                    break;
+                }
                 continue;
             }
 
-            if (unlikely(offset<8)) {
-                LZ4_write32(op, 0);   /* silence msan warning when offset==0 */
+            if (unlikely(offset < 8)) {
+                LZ4_write32(op, 0); /* silence msan warning when offset==0 */
                 op[0] = match[0];
                 op[1] = match[1];
                 op[2] = match[2];
                 op[3] = match[3];
                 match += inc32table[offset];
-                LZ4_memcpy(op+4, match, 4);
+                LZ4_memcpy(op + 4, match, 4);
                 match -= dec64table[offset];
             } else {
                 LZ4_memcpy(op, match, 8);
@@ -2414,136 +2652,152 @@ LZ4_decompress_generic(
             }
             op += 8;
 
-            if (unlikely(cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
-                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH-1);
-                if (cpy > oend-LASTLITERALS) { goto _output_error; } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
+            if (unlikely(cpy > oend - MATCH_SAFEGUARD_DISTANCE)) {
+                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH - 1);
+                if (cpy > oend - LASTLITERALS) {
+                    goto _output_error;
+                } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
                 if (op < oCopyLimit) {
                     LZ4_wildCopy8(op, match, oCopyLimit);
                     match += oCopyLimit - op;
                     op = oCopyLimit;
                 }
-                while (op < cpy) { *op++ = *match++; }
+                while (op < cpy) {
+                    *op++ = *match++;
+                }
             } else {
                 LZ4_memcpy(op, match, 8);
-                if (length > 16) { LZ4_wildCopy8(op+8, match+8, cpy); }
+                if (length > 16) {
+                    LZ4_wildCopy8(op + 8, match + 8, cpy);
+                }
             }
-            op = cpy;   /* wildcopy correction */
+            op = cpy; /* wildcopy correction */
         }
 
         /* end of decoding */
-        DEBUGLOG(5, "decoded %i bytes", (int) (((char*)op)-dst));
-        return (int) (((char*)op)-dst);     /* Nb of output bytes decoded */
+        DEBUGLOG(5, "decoded %i bytes", (int)(((char*)op) - dst));
+        return (int)(((char*)op) - dst); /* Nb of output bytes decoded */
 
         /* Overflow error detected */
-    _output_error:
-        return (int) (-(((const char*)ip)-src))-1;
+_output_error:
+        return (int)(-(((const char*)ip) - src)) - 1;
     }
 }
-
 
 /*===== Instantiate the API decoding functions. =====*/
 
 LZ4_FORCE_O2
 int LZ4_decompress_safe(const char* source, char* dest, int compressedSize, int maxDecompressedSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize,
-                                  decode_full_block, noDict,
-                                  (BYTE*)dest, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize, decode_full_block,
+                                  noDict, (BYTE*)dest, NULL, 0);
 }
 
 LZ4_FORCE_O2
 int LZ4_decompress_safe_partial(const char* src, char* dst, int compressedSize, int targetOutputSize, int dstCapacity)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity,
-                                  partial_decode,
-                                  noDict, (BYTE*)dst, NULL, 0);
+    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity, partial_decode, noDict, (BYTE*)dst,
+                                  NULL, 0);
 }
 
 LZ4_FORCE_O2
 int LZ4_decompress_fast(const char* source, char* dest, int originalSize)
 {
     DEBUGLOG(5, "LZ4_decompress_fast");
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                0, NULL, 0);
+    if (originalSize < 0) return -1;
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 0, NULL, 0);
 }
 
 /*===== Instantiate a few more decoding cases, used more than once. =====*/
 
 LZ4_FORCE_O2 /* Exported, an obsolete API function. */
-int LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
+    int
+    LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, withPrefix64k,
-                                  (BYTE*)dest - 64 KB, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  withPrefix64k, (BYTE*)dest - 64 KB, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_partial_withPrefix64k(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity)
+static int LZ4_decompress_safe_partial_withPrefix64k(const char* source,
+                                                     char*       dest,
+                                                     int         compressedSize,
+                                                     int         targetOutputSize,
+                                                     int         dstCapacity)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, withPrefix64k,
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, withPrefix64k,
                                   (BYTE*)dest - 64 KB, NULL, 0);
 }
 
 /* Another obsolete API function, paired with the previous one. */
 int LZ4_decompress_fast_withPrefix64k(const char* source, char* dest, int originalSize)
 {
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                64 KB, NULL, 0);
+    if (originalSize < 0) return -1;
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 64 KB, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_withSmallPrefix(const char* source, char* dest, int compressedSize, int maxOutputSize,
-                                               size_t prefixSize)
+static int LZ4_decompress_safe_withSmallPrefix(const char* source,
+                                               char*       dest,
+                                               int         compressedSize,
+                                               int         maxOutputSize,
+                                               size_t      prefixSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, noDict,
-                                  (BYTE*)dest-prefixSize, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block, noDict,
+                                  (BYTE*)dest - prefixSize, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity,
-                                               size_t prefixSize)
+static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source,
+                                                       char*       dest,
+                                                       int         compressedSize,
+                                                       int         targetOutputSize,
+                                                       int         dstCapacity,
+                                                       size_t      prefixSize)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, noDict,
-                                  (BYTE*)dest-prefixSize, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, noDict,
+                                  (BYTE*)dest - prefixSize, NULL, 0);
 }
 
 LZ4_FORCE_O2
-int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int maxOutputSize,
-                                     const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_forceExtDict(const char* source,
+                                     char*       dest,
+                                     int         compressedSize,
+                                     int         maxOutputSize,
+                                     const void* dictStart,
+                                     size_t      dictSize)
 {
     DEBUGLOG(5, "LZ4_decompress_safe_forceExtDict");
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, usingExtDict,
-                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  usingExtDict, (BYTE*)dest, (const BYTE*)dictStart, dictSize);
 }
 
 LZ4_FORCE_O2
-int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int targetOutputSize, int dstCapacity,
-                                     const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_partial_forceExtDict(const char* source,
+                                             char*       dest,
+                                             int         compressedSize,
+                                             int         targetOutputSize,
+                                             int         dstCapacity,
+                                             const void* dictStart,
+                                             size_t      dictSize)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, usingExtDict,
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, usingExtDict,
                                   (BYTE*)dest, (const BYTE*)dictStart, dictSize);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_fast_extDict(const char* source, char* dest, int originalSize,
-                                       const void* dictStart, size_t dictSize)
+static int LZ4_decompress_fast_extDict(const char* source,
+                                       char*       dest,
+                                       int         originalSize,
+                                       const void* dictStart,
+                                       size_t      dictSize)
 {
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                0, (const BYTE*)dictStart, dictSize);
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 0,
+                                         (const BYTE*)dictStart, dictSize);
 }
 
 /* The "double dictionary" mode, for use with e.g. ring buffers: the first part
@@ -2551,30 +2805,36 @@ static int LZ4_decompress_fast_extDict(const char* source, char* dest, int origi
  * These routines are used only once, in LZ4_decompress_*_continue().
  */
 LZ4_FORCE_INLINE
-int LZ4_decompress_safe_doubleDict(const char* source, char* dest, int compressedSize, int maxOutputSize,
-                                   size_t prefixSize, const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_doubleDict(const char* source,
+                                   char*       dest,
+                                   int         compressedSize,
+                                   int         maxOutputSize,
+                                   size_t      prefixSize,
+                                   const void* dictStart,
+                                   size_t      dictSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, usingExtDict,
-                                  (BYTE*)dest-prefixSize, (const BYTE*)dictStart, dictSize);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  usingExtDict, (BYTE*)dest - prefixSize, (const BYTE*)dictStart, dictSize);
 }
 
 /*===== streaming decompression functions =====*/
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 {
     LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
-    return (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
+    return (LZ4_streamDecode_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
 }
 
-int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
+int LZ4_freeStreamDecode(LZ4_streamDecode_t* LZ4_stream)
 {
-    if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
+    if (LZ4_stream == NULL) {
+        return 0;
+    } /* support free on NULL */
     FREEMEM(LZ4_stream);
     return 0;
 }
-#endif
+#  endif
 
 /*! LZ4_setStreamDecode() :
  *  Use this function to instruct where to find the dictionary.
@@ -2582,15 +2842,15 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
  *  Loading a size of 0 is allowed (same effect as no dictionary).
  * @return : 1 if OK, 0 if error
  */
-int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
+int LZ4_setStreamDecode(LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
 {
     LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
-    lz4sd->prefixSize = (size_t)dictSize;
+    lz4sd->prefixSize                  = (size_t)dictSize;
     if (dictSize) {
         assert(dictionary != NULL);
-        lz4sd->prefixEnd = (const BYTE*) dictionary + dictSize;
+        lz4sd->prefixEnd = (const BYTE*)dictionary + dictSize;
     } else {
-        lz4sd->prefixEnd = (const BYTE*) dictionary;
+        lz4sd->prefixEnd = (const BYTE*)dictionary;
     }
     lz4sd->externalDict = NULL;
     lz4sd->extDictSize  = 0;
@@ -2624,10 +2884,14 @@ int LZ4_decoderRingBufferSize(int maxBlockSize)
     and indicate where it stands using LZ4_setStreamDecode()
 */
 LZ4_FORCE_O2
-int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* source, char* dest, int compressedSize, int maxOutputSize)
+int LZ4_decompress_safe_continue(LZ4_streamDecode_t* LZ4_streamDecode,
+                                 const char*         source,
+                                 char*               dest,
+                                 int                 compressedSize,
+                                 int                 maxOutputSize)
 {
     LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
-    int result;
+    int                          result;
 
     if (lz4sd->prefixSize == 0) {
         /* The first call, no dictionary yet. */
@@ -2635,7 +2899,7 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
         result = LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)result;
-        lz4sd->prefixEnd = (BYTE*)dest + result;
+        lz4sd->prefixEnd  = (BYTE*)dest + result;
     } else if (lz4sd->prefixEnd == (BYTE*)dest) {
         /* They're rolling the current segment. */
         if (lz4sd->prefixSize >= 64 KB - 1)
@@ -2648,13 +2912,13 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
                                                     lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize += (size_t)result;
-        lz4sd->prefixEnd  += result;
+        lz4sd->prefixEnd += result;
     } else {
         /* The buffer wraps around, or they're switching to another buffer. */
-        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->extDictSize  = lz4sd->prefixSize;
         lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
-        result = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
-                                                  lz4sd->externalDict, lz4sd->extDictSize);
+        result              = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
+                                                               lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)result;
         lz4sd->prefixEnd  = (BYTE*)dest + result;
@@ -2663,13 +2927,14 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
     return result;
 }
 
-LZ4_FORCE_O2 int
-LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
-                        const char* source, char* dest, int originalSize)
+LZ4_FORCE_O2 int LZ4_decompress_fast_continue(LZ4_streamDecode_t* LZ4_streamDecode,
+                                              const char*         source,
+                                              char*               dest,
+                                              int                 originalSize)
 {
-    LZ4_streamDecode_t_internal* const lz4sd =
-        (assert(LZ4_streamDecode!=NULL), &LZ4_streamDecode->internal_donotuse);
-    int result;
+    LZ4_streamDecode_t_internal* const lz4sd = (assert(LZ4_streamDecode != NULL),
+                                                &LZ4_streamDecode->internal_donotuse);
+    int                                result;
 
     DEBUGLOG(5, "LZ4_decompress_fast_continue (toDecodeSize=%i)", originalSize);
     assert(originalSize >= 0);
@@ -2680,22 +2945,20 @@ LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
         result = LZ4_decompress_fast(source, dest, originalSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)originalSize;
-        lz4sd->prefixEnd = (BYTE*)dest + originalSize;
+        lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
     } else if (lz4sd->prefixEnd == (BYTE*)dest) {
         DEBUGLOG(5, "continue using existing prefix");
-        result = LZ4_decompress_unsafe_generic(
-                        (const BYTE*)source, (BYTE*)dest, originalSize,
-                        lz4sd->prefixSize,
-                        lz4sd->externalDict, lz4sd->extDictSize);
+        result = LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize,
+                                               lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize += (size_t)originalSize;
-        lz4sd->prefixEnd  += originalSize;
+        lz4sd->prefixEnd += originalSize;
     } else {
         DEBUGLOG(5, "prefix becomes extDict");
-        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->extDictSize  = lz4sd->prefixSize;
         lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
-        result = LZ4_decompress_fast_extDict(source, dest, originalSize,
-                                             lz4sd->externalDict, lz4sd->extDictSize);
+        result              = LZ4_decompress_fast_extDict(source, dest, originalSize, lz4sd->externalDict,
+                                                          lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)originalSize;
         lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
@@ -2704,7 +2967,6 @@ LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
     return result;
 }
 
-
 /*
 Advanced decoding functions :
 *_usingDict() :
@@ -2712,46 +2974,65 @@ Advanced decoding functions :
     the dictionary must be explicitly provided within parameters
 */
 
-int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressedSize, int maxOutputSize, const char* dictStart, int dictSize)
+int LZ4_decompress_safe_usingDict(const char* source,
+                                  char*       dest,
+                                  int         compressedSize,
+                                  int         maxOutputSize,
+                                  const char* dictStart,
+                                  int         dictSize)
 {
-    if (dictSize==0)
-        return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
-    if (dictStart+dictSize == dest) {
+    if (dictSize == 0) return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+    if (dictStart + dictSize == dest) {
         if (dictSize >= 64 KB - 1) {
             return LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
         }
         assert(dictSize >= 0);
-        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize, (size_t)dictSize);
+        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize,
+                                                   (size_t)dictSize);
     }
     assert(dictSize >= 0);
-    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart, (size_t)dictSize);
+    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart,
+                                            (size_t)dictSize);
 }
 
-int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity, const char* dictStart, int dictSize)
+int LZ4_decompress_safe_partial_usingDict(const char* source,
+                                          char*       dest,
+                                          int         compressedSize,
+                                          int         targetOutputSize,
+                                          int         dstCapacity,
+                                          const char* dictStart,
+                                          int         dictSize)
 {
-    if (dictSize==0)
+    if (dictSize == 0)
         return LZ4_decompress_safe_partial(source, dest, compressedSize, targetOutputSize, dstCapacity);
-    if (dictStart+dictSize == dest) {
+    if (dictStart + dictSize == dest) {
         if (dictSize >= 64 KB - 1) {
-            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize, dstCapacity);
+            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize,
+                                                             dstCapacity);
         }
         assert(dictSize >= 0);
-        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize, dstCapacity, (size_t)dictSize);
+        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize,
+                                                           dstCapacity, (size_t)dictSize);
     }
     assert(dictSize >= 0);
-    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize, dstCapacity, dictStart, (size_t)dictSize);
+    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize,
+                                                    dstCapacity, dictStart, (size_t)dictSize);
 }
 
-int LZ4_decompress_fast_usingDict(const char* source, char* dest, int originalSize, const char* dictStart, int dictSize)
+int LZ4_decompress_fast_usingDict(const char* source,
+                                  char*       dest,
+                                  int         originalSize,
+                                  const char* dictStart,
+                                  int         dictSize)
 {
-    if (dictSize==0 || dictStart+dictSize == dest)
-        return LZ4_decompress_unsafe_generic(
-                        (const BYTE*)source, (BYTE*)dest, originalSize,
-                        (size_t)dictSize, NULL, 0);
+    if (originalSize < 0) return -1;
+    if (dictSize == 0 || dictStart + dictSize == dest) {
+        return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, (size_t)dictSize,
+                                             NULL, 0);
+    }
     assert(dictSize >= 0);
     return LZ4_decompress_fast_extDict(source, dest, originalSize, dictStart, (size_t)dictSize);
 }
-
 
 /*=*************************************************
 *  Obsolete Functions
@@ -2761,23 +3042,32 @@ int LZ4_compress_limitedOutput(const char* source, char* dest, int inputSize, in
 {
     return LZ4_compress_default(source, dest, inputSize, maxOutputSize);
 }
+
 int LZ4_compress(const char* src, char* dest, int srcSize)
 {
     return LZ4_compress_default(src, dest, srcSize, LZ4_compressBound(srcSize));
 }
-int LZ4_compress_limitedOutput_withState (void* state, const char* src, char* dst, int srcSize, int dstSize)
+
+int LZ4_compress_limitedOutput_withState(void* state, const char* src, char* dst, int srcSize, int dstSize)
 {
     return LZ4_compress_fast_extState(state, src, dst, srcSize, dstSize, 1);
 }
-int LZ4_compress_withState (void* state, const char* src, char* dst, int srcSize)
+
+int LZ4_compress_withState(void* state, const char* src, char* dst, int srcSize)
 {
     return LZ4_compress_fast_extState(state, src, dst, srcSize, LZ4_compressBound(srcSize), 1);
 }
-int LZ4_compress_limitedOutput_continue (LZ4_stream_t* LZ4_stream, const char* src, char* dst, int srcSize, int dstCapacity)
+
+int LZ4_compress_limitedOutput_continue(LZ4_stream_t* LZ4_stream,
+                                        const char*   src,
+                                        char*         dst,
+                                        int           srcSize,
+                                        int           dstCapacity)
 {
     return LZ4_compress_fast_continue(LZ4_stream, src, dst, srcSize, dstCapacity, 1);
 }
-int LZ4_compress_continue (LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
+
+int LZ4_compress_continue(LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
 {
     return LZ4_compress_fast_continue(LZ4_stream, source, dest, inputSize, LZ4_compressBound(inputSize), 1);
 }
@@ -2788,18 +3078,22 @@ They are only provided here for compatibility with older user programs.
 - LZ4_uncompress is totally equivalent to LZ4_decompress_fast
 - LZ4_uncompress_unknownOutputSize is totally equivalent to LZ4_decompress_safe
 */
-int LZ4_uncompress (const char* source, char* dest, int outputSize)
+int LZ4_uncompress(const char* source, char* dest, int outputSize)
 {
     return LZ4_decompress_fast(source, dest, outputSize);
 }
-int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize)
+
+int LZ4_uncompress_unknownOutputSize(const char* source, char* dest, int isize, int maxOutputSize)
 {
     return LZ4_decompress_safe(source, dest, isize, maxOutputSize);
 }
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState(void) { return sizeof(LZ4_stream_t); }
+int LZ4_sizeofStreamState(void)
+{
+    return sizeof(LZ4_stream_t);
+}
 
 int LZ4_resetStreamState(void* state, char* inputBuffer)
 {
@@ -2808,18 +3102,18 @@ int LZ4_resetStreamState(void* state, char* inputBuffer)
     return 0;
 }
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-void* LZ4_create (char* inputBuffer)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+void* LZ4_create(char* inputBuffer)
 {
     (void)inputBuffer;
     return LZ4_createStream();
 }
-#endif
+#  endif
 
-char* LZ4_slideInputBuffer (void* state)
+char* LZ4_slideInputBuffer(void* state)
 {
     /* avoid const char * -> char * conversion warning */
-    return (char *)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
+    return (char*)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
 }
 
-#endif   /* LZ4_COMMONDEFS_ONLY */
+#endif /* LZ4_COMMONDEFS_ONLY */

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -159,7 +159,9 @@ static int g_debuglog_enable = 1;
                     fprintf(stderr, __VA_ARGS__);             \
                     fprintf(stderr, " \n");                   \
             }   }
-#else
+#endif
+
+#ifndef DEBUGLOG
 #  define DEBUGLOG(l, ...)      {}    /* disabled */
 #endif
 
@@ -346,7 +348,10 @@ size_t LZ4F_getBlockSize(LZ4F_blockSizeID_t blockSizeID)
 /*-************************************
 *  Private functions
 **************************************/
+#ifndef MIN
 #define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#endif
+
 
 static BYTE LZ4F_headerChecksum (const void* header, size_t length)
 {

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -78,8 +78,13 @@ typedef enum { noDictCtx, usingDictCtxHc } dictCtx_directive;
 
 
 /*===   Macros   ===*/
+#ifndef MIN
 #define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#endif
+#ifndef MAX
 #define MAX(a,b)   ( (a) > (b) ? (a) : (b) )
+#endif
+
 
 
 /*===   Levels definition   ===*/


### PR DESCRIPTION
This patch improves safety for deprecated fast decompression APIs in lz4.c. It adds explicit validation for negative originalSize values and bounds the source buffer consumption to LZ4_COMPRESSBOUND(originalSize) before parsing compressed input in legacy fast-decompression wrappers.