### PR TITLE
Harden LZ4 decompression APIs against negative inputs and bounds viol…

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -57,7 +57,6 @@
  */
 #define LZ4_ACCELERATION_MAX 65537
 
-
 /*-************************************
 *  CPU Feature Detection
 **************************************/
@@ -75,10 +74,9 @@
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef LZ4_FORCE_MEMORY_ACCESS   /* can be defined externally */
-#  if defined(__GNUC__) && \
-  ( defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) \
-  || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) \
-  || (defined(__riscv) && defined(__riscv_zicclsm)) )
+#  if defined(__GNUC__) && (defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || \
+                            defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) ||                           \
+                            defined(__ARM_ARCH_6T2__) || (defined(__riscv) && defined(__riscv_zicclsm)))
 #    define LZ4_FORCE_MEMORY_ACCESS 2
 #  elif (defined(__INTEL_COMPILER) && !defined(_WIN32)) || defined(__GNUC__) || defined(_MSC_VER)
 #    define LZ4_FORCE_MEMORY_ACCESS 1
@@ -89,12 +87,10 @@
  * LZ4_FORCE_SW_BITCOUNT
  * Define this parameter if your target system or compiler does not support hardware bit count
  */
-#if defined(_MSC_VER) && defined(_WIN32_WCE)   /* Visual Studio for WinCE doesn't support Hardware bit count */
-#  undef  LZ4_FORCE_SW_BITCOUNT  /* avoid double def */
+#if defined(_MSC_VER) && defined(_WIN32_WCE) /* Visual Studio for WinCE doesn't support Hardware bit count */
+#  undef LZ4_FORCE_SW_BITCOUNT /* avoid double def */
 #  define LZ4_FORCE_SW_BITCOUNT
 #endif
-
-
 
 /*-************************************
 *  Dependency
@@ -117,25 +113,28 @@
 #include "lz4.h"
 /* see also "memory routines" below */
 
-
 /*-************************************
 *  Compiler Options
 **************************************/
-#if defined(_MSC_VER) && (_MSC_VER >= 1400)  /* Visual Studio 2005+ */
-#  include <intrin.h>               /* only present in VS2005+ */
-#  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
-#  pragma warning(disable : 6237)   /* disable: C6237: conditional expression is always 0 */
-#  pragma warning(disable : 6239)   /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
-#  pragma warning(disable : 6240)   /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
-#  pragma warning(disable : 6326)   /* disable: C6326: Potential comparison of a constant with another constant */
-#endif  /* _MSC_VER */
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) /* Visual Studio 2005+ */
+#  include <intrin.h> /* only present in VS2005+ */
+#  pragma warning(disable : 4127) /* disable: C4127: conditional expression is constant */
+#  pragma warning(disable : 6237) /* disable: C6237: conditional expression is always 0 */
+#  pragma warning( \
+      disable      \
+      : 6239) /* disable: C6239: (<non-zero constant> && <expression>) always evaluates to the result of <expression> */
+#  pragma warning( \
+      disable      \
+      : 6240) /* disable: C6240: (<expression> && <non-zero constant>) always evaluates to the result of <expression> */
+#  pragma warning(disable : 6326) /* disable: C6326: Potential comparison of a constant with another constant */
+#endif /* _MSC_VER */
 
 #ifndef LZ4_FORCE_INLINE
-#  if defined (_MSC_VER) && !defined (__clang__)    /* MSVC */
+#  if defined(_MSC_VER) && !defined(__clang__) /* MSVC */
 #    define LZ4_FORCE_INLINE static __forceinline
 #  else
-#    if defined (__cplusplus) || defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   /* C99 */
-#      if defined (__GNUC__) || defined (__clang__)
+#    if defined(__cplusplus) || defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L /* C99 */
+#      if defined(__GNUC__) || defined(__clang__)
 #        define LZ4_FORCE_INLINE static inline __attribute__((always_inline))
 #      else
 #        define LZ4_FORCE_INLINE static inline
@@ -143,7 +142,7 @@
 #    else
 #      define LZ4_FORCE_INLINE static
 #    endif /* __STDC_VERSION__ */
-#  endif  /* _MSC_VER */
+#  endif /* _MSC_VER */
 #endif /* LZ4_FORCE_INLINE */
 
 /* LZ4_FORCE_O2 and LZ4_FORCE_INLINE
@@ -161,32 +160,32 @@
  * of LZ4_wildCopy8 does not affect the compression speed.
  */
 #if defined(__PPC64__) && defined(__LITTLE_ENDIAN__) && defined(__GNUC__) && !defined(__clang__)
-#  define LZ4_FORCE_O2  __attribute__((optimize("O2")))
+#  define LZ4_FORCE_O2 __attribute__((optimize("O2")))
 #  undef LZ4_FORCE_INLINE
-#  define LZ4_FORCE_INLINE  static __inline __attribute__((optimize("O2"),always_inline))
+#  define LZ4_FORCE_INLINE static __inline __attribute__((optimize("O2"), always_inline))
 #else
 #  define LZ4_FORCE_O2
 #endif
 
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || defined(__clang__)
-#  define expect(expr,value)    (__builtin_expect ((expr),(value)) )
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 800)) || \
+    defined(__clang__)
+#  define expect(expr, value) (__builtin_expect((expr), (value)))
 #else
-#  define expect(expr,value)    (expr)
+#  define expect(expr, value) (expr)
 #endif
 
 #ifndef likely
-#define likely(expr)     expect((expr) != 0, 1)
+#  define likely(expr) expect((expr) != 0, 1)
 #endif
 #ifndef unlikely
-#define unlikely(expr)   expect((expr) != 0, 0)
+#  define unlikely(expr) expect((expr) != 0, 0)
 #endif
 
 /* Should the alignment test prove unreliable, for some reason,
  * it can be disabled by setting LZ4_ALIGN_TEST to 0 */
-#ifndef LZ4_ALIGN_TEST  /* can be externally provided */
-# define LZ4_ALIGN_TEST 1
+#ifndef LZ4_ALIGN_TEST /* can be externally provided */
+#  define LZ4_ALIGN_TEST 1
 #endif
-
 
 /*-************************************
 *  Memory routines
@@ -218,24 +217,23 @@
 void* LZ4_malloc(size_t s);
 void* LZ4_calloc(size_t n, size_t s);
 void  LZ4_free(void* p);
-# define ALLOC(s)          LZ4_malloc(s)
-# define ALLOC_AND_ZERO(s) LZ4_calloc(1,s)
-# define FREEMEM(p)        LZ4_free(p)
+#  define ALLOC(s)          LZ4_malloc(s)
+#  define ALLOC_AND_ZERO(s) LZ4_calloc(1, s)
+#  define FREEMEM(p)        LZ4_free(p)
 #else
-# include <stdlib.h>   /* malloc, calloc, free */
-# define ALLOC(s)          malloc(s)
-# define ALLOC_AND_ZERO(s) calloc(1,s)
-# define FREEMEM(p)        free(p)
+#  include <stdlib.h> /* malloc, calloc, free */
+#  define ALLOC(s)          malloc(s)
+#  define ALLOC_AND_ZERO(s) calloc(1, s)
+#  define FREEMEM(p)        free(p)
 #endif
 
-#if ! LZ4_FREESTANDING
-#  include <string.h>   /* memset, memcpy */
+#if !LZ4_FREESTANDING
+#  include <string.h> /* memset, memcpy */
 #endif
 #if !defined(LZ4_memset)
-#  define LZ4_memset(p,v,s) memset((p),(v),(s))
+#  define LZ4_memset(p, v, s) memset((p), (v), (s))
 #endif
-#define MEM_INIT(p,v,s)   LZ4_memset((p),(v),(s))
-
+#define MEM_INIT(p, v, s) LZ4_memset((p), (v), (s))
 
 /*-************************************
 *  Common Constants
@@ -243,31 +241,32 @@ void  LZ4_free(void* p);
 #define MINMATCH 4
 
 #define WILDCOPYLENGTH 8
-#define LASTLITERALS   5   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
-#define MFLIMIT       12   /* see ../doc/lz4_Block_format.md#parsing-restrictions */
-#define MATCH_SAFEGUARD_DISTANCE  ((2*WILDCOPYLENGTH) - MINMATCH)   /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
+#define LASTLITERALS   5 /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MFLIMIT        12 /* see ../doc/lz4_Block_format.md#parsing-restrictions */
+#define MATCH_SAFEGUARD_DISTANCE \
+    ((2 * WILDCOPYLENGTH) -      \
+     MINMATCH) /* ensure it's possible to write 2 x wildcopyLength without overflowing output buffer */
 #define FASTLOOP_SAFE_DISTANCE 64
-static const int LZ4_minLength = (MFLIMIT+1);
+static const int LZ4_minLength = (MFLIMIT + 1);
 
-#define KB *(1 <<10)
-#define MB *(1 <<20)
-#define GB *(1U<<30)
+#define KB *(1 << 10)
+#define MB *(1 << 20)
+#define GB *(1U << 30)
 
 #define LZ4_DISTANCE_ABSOLUTE_MAX 65535
-#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX)   /* max supported by LZ4 format */
+#if (LZ4_DISTANCE_MAX > LZ4_DISTANCE_ABSOLUTE_MAX) /* max supported by LZ4 format */
 #  error "LZ4_DISTANCE_MAX is too big : must be <= 65535"
 #endif
 
 #define ML_BITS  4
-#define ML_MASK  ((1U<<ML_BITS)-1)
-#define RUN_BITS (8-ML_BITS)
-#define RUN_MASK ((1U<<RUN_BITS)-1)
-
+#define ML_MASK  ((1U << ML_BITS) - 1)
+#define RUN_BITS (8 - ML_BITS)
+#define RUN_MASK ((1U << RUN_BITS) - 1)
 
 /*-************************************
 *  Error detection
 **************************************/
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 1)
 #  include <assert.h>
 #else
 #  ifndef assert
@@ -275,63 +274,64 @@ static const int LZ4_minLength = (MFLIMIT+1);
 #  endif
 #endif
 
-#define LZ4_STATIC_ASSERT(c)   { enum { LZ4_static_assert = 1/(int)(!!(c)) }; }   /* use after variable declarations */
+#define LZ4_STATIC_ASSERT(c)                           \
+    {                                                  \
+        enum { LZ4_static_assert = 1 / (int)(!!(c)) }; \
+    } /* use after variable declarations */
 
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2)
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
 #  include <stdio.h>
-   static int g_debuglog_enable = 1;
-#  define DEBUGLOG(l, ...) {                          \
-        if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
-            fprintf(stderr, __FILE__  " %i: ", __LINE__); \
-            fprintf(stderr, __VA_ARGS__);             \
-            fprintf(stderr, " \n");                   \
-    }   }
+static int g_debuglog_enable = 1;
+#  define DEBUGLOG(l, ...)                                 \
+      {                                                    \
+          if ((g_debuglog_enable) && (l <= LZ4_DEBUG)) {   \
+              fprintf(stderr, __FILE__ " %i: ", __LINE__); \
+              fprintf(stderr, __VA_ARGS__);                \
+              fprintf(stderr, " \n");                      \
+          }                                                \
+      }
 #else
-#  define DEBUGLOG(l, ...) {}    /* disabled */
+#  define DEBUGLOG(l, ...) \
+      {                    \
+      } /* disabled */
 #endif
 
 static int LZ4_isAligned(const void* ptr, size_t alignment)
 {
-    return ((size_t)ptr & (alignment -1)) == 0;
+    return ((size_t)ptr & (alignment - 1)) == 0;
 }
-
 
 /*-************************************
 *  Types
 **************************************/
 #include <limits.h>
-#if defined(__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
-# include <stdint.h>
-  typedef unsigned char BYTE; /*uint8_t not necessarily blessed to alias arbitrary type*/
-  typedef uint16_t      U16;
-  typedef uint32_t      U32;
-  typedef  int32_t      S32;
-  typedef uint64_t      U64;
-  typedef uintptr_t     uptrval;
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */)
+#  include <stdint.h>
+typedef unsigned char BYTE; /*uint8_t not necessarily blessed to alias arbitrary type*/
+typedef uint16_t      U16;
+typedef uint32_t      U32;
+typedef int32_t       S32;
+typedef uint64_t      U64;
+typedef uintptr_t     uptrval;
 #else
-# if UINT_MAX != 4294967295UL
-#   error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
-# endif
-  typedef unsigned char       BYTE;
-  typedef unsigned short      U16;
-  typedef unsigned int        U32;
-  typedef   signed int        S32;
-  typedef unsigned long long  U64;
-  typedef size_t              uptrval;   /* generally true, except OpenVMS-64 */
+#  if UINT_MAX != 4294967295UL
+#    error "LZ4 code (when not C++ or C99) assumes that sizeof(int) == 4"
+#  endif
+typedef unsigned char      BYTE;
+typedef unsigned short     U16;
+typedef unsigned int       U32;
+typedef signed int         S32;
+typedef unsigned long long U64;
+typedef size_t             uptrval;   /* generally true, except OpenVMS-64 */
 #endif
 
 #if defined(__x86_64__)
-  typedef U64    reg_t;   /* 64-bits in x32 mode */
+typedef U64 reg_t; /* 64-bits in x32 mode */
 #else
-  typedef size_t reg_t;   /* 32-bits in x32 mode */
+typedef size_t reg_t;   /* 32-bits in x32 mode */
 #endif
 
-typedef enum {
-    notLimited = 0,
-    limitedOutput = 1,
-    fillOutput = 2
-} limitedOutput_directive;
-
+typedef enum { notLimited = 0, limitedOutput = 1, fillOutput = 2 } limitedOutput_directive;
 
 /*-************************************
 *  Reading and writing into memory
@@ -363,27 +363,49 @@ typedef enum {
 
 static unsigned LZ4_isLittleEndian(void)
 {
-    const union { U32 u; BYTE c[4]; } one = { 1 };   /* don't use static : performance detrimental */
+    const union {
+        U32  u;
+        BYTE c[4];
+    } one = {1}; /* don't use static : performance detrimental */
+
     return one.c[0];
 }
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
-#define LZ4_PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#  define LZ4_PACK(__Declaration__) __Declaration__ __attribute__((__packed__))
 #elif defined(_MSC_VER)
-#define LZ4_PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop))
+#  define LZ4_PACK(__Declaration__) __pragma(pack(push, 1)) __Declaration__ __pragma(pack(pop))
 #endif
 
-#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 2)
 /* lie to the compiler about data alignment; use with caution */
 
-static U16 LZ4_read16(const void* memPtr) { return *(const U16*) memPtr; }
-static U32 LZ4_read32(const void* memPtr) { return *(const U32*) memPtr; }
-static reg_t LZ4_read_ARCH(const void* memPtr) { return *(const reg_t*) memPtr; }
+static U16 LZ4_read16(const void* memPtr)
+{
+    return *(const U16*)memPtr;
+}
 
-static void LZ4_write16(void* memPtr, U16 value) { *(U16*)memPtr = value; }
-static void LZ4_write32(void* memPtr, U32 value) { *(U32*)memPtr = value; }
+static U32 LZ4_read32(const void* memPtr)
+{
+    return *(const U32*)memPtr;
+}
 
-#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+static reg_t LZ4_read_ARCH(const void* memPtr)
+{
+    return *(const reg_t*)memPtr;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    *(U16*)memPtr = value;
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    *(U32*)memPtr = value;
+}
+
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 1)
 
 /* __pack instructions are safer, but compiler specific, hence potentially problematic for some compilers */
 /* currently only defined for gcc and icc */
@@ -391,28 +413,52 @@ LZ4_PACK(typedef struct { U16 u16; }) LZ4_unalign16;
 LZ4_PACK(typedef struct { U32 u32; }) LZ4_unalign32;
 LZ4_PACK(typedef struct { reg_t uArch; }) LZ4_unalignST;
 
-static U16 LZ4_read16(const void* ptr) { return ((const LZ4_unalign16*)ptr)->u16; }
-static U32 LZ4_read32(const void* ptr) { return ((const LZ4_unalign32*)ptr)->u32; }
-static reg_t LZ4_read_ARCH(const void* ptr) { return ((const LZ4_unalignST*)ptr)->uArch; }
+static U16 LZ4_read16(const void* ptr)
+{
+    return ((const LZ4_unalign16*)ptr)->u16;
+}
 
-static void LZ4_write16(void* memPtr, U16 value) { ((LZ4_unalign16*)memPtr)->u16 = value; }
-static void LZ4_write32(void* memPtr, U32 value) { ((LZ4_unalign32*)memPtr)->u32 = value; }
+static U32 LZ4_read32(const void* ptr)
+{
+    return ((const LZ4_unalign32*)ptr)->u32;
+}
 
-#else  /* safe and portable access using memcpy() */
+static reg_t LZ4_read_ARCH(const void* ptr)
+{
+    return ((const LZ4_unalignST*)ptr)->uArch;
+}
+
+static void LZ4_write16(void* memPtr, U16 value)
+{
+    ((LZ4_unalign16*)memPtr)->u16 = value;
+}
+
+static void LZ4_write32(void* memPtr, U32 value)
+{
+    ((LZ4_unalign32*)memPtr)->u32 = value;
+}
+
+#else /* safe and portable access using memcpy() */
 
 static U16 LZ4_read16(const void* memPtr)
 {
-    U16 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    U16 val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static U32 LZ4_read32(const void* memPtr)
 {
-    U32 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    U32 val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static reg_t LZ4_read_ARCH(const void* memPtr)
 {
-    reg_t val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    reg_t val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 static void LZ4_write16(void* memPtr, U16 value)
@@ -427,14 +473,13 @@ static void LZ4_write32(void* memPtr, U32 value)
 
 #endif /* LZ4_FORCE_MEMORY_ACCESS */
 
-
 static U16 LZ4_readLE16(const void* memPtr)
 {
     if (LZ4_isLittleEndian()) {
         return LZ4_read16(memPtr);
     } else {
         const BYTE* p = (const BYTE*)memPtr;
-        return (U16)((U16)p[0] | (p[1]<<8));
+        return (U16)((U16)p[0] | (p[1] << 8));
     }
 }
 
@@ -445,7 +490,7 @@ static U32 LZ4_readLE32(const void* memPtr)
         return LZ4_read32(memPtr);
     } else {
         const BYTE* p = (const BYTE*)memPtr;
-        return (U32)p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24);
+        return (U32)p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
     }
 }
 #endif
@@ -456,8 +501,8 @@ static void LZ4_writeLE16(void* memPtr, U16 value)
         LZ4_write16(memPtr, value);
     } else {
         BYTE* p = (BYTE*)memPtr;
-        p[0] = (BYTE) value;
-        p[1] = (BYTE)(value>>8);
+        p[0]    = (BYTE)value;
+        p[1]    = (BYTE)(value >> 8);
     }
 }
 
@@ -465,16 +510,19 @@ static void LZ4_writeLE16(void* memPtr, U16 value)
 LZ4_FORCE_INLINE
 void LZ4_wildCopy8(void* dstPtr, const void* srcPtr, void* dstEnd)
 {
-    BYTE* d = (BYTE*)dstPtr;
+    BYTE*       d = (BYTE*)dstPtr;
     const BYTE* s = (const BYTE*)srcPtr;
     BYTE* const e = (BYTE*)dstEnd;
 
-    do { LZ4_memcpy(d,s,8); d+=8; s+=8; } while (d<e);
+    do {
+        LZ4_memcpy(d, s, 8);
+        d += 8;
+        s += 8;
+    } while (d < e);
 }
 
-static const unsigned inc32table[8] = {0, 1, 2,  1,  0,  4, 4, 4};
-static const int      dec64table[8] = {0, 0, 0, -1, -4,  1, 2, 3};
-
+static const unsigned inc32table[8] = {0, 1, 2, 1, 0, 4, 4, 4};
+static const int      dec64table[8] = {0, 0, 0, -1, -4, 1, 2, 3};
 
 #ifndef LZ4_FAST_DEC_LOOP
 #  if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
@@ -493,13 +541,13 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
 {
     assert(srcPtr + offset == dstPtr);
     if (offset < 8) {
-        LZ4_write32(dstPtr, 0);   /* silence an msan warning when offset==0 */
+        LZ4_write32(dstPtr, 0); /* silence an msan warning when offset==0 */
         dstPtr[0] = srcPtr[0];
         dstPtr[1] = srcPtr[1];
         dstPtr[2] = srcPtr[2];
         dstPtr[3] = srcPtr[3];
         srcPtr += inc32table[offset];
-        LZ4_memcpy(dstPtr+4, srcPtr, 4);
+        LZ4_memcpy(dstPtr + 4, srcPtr, 4);
         srcPtr -= dec64table[offset];
         dstPtr += 8;
     } else {
@@ -514,41 +562,44 @@ LZ4_memcpy_using_offset_base(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, con
 /* customized variant of memcpy, which can overwrite up to 32 bytes beyond dstEnd
  * this version copies two times 16 bytes (instead of one time 32 bytes)
  * because it must be compatible with offsets >= 16. */
-LZ4_FORCE_INLINE void
-LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
+LZ4_FORCE_INLINE void LZ4_wildCopy32(void* dstPtr, const void* srcPtr, void* dstEnd)
 {
-    BYTE* d = (BYTE*)dstPtr;
+    BYTE*       d = (BYTE*)dstPtr;
     const BYTE* s = (const BYTE*)srcPtr;
     BYTE* const e = (BYTE*)dstEnd;
 
-    do { LZ4_memcpy(d,s,16); LZ4_memcpy(d+16,s+16,16); d+=32; s+=32; } while (d<e);
+    do {
+        LZ4_memcpy(d, s, 16);
+        LZ4_memcpy(d + 16, s + 16, 16);
+        d += 32;
+        s += 32;
+    } while (d < e);
 }
 
 /* LZ4_memcpy_using_offset()  presumes :
  * - dstEnd >= dstPtr + MINMATCH
  * - there is at least 12 bytes available to write after dstEnd */
-LZ4_FORCE_INLINE void
-LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
+LZ4_FORCE_INLINE void LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const size_t offset)
 {
     BYTE v[8];
 
     assert(dstEnd >= dstPtr + MINMATCH);
 
-    switch(offset) {
+    switch (offset) {
     case 1:
         MEM_INIT(v, *srcPtr, 8);
         break;
     case 2:
         LZ4_memcpy(v, srcPtr, 2);
         LZ4_memcpy(&v[2], srcPtr, 2);
-#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
-#  pragma warning(push)
-#  pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
-#endif
+#  if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#    pragma warning(push)
+#    pragma warning(disable : 6385) /* warning C6385: Reading invalid data from 'v'. */
+#  endif
         LZ4_memcpy(&v[4], v, 4);
-#if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
-#  pragma warning(pop)
-#endif
+#  if defined(_MSC_VER) && (_MSC_VER <= 1937) /* MSVC 2022 ver 17.7 or earlier */
+#    pragma warning(pop)
+#  endif
         break;
     case 4:
         LZ4_memcpy(v, srcPtr, 4);
@@ -568,144 +619,160 @@ LZ4_memcpy_using_offset(BYTE* dstPtr, const BYTE* srcPtr, BYTE* dstEnd, const si
 }
 #endif
 
-
 /*-************************************
 *  Common functions
 **************************************/
-static unsigned LZ4_NbCommonBytes (reg_t val)
+static unsigned LZ4_NbCommonBytes(reg_t val)
 {
     assert(val != 0);
     if (LZ4_isLittleEndian()) {
         if (sizeof(val) == 8) {
-#       if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1800) && (defined(_M_AMD64) && !defined(_M_ARM64EC)) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
 /*-*************************************************************************************************
 * ARM64EC is a Microsoft-designed ARM64 ABI compatible with AMD64 applications on ARM64 Windows 11.
 * The ARM64EC ABI does not support AVX/AVX2/AVX512 instructions, nor their relevant intrinsics
 * including _tzcnt_u64. Therefore, we need to neuter the _tzcnt_u64 code path for ARM64EC.
 ****************************************************************************************************/
-#         if defined(__clang__) && (__clang_major__ < 10)
+#  if defined(__clang__) && (__clang_major__ < 10)
             /* Avoid undefined clang-cl intrinsics issue.
              * See https://github.com/lz4/lz4/pull/1017 for details. */
             return (unsigned)__builtin_ia32_tzcnt_u64(val) >> 3;
-#         else
+#  else
             /* x64 CPUS without BMI support interpret `TZCNT` as `REP BSF` */
             return (unsigned)_tzcnt_u64(val) >> 3;
-#         endif
-#       elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#  endif
+#elif defined(_MSC_VER) && defined(_WIN64) && !defined(LZ4_FORCE_SW_BITCOUNT)
             unsigned long r = 0;
             _BitScanForward64(&r, (U64)val);
             return (unsigned)r >> 3;
-#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_ctzll((U64)val) >> 3;
-#       else
+#else
             const U64 m = 0x0101010101010101ULL;
             val ^= val - 1;
             return (unsigned)(((U64)((val & (m - 1)) * m)) >> 56);
-#       endif
+#endif
         } else /* 32 bits */ {
-#       if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
             unsigned long r;
             _BitScanForward(&r, (U32)val);
             return (unsigned)r >> 3;
-#       elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_ctz((U32)val) >> 3;
-#       else
+#else
             const U32 m = 0x01010101;
             return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
-#       endif
+#endif
         }
-    } else   /* Big Endian CPU */ {
-        if (sizeof(val)==8) {
-#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                        !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
+    } else /* Big Endian CPU */ {
+        if (sizeof(val) == 8) {
+#if (defined(__clang__) ||                                                                     \
+     (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(__TINYC__) && !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_clzll((U64)val) >> 3;
-#       else
-#if 1
+#else
+#  if 1
             /* this method is probably faster,
              * but adds a 128 bytes lookup table */
             static const unsigned char ctz7_tab[128] = {
-                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-                4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+                7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
+                1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0,
+                2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0,
+                1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0,
+                3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
             };
             U64 const mask = 0x0101010101010101ULL;
-            U64 const t = (((val >> 8) - mask) | val) & mask;
+            U64 const t    = (((val >> 8) - mask) | val) & mask;
             return ctz7_tab[(t * 0x0080402010080402ULL) >> 57];
-#else
+#  else
             /* this method doesn't consume memory space like the previous one,
              * but it contains several branches,
              * that may end up slowing execution */
-            static const U32 by32 = sizeof(val)*4;  /* 32 on 64 bits (goal), 16 on 32 bits.
+            static const U32 by32 = sizeof(val) * 4;  /* 32 on 64 bits (goal), 16 on 32 bits.
             Just to avoid some static analyzer complaining about shift by 32 on 32-bits target.
             Note that this code path is never triggered in 32-bits mode. */
-            unsigned r;
-            if (!(val>>by32)) { r=4; } else { r=0; val>>=by32; }
-            if (!(val>>16)) { r+=2; val>>=8; } else { val>>=24; }
+            unsigned         r;
+            if (!(val >> by32)) {
+                r = 4;
+            } else {
+                r = 0;
+                val >>= by32;
+            }
+            if (!(val >> 16)) {
+                r += 2;
+                val >>= 8;
+            } else {
+                val >>= 24;
+            }
             r += (!val);
             return r;
+#  endif
 #endif
-#       endif
         } else /* 32 bits */ {
-#       if (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#if (defined(__clang__) ||                                                                     \
+     (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
             return (unsigned)__builtin_clz((U32)val) >> 3;
-#       else
+#else
             val >>= 8;
-            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
-              (val + 0x00FF0000)) >> 24;
+            val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) | (val + 0x00FF0000)) >> 24;
             return (unsigned)val ^ 3;
-#       endif
+#endif
         }
     }
 }
 
-
 #define STEPSIZE sizeof(reg_t)
+
 LZ4_FORCE_INLINE
 unsigned LZ4_count(const BYTE* pIn, const BYTE* pMatch, const BYTE* pInLimit)
 {
     const BYTE* const pStart = pIn;
 
-    if (likely(pIn < pInLimit-(STEPSIZE-1))) {
-        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+    if (likely(pIn < pInLimit - (STEPSIZE - 1))) {
+        const reg_t diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
         if (!diff) {
-            pIn+=STEPSIZE; pMatch+=STEPSIZE;
+            pIn += STEPSIZE;
+            pMatch += STEPSIZE;
         } else {
             return LZ4_NbCommonBytes(diff);
-    }   }
+        }
+    }
 
-    while (likely(pIn < pInLimit-(STEPSIZE-1))) {
-        reg_t const diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
-        if (!diff) { pIn+=STEPSIZE; pMatch+=STEPSIZE; continue; }
+    while (likely(pIn < pInLimit - (STEPSIZE - 1))) {
+        const reg_t diff = LZ4_read_ARCH(pMatch) ^ LZ4_read_ARCH(pIn);
+        if (!diff) {
+            pIn += STEPSIZE;
+            pMatch += STEPSIZE;
+            continue;
+        }
         pIn += LZ4_NbCommonBytes(diff);
         return (unsigned)(pIn - pStart);
     }
 
-    if ((STEPSIZE==8) && (pIn<(pInLimit-3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) { pIn+=4; pMatch+=4; }
-    if ((pIn<(pInLimit-1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) { pIn+=2; pMatch+=2; }
-    if ((pIn<pInLimit) && (*pMatch == *pIn)) pIn++;
+    if ((STEPSIZE == 8) && (pIn < (pInLimit - 3)) && (LZ4_read32(pMatch) == LZ4_read32(pIn))) {
+        pIn += 4;
+        pMatch += 4;
+    }
+    if ((pIn < (pInLimit - 1)) && (LZ4_read16(pMatch) == LZ4_read16(pIn))) {
+        pIn += 2;
+        pMatch += 2;
+    }
+    if ((pIn < pInLimit) && (*pMatch == *pIn)) pIn++;
     return (unsigned)(pIn - pStart);
 }
-
 
 #ifndef LZ4_COMMONDEFS_ONLY
 /*-************************************
 *  Local Constants
 **************************************/
-static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT-1));
-static const U32 LZ4_skipTrigger = 6;  /* Increase this value ==> compression run slower on incompressible data */
-
+static const int LZ4_64Klimit = ((64 KB) + (MFLIMIT - 1));
+static const U32 LZ4_skipTrigger = 6; /* Increase this value ==> compression run slower on incompressible data */
 
 /*-************************************
 *  Local Structures and types
@@ -736,51 +803,70 @@ typedef enum { clearedTable = 0, byPtr, byU32, byU16 } tableType_t;
  *                   ->dictCtx->hashTable.
  */
 typedef enum { noDict = 0, withPrefix64k, usingExtDict, usingDictCtx } dict_directive;
-typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
 
+typedef enum { noDictIssue = 0, dictSmall } dictIssue_directive;
 
 /*-************************************
 *  Local Utils
 **************************************/
-int LZ4_versionNumber (void) { return LZ4_VERSION_NUMBER; }
-const char* LZ4_versionString(void) { return LZ4_VERSION_STRING; }
-int LZ4_compressBound(int isize)  { return LZ4_COMPRESSBOUND(isize); }
-int LZ4_sizeofState(void) { return sizeof(LZ4_stream_t); }
+int LZ4_versionNumber(void)
+{
+    return LZ4_VERSION_NUMBER;
+}
 
+const char* LZ4_versionString(void)
+{
+    return LZ4_VERSION_STRING;
+}
+
+int LZ4_compressBound(int isize)
+{
+    return LZ4_COMPRESSBOUND(isize);
+}
+
+int LZ4_sizeofState(void)
+{
+    return sizeof(LZ4_stream_t);
+}
 
 /*-****************************************
 *  Internal Definitions, used only in Tests
 *******************************************/
-#if defined (__cplusplus)
+#  if defined(__cplusplus)
 extern "C" {
-#endif
+#  endif
 
-int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
+int LZ4_compress_forceExtDict(LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize);
 
-int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int maxOutputSize,
-                                     const void* dictStart, size_t dictSize);
-int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int targetOutputSize, int dstCapacity,
-                                     const void* dictStart, size_t dictSize);
-#if defined (__cplusplus)
+int LZ4_decompress_safe_forceExtDict(const char* source,
+                                     char*       dest,
+                                     int         compressedSize,
+                                     int         maxOutputSize,
+                                     const void* dictStart,
+                                     size_t      dictSize);
+int LZ4_decompress_safe_partial_forceExtDict(const char* source,
+                                             char*       dest,
+                                             int         compressedSize,
+                                             int         targetOutputSize,
+                                             int         dstCapacity,
+                                             const void* dictStart,
+                                             size_t      dictSize);
+#  if defined(__cplusplus)
 }
-#endif
+#  endif
 
 /*-******************************
 *  Compression functions
 ********************************/
-LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash4(U32 sequence, const tableType_t tableType)
 {
-    if (tableType == byU16)
-        return ((sequence * 2654435761U) >> ((MINMATCH*8)-(LZ4_HASHLOG+1)));
-    else
-        return ((sequence * 2654435761U) >> ((MINMATCH*8)-LZ4_HASHLOG));
+    if (tableType == byU16) return (sequence * 2654435761U) >> ((MINMATCH * 8) - (LZ4_HASHLOG + 1));
+    else return (sequence * 2654435761U) >> ((MINMATCH * 8) - LZ4_HASHLOG);
 }
 
-LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, const tableType_t tableType)
 {
-    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG+1 : LZ4_HASHLOG;
+    const U32 hashLog = (tableType == byU16) ? LZ4_HASHLOG + 1 : LZ4_HASHLOG;
     if (LZ4_isLittleEndian()) {
         const U64 prime5bytes = 889523592379ULL;
         return (U32)(((sequence << 24) * prime5bytes) >> (64 - hashLog));
@@ -790,47 +876,72 @@ LZ4_FORCE_INLINE U32 LZ4_hash5(U64 sequence, tableType_t const tableType)
     }
 }
 
-LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, tableType_t const tableType)
+LZ4_FORCE_INLINE U32 LZ4_hashPosition(const void* const p, const tableType_t tableType)
 {
-    if ((sizeof(reg_t)==8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
+    if ((sizeof(reg_t) == 8) && (tableType != byU16)) return LZ4_hash5(LZ4_read_ARCH(p), tableType);
 
-#ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
+#  ifdef LZ4_STATIC_LINKING_ONLY_ENDIANNESS_INDEPENDENT_OUTPUT
     return LZ4_hash4(LZ4_readLE32(p), tableType);
-#else
+#  else
     return LZ4_hash4(LZ4_read32(p), tableType);
-#endif
+#  endif
 }
 
-LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_clearHash(U32 h, void* tableBase, const tableType_t tableType)
 {
-    switch (tableType)
-    {
+    switch (tableType) {
     default: /* fallthrough */
-    case clearedTable: { /* illegal! */ assert(0); return; }
-    case byPtr: { const BYTE** hashTable = (const BYTE**)tableBase; hashTable[h] = NULL; return; }
-    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = 0; return; }
-    case byU16: { U16* hashTable = (U16*) tableBase; hashTable[h] = 0; return; }
+    case clearedTable: { /* illegal! */
+        assert(0);
+        return;
+    }
+    case byPtr: {
+        const BYTE** hashTable = (const BYTE**)tableBase;
+        hashTable[h]           = NULL;
+        return;
+    }
+    case byU32: {
+        U32* hashTable = (U32*)tableBase;
+        hashTable[h]   = 0;
+        return;
+    }
+    case byU16: {
+        U16* hashTable = (U16*)tableBase;
+        hashTable[h]   = 0;
+        return;
+    }
     }
 }
 
-LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_putIndexOnHash(U32 idx, U32 h, void* tableBase, const tableType_t tableType)
 {
-    switch (tableType)
-    {
+    switch (tableType) {
     default: /* fallthrough */
     case clearedTable: /* fallthrough */
-    case byPtr: { /* illegal! */ assert(0); return; }
-    case byU32: { U32* hashTable = (U32*) tableBase; hashTable[h] = idx; return; }
-    case byU16: { U16* hashTable = (U16*) tableBase; assert(idx < 65536); hashTable[h] = (U16)idx; return; }
+    case byPtr: { /* illegal! */
+        assert(0);
+        return;
+    }
+    case byU32: {
+        U32* hashTable = (U32*)tableBase;
+        hashTable[h]   = idx;
+        return;
+    }
+    case byU16: {
+        U16* hashTable = (U16*)tableBase;
+        assert(idx < 65536);
+        hashTable[h] = (U16)idx;
+        return;
+    }
     }
 }
 
 /* LZ4_putPosition*() : only used in byPtr mode */
-LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h,
-                                  void* tableBase, tableType_t const tableType)
+LZ4_FORCE_INLINE void LZ4_putPositionOnHash(const BYTE* p, U32 h, void* tableBase, const tableType_t tableType)
 {
     const BYTE** const hashTable = (const BYTE**)tableBase;
-    assert(tableType == byPtr); (void)tableType;
+    assert(tableType == byPtr);
+    (void)tableType;
     hashTable[h] = p;
 }
 
@@ -850,52 +961,51 @@ LZ4_FORCE_INLINE U32 LZ4_getIndexOnHash(U32 h, const void* tableBase, tableType_
 {
     LZ4_STATIC_ASSERT(LZ4_MEMORY_USAGE > 2);
     if (tableType == byU32) {
-        const U32* const hashTable = (const U32*) tableBase;
-        assert(h < (1U << (LZ4_MEMORY_USAGE-2)));
+        const U32* const hashTable = (const U32*)tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE - 2)));
         return hashTable[h];
     }
     if (tableType == byU16) {
-        const U16* const hashTable = (const U16*) tableBase;
-        assert(h < (1U << (LZ4_MEMORY_USAGE-1)));
+        const U16* const hashTable = (const U16*)tableBase;
+        assert(h < (1U << (LZ4_MEMORY_USAGE - 1)));
         return hashTable[h];
     }
-    assert(0); return 0;  /* forbidden case */
+    assert(0);
+    return 0; /* forbidden case */
 }
 
 static const BYTE* LZ4_getPositionOnHash(U32 h, const void* tableBase, tableType_t tableType)
 {
-    assert(tableType == byPtr); (void)tableType;
-    { const BYTE* const* hashTable = (const BYTE* const*) tableBase; return hashTable[h]; }
+    assert(tableType == byPtr);
+    (void)tableType;
+    {
+        const BYTE* const* hashTable = (const BYTE* const*)tableBase;
+        return hashTable[h];
+    }
 }
 
-LZ4_FORCE_INLINE const BYTE*
-LZ4_getPosition(const BYTE* p,
-                const void* tableBase, tableType_t tableType)
+LZ4_FORCE_INLINE const BYTE* LZ4_getPosition(const BYTE* p, const void* tableBase, tableType_t tableType)
 {
     U32 const h = LZ4_hashPosition(p, tableType);
     return LZ4_getPositionOnHash(h, tableBase, tableType);
 }
 
 LZ4_FORCE_INLINE void
-LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
-           const int inputSize,
-           const tableType_t tableType) {
+LZ4_prepareTable(LZ4_stream_t_internal* const cctx, const int inputSize, const tableType_t tableType)
+{
     /* If the table hasn't been used, it's guaranteed to be zeroed out, and is
      * therefore safe to use no matter what mode we're in. Otherwise, we figure
      * out if it's safe to leave as is or whether it needs to be reset.
      */
     if ((tableType_t)cctx->tableType != clearedTable) {
         assert(inputSize >= 0);
-        if ((tableType_t)cctx->tableType != tableType
-          || ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU)
-          || ((tableType == byU32) && cctx->currentOffset > 1 GB)
-          || tableType == byPtr
-          || inputSize >= 4 KB)
-        {
+        if ((tableType_t)cctx->tableType != tableType ||
+            ((tableType == byU16) && cctx->currentOffset + (unsigned)inputSize >= 0xFFFFU) ||
+            ((tableType == byU32) && cctx->currentOffset > 1 GB) || tableType == byPtr || inputSize >= 4 KB) {
             DEBUGLOG(4, "LZ4_prepareTable: Resetting table in %p", (void*)cctx);
             MEM_INIT(cctx->hashTable, 0, LZ4_HASHTABLESIZE);
             cctx->currentOffset = 0;
-            cctx->tableType = (U32)clearedTable;
+            cctx->tableType     = (U32)clearedTable;
         } else {
             DEBUGLOG(4, "LZ4_prepareTable: Re-use hash table (no reset)");
         }
@@ -912,9 +1022,9 @@ LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
     }
 
     /* Finally, clear history */
-    cctx->dictCtx = NULL;
+    cctx->dictCtx    = NULL;
     cctx->dictionary = NULL;
-    cctx->dictSize = 0;
+    cctx->dictSize   = 0;
 }
 
 /** LZ4_compress_generic_validated() :
@@ -923,50 +1033,48 @@ LZ4_prepareTable(LZ4_stream_t_internal* const cctx,
  *  - source != NULL
  *  - inputSize > 0
  */
-LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
-                 LZ4_stream_t_internal* const cctx,
-                 const char* const source,
-                 char* const dest,
-                 const int inputSize,
-                 int*  inputConsumed, /* only written when outputDirective == fillOutput */
-                 const int maxOutputSize,
-                 const limitedOutput_directive outputDirective,
-                 const tableType_t tableType,
-                 const dict_directive dictDirective,
-                 const dictIssue_directive dictIssue,
-                 const int acceleration)
+LZ4_FORCE_INLINE int
+LZ4_compress_generic_validated(LZ4_stream_t_internal* const cctx,
+                               const char* const            source,
+                               char* const                  dest,
+                               const int                    inputSize,
+                               int*      inputConsumed, /* only written when outputDirective == fillOutput */
+                               const int maxOutputSize,
+                               const limitedOutput_directive outputDirective,
+                               const tableType_t             tableType,
+                               const dict_directive          dictDirective,
+                               const dictIssue_directive     dictIssue,
+                               const int                     acceleration)
 {
-    int result;
+    int         result;
     const BYTE* ip = (const BYTE*)source;
 
-    U32 const startIndex = cctx->currentOffset;
-    const BYTE* base = (const BYTE*)source - startIndex;
+    U32 const   startIndex = cctx->currentOffset;
+    const BYTE* base       = (const BYTE*)source - startIndex;
     const BYTE* lowLimit;
 
-    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*) cctx->dictCtx;
-    const BYTE* const dictionary =
-        dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
-    const U32 dictSize =
-        dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
-    const U32 dictDelta =
-        (dictDirective == usingDictCtx) ? startIndex - dictCtx->currentOffset : 0;   /* make indexes in dictCtx comparable with indexes in current context */
+    const LZ4_stream_t_internal* dictCtx = (const LZ4_stream_t_internal*)cctx->dictCtx;
+    const BYTE* const dictionary = dictDirective == usingDictCtx ? dictCtx->dictionary : cctx->dictionary;
+    const U32         dictSize   = dictDirective == usingDictCtx ? dictCtx->dictSize : cctx->dictSize;
+    const U32 dictDelta = (dictDirective == usingDictCtx)
+                              ? startIndex - dictCtx->currentOffset
+                              : 0; /* make indexes in dictCtx comparable with indexes in current context */
 
-    int const maybe_extMem = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
-    U32 const prefixIdxLimit = startIndex - dictSize;   /* used when dictDirective == dictSmall */
-    const BYTE* const dictEnd = dictionary ? dictionary + dictSize : dictionary;
-    const BYTE* anchor = (const BYTE*) source;
-    const BYTE* const iend = ip + inputSize;
+    const int         maybe_extMem   = (dictDirective == usingExtDict) || (dictDirective == usingDictCtx);
+    U32 const         prefixIdxLimit = startIndex - dictSize; /* used when dictDirective == dictSmall */
+    const BYTE* const dictEnd        = dictionary ? dictionary + dictSize : dictionary;
+    const BYTE*       anchor         = (const BYTE*)source;
+    const BYTE* const iend           = ip + inputSize;
     const BYTE* const mflimitPlusOne = iend - MFLIMIT + 1;
-    const BYTE* const matchlimit = iend - LASTLITERALS;
+    const BYTE* const matchlimit     = iend - LASTLITERALS;
 
     /* the dictCtx currentOffset is indexed on the start of the dictionary,
      * while a dictionary in the current context precedes the currentOffset */
-    const BYTE* dictBase = (dictionary == NULL) ? NULL :
-                           (dictDirective == usingDictCtx) ?
-                            dictionary + dictSize - dictCtx->currentOffset :
-                            dictionary + dictSize - startIndex;
+    const BYTE* dictBase = (dictionary == NULL)              ? NULL
+                           : (dictDirective == usingDictCtx) ? dictionary + dictSize - dictCtx->currentOffset
+                                                             : dictionary + dictSize - startIndex;
 
-    BYTE* op = (BYTE*) dest;
+    BYTE*       op     = (BYTE*)dest;
     BYTE* const olimit = op + maxOutputSize;
 
     U32 offset = 0;
@@ -974,11 +1082,13 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
 
     DEBUGLOG(5, "LZ4_compress_generic_validated: srcSize=%i, tableType=%u", inputSize, tableType);
     assert(ip != NULL);
-    if (tableType == byU16) assert(inputSize<LZ4_64Klimit);  /* Size too large (not within 64K limit) */
-    if (tableType == byPtr) assert(dictDirective==noDict);   /* only supported use case with byPtr */
+    if (tableType == byU16) assert(inputSize < LZ4_64Klimit); /* Size too large (not within 64K limit) */
+    if (tableType == byPtr) assert(dictDirective == noDict); /* only supported use case with byPtr */
     /* If init conditions are not met, we don't have to mark stream
      * as having dirty context, since no action was taken yet */
-    if (outputDirective == fillOutput && maxOutputSize < 1) { return 0; } /* Impossible to store anything */
+    if (outputDirective == fillOutput && maxOutputSize < 1) {
+        return 0;
+    } /* Impossible to store anything */
     assert(acceleration >= 1);
 
     lowLimit = (const BYTE*)source - (dictDirective == withPrefix64k ? dictSize : 0);
@@ -987,7 +1097,7 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
     if (dictDirective == usingDictCtx) {
         /* Subsequent linked blocks can't use the dictionary. */
         /* Instead, they use the block we just compressed. */
-        cctx->dictCtx = NULL;
+        cctx->dictCtx  = NULL;
         cctx->dictSize = (U32)inputSize;
     } else {
         cctx->dictSize += (U32)inputSize;
@@ -995,53 +1105,55 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
     cctx->currentOffset += (U32)inputSize;
     cctx->tableType = (U32)tableType;
 
-    if (inputSize<LZ4_minLength) goto _last_literals;        /* Input too small, no compression (all literals) */
+    if (inputSize < LZ4_minLength) goto _last_literals; /* Input too small, no compression (all literals) */
 
     /* First Byte */
-    {   U32 const h = LZ4_hashPosition(ip, tableType);
+    {
+        U32 const h = LZ4_hashPosition(ip, tableType);
         if (tableType == byPtr) {
             LZ4_putPositionOnHash(ip, h, cctx->hashTable, byPtr);
         } else {
             LZ4_putIndexOnHash(startIndex, h, cctx->hashTable, tableType);
-    }   }
-    ip++; forwardH = LZ4_hashPosition(ip, tableType);
+        }
+    }
+    ip++;
+    forwardH = LZ4_hashPosition(ip, tableType);
 
     /* Main Loop */
-    for ( ; ; ) {
+    for (;;) {
         const BYTE* match;
-        BYTE* token;
+        BYTE*       token;
         const BYTE* filledIp;
 
         /* Find a match */
         if (tableType == byPtr) {
-            const BYTE* forwardIp = ip;
-            int step = 1;
-            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            const BYTE* forwardIp     = ip;
+            int         step          = 1;
+            int         searchMatchNb = acceleration << LZ4_skipTrigger;
             do {
                 U32 const h = forwardH;
-                ip = forwardIp;
+                ip          = forwardIp;
                 forwardIp += step;
                 step = (searchMatchNb++ >> LZ4_skipTrigger);
 
                 if (unlikely(forwardIp > mflimitPlusOne)) goto _last_literals;
                 assert(ip < mflimitPlusOne);
 
-                match = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
+                match    = LZ4_getPositionOnHash(h, cctx->hashTable, tableType);
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putPositionOnHash(ip, h, cctx->hashTable, tableType);
 
-            } while ( (match+LZ4_DISTANCE_MAX < ip)
-                   || (LZ4_read32(match) != LZ4_read32(ip)) );
+            } while ((match + LZ4_DISTANCE_MAX < ip) || (LZ4_read32(match) != LZ4_read32(ip)));
 
-        } else {   /* byU32, byU16 */
+        } else { /* byU32, byU16 */
 
-            const BYTE* forwardIp = ip;
-            int step = 1;
-            int searchMatchNb = acceleration << LZ4_skipTrigger;
+            const BYTE* forwardIp     = ip;
+            int         step          = 1;
+            int         searchMatchNb = acceleration << LZ4_skipTrigger;
             do {
-                U32 const h = forwardH;
-                U32 const current = (U32)(forwardIp - base);
-                U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+                U32 const h          = forwardH;
+                U32 const current    = (U32)(forwardIp - base);
+                U32       matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
                 assert(matchIndex <= current);
                 assert(forwardIp - base < (ptrdiff_t)(2 GB - 1));
                 ip = forwardIp;
@@ -1056,79 +1168,89 @@ LZ4_FORCE_INLINE int LZ4_compress_generic_validated(
                         /* there was no match, try the dictionary */
                         assert(tableType == byU32);
                         matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
-                        match = dictBase + matchIndex;
-                        matchIndex += dictDelta;   /* make dictCtx index comparable with current context */
+                        match      = dictBase + matchIndex;
+                        matchIndex += dictDelta; /* make dictCtx index comparable with current context */
                         lowLimit = dictionary;
                     } else {
-                        match = base + matchIndex;
+                        match    = base + matchIndex;
                         lowLimit = (const BYTE*)source;
                     }
                 } else if (dictDirective == usingExtDict) {
                     if (matchIndex < startIndex) {
-                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex, startIndex);
+                        DEBUGLOG(7, "extDict candidate: matchIndex=%5u  <  startIndex=%5u", matchIndex,
+                                 startIndex);
                         assert(startIndex - matchIndex >= MINMATCH);
                         assert(dictBase);
-                        match = dictBase + matchIndex;
+                        match    = dictBase + matchIndex;
                         lowLimit = dictionary;
                     } else {
-                        match = base + matchIndex;
+                        match    = base + matchIndex;
                         lowLimit = (const BYTE*)source;
                     }
-                } else {   /* single continuous memory segment */
+                } else { /* single continuous memory segment */
                     match = base + matchIndex;
                 }
                 forwardH = LZ4_hashPosition(forwardIp, tableType);
                 LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
 
                 DEBUGLOG(7, "candidate at pos=%u  (offset=%u \n", matchIndex, current - matchIndex);
-                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) { continue; }    /* match outside of valid area */
+                if ((dictIssue == dictSmall) && (matchIndex < prefixIdxLimit)) {
+                    continue;
+                } /* match outside of valid area */
                 assert(matchIndex < current);
-                if ( ((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX))
-                  && (matchIndex+LZ4_DISTANCE_MAX < current)) {
+                if (((tableType != byU16) || (LZ4_DISTANCE_MAX < LZ4_DISTANCE_ABSOLUTE_MAX)) &&
+                    (matchIndex + LZ4_DISTANCE_MAX < current)) {
                     continue;
                 } /* too far */
-                assert((current - matchIndex) <= LZ4_DISTANCE_MAX);  /* match now expected within distance */
+                assert((current - matchIndex) <= LZ4_DISTANCE_MAX); /* match now expected within distance */
 
                 if (LZ4_read32(match) == LZ4_read32(ip)) {
                     if (maybe_extMem) offset = current - matchIndex;
-                    break;   /* match found */
+                    break; /* match found */
                 }
 
-            } while(1);
+            } while (1);
         }
 
         /* Catch up */
         filledIp = ip;
         assert(ip > anchor); /* this is always true as ip has been advanced before entering the main loop */
         if ((match > lowLimit) && unlikely(ip[-1] == match[-1])) {
-            do { ip--; match--; } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
+            do {
+                ip--;
+                match--;
+            } while (((ip > anchor) & (match > lowLimit)) && (unlikely(ip[-1] == match[-1])));
         }
 
         /* Encode Literals */
-        {   unsigned const litLength = (unsigned)(ip - anchor);
-            token = op++;
-            if ((outputDirective == limitedOutput) &&  /* Check output buffer overflow */
-                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength/255) > olimit)) ) {
-                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+        {
+            const unsigned litLength = (unsigned)(ip - anchor);
+            token                    = op++;
+            if ((outputDirective == limitedOutput) && /* Check output buffer overflow */
+                (unlikely(op + litLength + (2 + 1 + LASTLITERALS) + (litLength / 255) > olimit))) {
+                return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
             }
             if ((outputDirective == fillOutput) &&
-                (unlikely(op + (litLength+240)/255 /* litlen */ + litLength /* literals */ + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit))) {
+                (unlikely(op + (litLength + 240) / 255 /* litlen */ + litLength /* literals */ +
+                              2 /* offset */ + 1 /* token */ + MFLIMIT -
+                              MINMATCH /* min last literals so last match is <= end - MFLIMIT */
+                          > olimit))) {
                 op--;
                 goto _last_literals;
             }
             if (litLength >= RUN_MASK) {
                 unsigned len = litLength - RUN_MASK;
-                *token = (RUN_MASK<<ML_BITS);
-                for(; len >= 255 ; len-=255) *op++ = 255;
+                *token       = (RUN_MASK << ML_BITS);
+                for (; len >= 255; len -= 255)
+                    *op++ = 255;
                 *op++ = (BYTE)len;
-            }
-            else *token = (BYTE)(litLength<<ML_BITS);
+            } else *token = (BYTE)(litLength << ML_BITS);
 
             /* Copy Literals */
-            LZ4_wildCopy8(op, anchor, op+litLength);
-            op+=litLength;
-            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
-                        (int)(anchor-(const BYTE*)source), litLength, (int)(ip-(const BYTE*)source));
+            LZ4_wildCopy8(op, anchor, op + litLength);
+            op += litLength;
+            DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i", (int)(anchor - (const BYTE*)source),
+                     litLength, (int)(ip - (const BYTE*)source));
         }
 
 _next_match:
@@ -1141,50 +1263,55 @@ _next_match:
          */
 
         if ((outputDirective == fillOutput) &&
-            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ > olimit)) {
+            (op + 2 /* offset */ + 1 /* token */ + MFLIMIT - MINMATCH /* min last literals so last match is <= end - MFLIMIT */ >
+             olimit)) {
             /* the match was too close to the end, rewind and go to last literals */
             op = token;
             goto _last_literals;
         }
 
         /* Encode Offset */
-        if (maybe_extMem) {   /* static test */
+        if (maybe_extMem) { /* static test */
             DEBUGLOG(6, "             with offset=%u  (ext if > %i)", offset, (int)(ip - (const BYTE*)source));
             assert(offset <= LZ4_DISTANCE_MAX && offset > 0);
-            LZ4_writeLE16(op, (U16)offset); op+=2;
-        } else  {
+            LZ4_writeLE16(op, (U16)offset);
+            op += 2;
+        } else {
             DEBUGLOG(6, "             with offset=%u  (same segment)", (U32)(ip - match));
-            assert(ip-match <= LZ4_DISTANCE_MAX);
-            LZ4_writeLE16(op, (U16)(ip - match)); op+=2;
+            assert(ip - match <= LZ4_DISTANCE_MAX);
+            LZ4_writeLE16(op, (U16)(ip - match));
+            op += 2;
         }
 
         /* Encode MatchLength */
-        {   unsigned matchCode;
+        {
+            unsigned matchCode;
 
-            if ( (dictDirective==usingExtDict || dictDirective==usingDictCtx)
-              && (lowLimit==dictionary) /* match within extDict */ ) {
-                const BYTE* limit = ip + (dictEnd-match);
+            if ((dictDirective == usingExtDict || dictDirective == usingDictCtx) &&
+                (lowLimit == dictionary) /* match within extDict */) {
+                const BYTE* limit = ip + (dictEnd - match);
                 assert(dictEnd > match);
                 if (limit > matchlimit) limit = matchlimit;
-                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, limit);
+                matchCode = LZ4_count(ip + MINMATCH, match + MINMATCH, limit);
                 ip += (size_t)matchCode + MINMATCH;
-                if (ip==limit) {
-                    unsigned const more = LZ4_count(limit, (const BYTE*)source, matchlimit);
+                if (ip == limit) {
+                    const unsigned more = LZ4_count(limit, (const BYTE*)source, matchlimit);
                     matchCode += more;
                     ip += more;
                 }
-                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode+MINMATCH);
+                DEBUGLOG(6, "             with matchLength=%u starting in extDict", matchCode + MINMATCH);
             } else {
-                matchCode = LZ4_count(ip+MINMATCH, match+MINMATCH, matchlimit);
+                matchCode = LZ4_count(ip + MINMATCH, match + MINMATCH, matchlimit);
                 ip += (size_t)matchCode + MINMATCH;
-                DEBUGLOG(6, "             with matchLength=%u", matchCode+MINMATCH);
+                DEBUGLOG(6, "             with matchLength=%u", matchCode + MINMATCH);
             }
 
-            if ((outputDirective) &&    /* Check output buffer overflow */
-                (unlikely(op + (1 + LASTLITERALS) + (matchCode+240)/255 > olimit)) ) {
+            if ((outputDirective) && /* Check output buffer overflow */
+                (unlikely(op + (1 + LASTLITERALS) + (matchCode + 240) / 255 > olimit))) {
                 if (outputDirective == fillOutput) {
                     /* Match description too long : reduce it */
-                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ + ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
+                    U32 newMatchCode = 15 /* in token */ - 1 /* to avoid needing a zero byte */ +
+                                       ((U32)(olimit - op) - 1 - LASTLITERALS) * 255;
                     ip -= matchCode - newMatchCode;
                     assert(newMatchCode < matchCode);
                     matchCode = newMatchCode;
@@ -1203,22 +1330,21 @@ _next_match:
                     }
                 } else {
                     assert(outputDirective == limitedOutput);
-                    return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                    return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
                 }
             }
             if (matchCode >= ML_MASK) {
                 *token += ML_MASK;
                 matchCode -= ML_MASK;
                 LZ4_write32(op, 0xFFFFFFFF);
-                while (matchCode >= 4*255) {
-                    op+=4;
+                while (matchCode >= 4 * 255) {
+                    op += 4;
                     LZ4_write32(op, 0xFFFFFFFF);
-                    matchCode -= 4*255;
+                    matchCode -= 4 * 255;
                 }
                 op += matchCode / 255;
                 *op++ = (BYTE)(matchCode % 255);
-            } else
-                *token += (BYTE)(matchCode);
+            } else *token += (BYTE)(matchCode);
         }
         /* Ensure we have enough space for the last literals. */
         assert(!(outputDirective == fillOutput && op + 1 + LASTLITERALS > olimit));
@@ -1229,95 +1355,101 @@ _next_match:
         if (ip >= mflimitPlusOne) break;
 
         /* Fill table */
-        {   U32 const h = LZ4_hashPosition(ip-2, tableType);
+        {
+            U32 const h = LZ4_hashPosition(ip - 2, tableType);
             if (tableType == byPtr) {
-                LZ4_putPositionOnHash(ip-2, h, cctx->hashTable, byPtr);
+                LZ4_putPositionOnHash(ip - 2, h, cctx->hashTable, byPtr);
             } else {
-                U32 const idx = (U32)((ip-2) - base);
+                U32 const idx = (U32)((ip - 2) - base);
                 LZ4_putIndexOnHash(idx, h, cctx->hashTable, tableType);
-        }   }
+            }
+        }
 
         /* Test next position */
         if (tableType == byPtr) {
-
             match = LZ4_getPosition(ip, cctx->hashTable, tableType);
             LZ4_putPosition(ip, cctx->hashTable, tableType);
-            if ( (match+LZ4_DISTANCE_MAX >= ip)
-              && (LZ4_read32(match) == LZ4_read32(ip)) )
-            { token=op++; *token=0; goto _next_match; }
+            if ((match + LZ4_DISTANCE_MAX >= ip) && (LZ4_read32(match) == LZ4_read32(ip))) {
+                token  = op++;
+                *token = 0;
+                goto _next_match;
+            }
 
-        } else {   /* byU32, byU16 */
+        } else { /* byU32, byU16 */
 
-            U32 const h = LZ4_hashPosition(ip, tableType);
-            U32 const current = (U32)(ip-base);
-            U32 matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
+            U32 const h          = LZ4_hashPosition(ip, tableType);
+            U32 const current    = (U32)(ip - base);
+            U32       matchIndex = LZ4_getIndexOnHash(h, cctx->hashTable, tableType);
             assert(matchIndex < current);
             if (dictDirective == usingDictCtx) {
                 if (matchIndex < startIndex) {
                     /* there was no match, try the dictionary */
                     assert(tableType == byU32);
                     matchIndex = LZ4_getIndexOnHash(h, dictCtx->hashTable, byU32);
-                    match = dictBase + matchIndex;
-                    lowLimit = dictionary;   /* required for match length counter */
+                    match      = dictBase + matchIndex;
+                    lowLimit   = dictionary; /* required for match length counter */
                     matchIndex += dictDelta;
                 } else {
-                    match = base + matchIndex;
-                    lowLimit = (const BYTE*)source;  /* required for match length counter */
+                    match    = base + matchIndex;
+                    lowLimit = (const BYTE*)source; /* required for match length counter */
                 }
-            } else if (dictDirective==usingExtDict) {
+            } else if (dictDirective == usingExtDict) {
                 if (matchIndex < startIndex) {
                     assert(dictBase);
-                    match = dictBase + matchIndex;
-                    lowLimit = dictionary;   /* required for match length counter */
+                    match    = dictBase + matchIndex;
+                    lowLimit = dictionary; /* required for match length counter */
                 } else {
-                    match = base + matchIndex;
-                    lowLimit = (const BYTE*)source;   /* required for match length counter */
+                    match    = base + matchIndex;
+                    lowLimit = (const BYTE*)source; /* required for match length counter */
                 }
-            } else {   /* single memory segment */
+            } else { /* single memory segment */
                 match = base + matchIndex;
             }
             LZ4_putIndexOnHash(current, h, cctx->hashTable, tableType);
             assert(matchIndex < current);
-            if ( ((dictIssue==dictSmall) ? (matchIndex >= prefixIdxLimit) : 1)
-              && (((tableType==byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX)) ? 1 : (matchIndex+LZ4_DISTANCE_MAX >= current))
-              && (LZ4_read32(match) == LZ4_read32(ip)) ) {
-                token=op++;
-                *token=0;
+            if (((dictIssue == dictSmall) ? (matchIndex >= prefixIdxLimit) : 1) &&
+                (((tableType == byU16) && (LZ4_DISTANCE_MAX == LZ4_DISTANCE_ABSOLUTE_MAX))
+                     ? 1
+                     : (matchIndex + LZ4_DISTANCE_MAX >= current)) &&
+                (LZ4_read32(match) == LZ4_read32(ip))) {
+                token  = op++;
+                *token = 0;
                 if (maybe_extMem) offset = current - matchIndex;
-                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i",
-                            (int)(anchor-(const BYTE*)source), 0, (int)(ip-(const BYTE*)source));
+                DEBUGLOG(6, "seq.start:%i, literals=%u, match.start:%i", (int)(anchor - (const BYTE*)source),
+                         0, (int)(ip - (const BYTE*)source));
                 goto _next_match;
             }
         }
 
         /* Prepare next loop */
         forwardH = LZ4_hashPosition(++ip, tableType);
-
     }
 
 _last_literals:
     /* Encode Last Literals */
-    {   size_t lastRun = (size_t)(iend - anchor);
-        if ( (outputDirective) &&  /* Check output buffer overflow */
-            (op + lastRun + 1 + ((lastRun+255-RUN_MASK)/255) > olimit)) {
+    {
+        size_t lastRun = (size_t)(iend - anchor);
+        if ((outputDirective) && /* Check output buffer overflow */
+            (op + lastRun + 1 + ((lastRun + 255 - RUN_MASK) / 255) > olimit)) {
             if (outputDirective == fillOutput) {
                 /* adapt lastRun to fill 'dst' */
                 assert(olimit >= op);
-                lastRun  = (size_t)(olimit-op) - 1/*token*/;
-                lastRun -= (lastRun + 256 - RUN_MASK) / 256;  /*additional length tokens*/
+                lastRun = (size_t)(olimit - op) - 1 /*token*/;
+                lastRun -= (lastRun + 256 - RUN_MASK) / 256; /*additional length tokens*/
             } else {
                 assert(outputDirective == limitedOutput);
-                return 0;   /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
+                return 0; /* cannot compress within `dst` budget. Stored indexes in hash table are nonetheless fine */
             }
         }
         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRun);
         if (lastRun >= RUN_MASK) {
             size_t accumulator = lastRun - RUN_MASK;
-            *op++ = RUN_MASK << ML_BITS;
-            for(; accumulator >= 255 ; accumulator-=255) *op++ = 255;
-            *op++ = (BYTE) accumulator;
+            *op++              = RUN_MASK << ML_BITS;
+            for (; accumulator >= 255; accumulator -= 255)
+                *op++ = 255;
+            *op++ = (BYTE)accumulator;
         } else {
-            *op++ = (BYTE)(lastRun<<ML_BITS);
+            *op++ = (BYTE)(lastRun << ML_BITS);
         }
         LZ4_memcpy(op, anchor, lastRun);
         ip = anchor + lastRun;
@@ -1325,7 +1457,7 @@ _last_literals:
     }
 
     if (outputDirective == fillOutput) {
-        *inputConsumed = (int) (((const char*)ip)-source);
+        *inputConsumed = (int)(((const char*)ip) - source);
     }
     result = (int)(((char*)op) - dest);
     assert(result > 0);
@@ -1337,63 +1469,74 @@ _last_literals:
  *  inlined, to ensure branches are decided at compilation time;
  *  takes care of src == (NULL, 0)
  *  and forward the rest to LZ4_compress_generic_validated */
-LZ4_FORCE_INLINE int LZ4_compress_generic(
-                 LZ4_stream_t_internal* const cctx,
-                 const char* const src,
-                 char* const dst,
-                 const int srcSize,
-                 int *inputConsumed, /* only written when outputDirective == fillOutput */
-                 const int dstCapacity,
-                 const limitedOutput_directive outputDirective,
-                 const tableType_t tableType,
-                 const dict_directive dictDirective,
-                 const dictIssue_directive dictIssue,
-                 const int acceleration)
+LZ4_FORCE_INLINE int LZ4_compress_generic(LZ4_stream_t_internal* const cctx,
+                                          const char* const            src,
+                                          char* const                  dst,
+                                          const int                    srcSize,
+                                          int* inputConsumed, /* only written when outputDirective == fillOutput */
+                                          const int                     dstCapacity,
+                                          const limitedOutput_directive outputDirective,
+                                          const tableType_t             tableType,
+                                          const dict_directive          dictDirective,
+                                          const dictIssue_directive     dictIssue,
+                                          const int                     acceleration)
 {
-    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i",
-                srcSize, dstCapacity);
+    DEBUGLOG(5, "LZ4_compress_generic: srcSize=%i, dstCapacity=%i", srcSize, dstCapacity);
 
-    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) { return 0; }  /* Unsupported srcSize, too large (or negative) */
-    if (srcSize == 0) {   /* src == NULL supported if srcSize == 0 */
-        if (outputDirective != notLimited && dstCapacity <= 0) return 0;  /* no output, can't write anything */
+    if ((U32)srcSize > (U32)LZ4_MAX_INPUT_SIZE) {
+        return 0;
+    } /* Unsupported srcSize, too large (or negative) */
+    if (srcSize == 0) { /* src == NULL supported if srcSize == 0 */
+        if (outputDirective != notLimited && dstCapacity <= 0) return 0; /* no output, can't write anything */
         DEBUGLOG(5, "Generating an empty block");
         assert(outputDirective == notLimited || dstCapacity >= 1);
         assert(dst != NULL);
         dst[0] = 0;
         if (outputDirective == fillOutput) {
-            assert (inputConsumed != NULL);
+            assert(inputConsumed != NULL);
             *inputConsumed = 0;
         }
         return 1;
     }
     assert(src != NULL);
 
-    return LZ4_compress_generic_validated(cctx, src, dst, srcSize,
-                inputConsumed, /* only written into if outputDirective == fillOutput */
-                dstCapacity, outputDirective,
-                tableType, dictDirective, dictIssue, acceleration);
+    return LZ4_compress_generic_validated(
+        cctx, src, dst, srcSize, inputConsumed, /* only written into if outputDirective == fillOutput */
+        dstCapacity, outputDirective, tableType, dictDirective, dictIssue, acceleration);
 }
 
-
-int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int inputSize, int maxOutputSize, int acceleration)
+int LZ4_compress_fast_extState(void*       state,
+                               const char* source,
+                               char*       dest,
+                               int         inputSize,
+                               int         maxOutputSize,
+                               int         acceleration)
 {
-    LZ4_stream_t_internal* const ctx = & LZ4_initStream(state, sizeof(LZ4_stream_t)) -> internal_donotuse;
+    LZ4_stream_t_internal* const ctx = &LZ4_initStream(state, sizeof(LZ4_stream_t))->internal_donotuse;
     assert(ctx != NULL);
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
     if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
     if (maxOutputSize >= LZ4_compressBound(inputSize)) {
         if (inputSize < LZ4_64Klimit) {
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, byU16, noDict,
+                                        noDictIssue, acceleration);
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)source > LZ4_DISTANCE_MAX))
+                                              ? byPtr
+                                              : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, 0, notLimited, tableType, noDict,
+                                        noDictIssue, acceleration);
         }
     } else {
         if (inputSize < LZ4_64Klimit) {
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput,
+                                        byU16, noDict, noDictIssue, acceleration);
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)source > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)source > LZ4_DISTANCE_MAX))
+                                              ? byPtr
+                                              : byU32;
+            return LZ4_compress_generic(ctx, source, dest, inputSize, NULL, maxOutputSize, limitedOutput,
+                                        tableType, noDict, noDictIssue, acceleration);
         }
     }
 }
@@ -1407,7 +1550,12 @@ int LZ4_compress_fast_extState(void* state, const char* source, char* dest, int 
  * (see comment in lz4.h on LZ4_resetStream_fast() for a definition of
  * "correctly initialized").
  */
-int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst, int srcSize, int dstCapacity, int acceleration)
+int LZ4_compress_fast_extState_fastReset(void*       state,
+                                         const char* src,
+                                         char*       dst,
+                                         int         srcSize,
+                                         int         dstCapacity,
+                                         int         acceleration)
 {
     LZ4_stream_t_internal* const ctx = &((LZ4_stream_t*)state)->internal_donotuse;
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
@@ -1419,111 +1567,130 @@ int LZ4_compress_fast_extState_fastReset(void* state, const char* src, char* dst
             const tableType_t tableType = byU16;
             LZ4_prepareTable(ctx, srcSize, tableType);
             if (ctx->currentOffset) {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, dictSmall, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                            dictSmall, acceleration);
             } else {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                            noDictIssue, acceleration);
             }
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                      : byU32;
             LZ4_prepareTable(ctx, srcSize, tableType);
-            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, 0, notLimited, tableType, noDict,
+                                        noDictIssue, acceleration);
         }
     } else {
         if (srcSize < LZ4_64Klimit) {
             const tableType_t tableType = byU16;
             LZ4_prepareTable(ctx, srcSize, tableType);
             if (ctx->currentOffset) {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, dictSmall, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput,
+                                            tableType, noDict, dictSmall, acceleration);
             } else {
-                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+                return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput,
+                                            tableType, noDict, noDictIssue, acceleration);
             }
         } else {
-            const tableType_t tableType = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
+            const tableType_t tableType = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                      : byU32;
             LZ4_prepareTable(ctx, srcSize, tableType);
-            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(ctx, src, dst, srcSize, NULL, dstCapacity, limitedOutput, tableType,
+                                        noDict, noDictIssue, acceleration);
         }
     }
 }
 
-
 int LZ4_compress_fast(const char* src, char* dest, int srcSize, int dstCapacity, int acceleration)
 {
     int result;
-#if (LZ4_HEAPMODE)
-    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+#  if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctxPtr = (LZ4_stream_t*)ALLOC(
+        sizeof(LZ4_stream_t)); /* malloc-calloc always properly aligned */
     if (ctxPtr == NULL) return 0;
-#else
-    LZ4_stream_t ctx;
+#  else
+    LZ4_stream_t        ctx;
     LZ4_stream_t* const ctxPtr = &ctx;
-#endif
+#  endif
     result = LZ4_compress_fast_extState(ctxPtr, src, dest, srcSize, dstCapacity, acceleration);
 
-#if (LZ4_HEAPMODE)
+#  if (LZ4_HEAPMODE)
     FREEMEM(ctxPtr);
-#endif
+#  endif
     return result;
 }
-
 
 int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacity)
 {
     return LZ4_compress_fast(src, dst, srcSize, dstCapacity, 1);
 }
 
-
 /* Note!: This function leaves the stream in an unclean/broken state!
  * It is not safe to subsequently use the same state with a _fastReset() or
  * _continue() call without resetting it. */
-static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state,
+                                                   const char*   src,
+                                                   char*         dst,
+                                                   int*          srcSizePtr,
+                                                   int           targetDstSize,
+                                                   int           acceleration)
 {
-    void* const s = LZ4_initStream(state, sizeof (*state));
-    assert(s != NULL); (void)s;
+    void* const s = LZ4_initStream(state, sizeof(*state));
+    assert(s != NULL);
+    (void)s;
 
-    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+    if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) { /* compression success is guaranteed */
         return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
     } else {
         if (*srcSizePtr < LZ4_64Klimit) {
-            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr,
+                                        targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
         } else {
-            tableType_t const addrMode = ((sizeof(void*)==4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr : byU32;
-            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
-    }   }
+            const tableType_t addrMode = ((sizeof(void*) == 4) && ((uptrval)src > LZ4_DISTANCE_MAX)) ? byPtr
+                                                                                                     : byU32;
+            return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr,
+                                        targetDstSize, fillOutput, addrMode, noDict, noDictIssue, acceleration);
+        }
+    }
 }
 
-int LZ4_compress_destSize_extState(void* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
+int LZ4_compress_destSize_extState(void*       state,
+                                   const char* src,
+                                   char*       dst,
+                                   int*        srcSizePtr,
+                                   int         targetDstSize,
+                                   int         acceleration)
 {
-    int const r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr, targetDstSize, acceleration);
+    const int r = LZ4_compress_destSize_extState_internal((LZ4_stream_t*)state, src, dst, srcSizePtr,
+                                                          targetDstSize, acceleration);
     /* clean the state on exit */
-    LZ4_initStream(state, sizeof (LZ4_stream_t));
+    LZ4_initStream(state, sizeof(LZ4_stream_t));
     return r;
 }
 
-
 int LZ4_compress_destSize(const char* src, char* dst, int* srcSizePtr, int targetDstSize)
 {
-#if (LZ4_HEAPMODE)
-    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));   /* malloc-calloc always properly aligned */
+#  if (LZ4_HEAPMODE)
+    LZ4_stream_t* const ctx = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t)); /* malloc-calloc always properly aligned */
     if (ctx == NULL) return 0;
-#else
-    LZ4_stream_t ctxBody;
+#  else
+    LZ4_stream_t        ctxBody;
     LZ4_stream_t* const ctx = &ctxBody;
-#endif
+#  endif
 
     int result = LZ4_compress_destSize_extState_internal(ctx, src, dst, srcSizePtr, targetDstSize, 1);
 
-#if (LZ4_HEAPMODE)
+#  if (LZ4_HEAPMODE)
     FREEMEM(ctx);
-#endif
+#  endif
     return result;
 }
-
-
 
 /*-******************************
 *  Streaming functions
 ********************************/
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_stream_t* LZ4_createStream(void)
 {
     LZ4_stream_t* const lz4s = (LZ4_stream_t*)ALLOC(sizeof(LZ4_stream_t));
@@ -1533,23 +1700,31 @@ LZ4_stream_t* LZ4_createStream(void)
     LZ4_initStream(lz4s, sizeof(*lz4s));
     return lz4s;
 }
-#endif
+#  endif
 
 static size_t LZ4_stream_t_alignment(void)
 {
-#if LZ4_ALIGN_TEST
-    typedef struct { char c; LZ4_stream_t t; } t_a;
+#  if LZ4_ALIGN_TEST
+    typedef struct {
+        char         c;
+        LZ4_stream_t t;
+    } t_a;
+
     return sizeof(t_a) - sizeof(LZ4_stream_t);
-#else
+#  else
     return 1;  /* effectively disabled */
-#endif
+#  endif
 }
 
-LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
+LZ4_stream_t* LZ4_initStream(void* buffer, size_t size)
 {
     DEBUGLOG(5, "LZ4_initStream");
-    if (buffer == NULL) { return NULL; }
-    if (size < sizeof(LZ4_stream_t)) { return NULL; }
+    if (buffer == NULL) {
+        return NULL;
+    }
+    if (size < sizeof(LZ4_stream_t)) {
+        return NULL;
+    }
     if (!LZ4_isAligned(buffer, LZ4_stream_t_alignment())) return NULL;
     MEM_INIT(buffer, 0, sizeof(LZ4_stream_t_internal));
     return (LZ4_stream_t*)buffer;
@@ -1557,38 +1732,38 @@ LZ4_stream_t* LZ4_initStream (void* buffer, size_t size)
 
 /* resetStream is now deprecated,
  * prefer initStream() which is more general */
-void LZ4_resetStream (LZ4_stream_t* LZ4_stream)
+void LZ4_resetStream(LZ4_stream_t* LZ4_stream)
 {
     DEBUGLOG(5, "LZ4_resetStream (ctx:%p)", (void*)LZ4_stream);
     MEM_INIT(LZ4_stream, 0, sizeof(LZ4_stream_t_internal));
 }
 
-void LZ4_resetStream_fast(LZ4_stream_t* ctx) {
+void LZ4_resetStream_fast(LZ4_stream_t* ctx)
+{
     LZ4_prepareTable(&(ctx->internal_donotuse), 0, byU32);
 }
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-int LZ4_freeStream (LZ4_stream_t* LZ4_stream)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+int LZ4_freeStream(LZ4_stream_t* LZ4_stream)
 {
-    if (!LZ4_stream) return 0;   /* support free on NULL */
+    if (!LZ4_stream) return 0; /* support free on NULL */
     DEBUGLOG(5, "LZ4_freeStream %p", (void*)LZ4_stream);
     FREEMEM(LZ4_stream);
-    return (0);
+    return 0;
 }
-#endif
-
+#  endif
 
 typedef enum { _ld_fast, _ld_slow } LoadDict_mode_e;
-#define HASH_UNIT sizeof(reg_t)
-static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
-                    const char* dictionary, int dictSize,
-                    LoadDict_mode_e _ld)
+
+#  define HASH_UNIT sizeof(reg_t)
+
+static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSize, LoadDict_mode_e _ld)
 {
-    LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
-    const tableType_t tableType = byU32;
-    const BYTE* p = (const BYTE*)dictionary;
-    const BYTE* const dictEnd = p + dictSize;
-    U32 idx32;
+    LZ4_stream_t_internal* const dict      = &LZ4_dict->internal_donotuse;
+    const tableType_t            tableType = byU32;
+    const BYTE*                  p         = (const BYTE*)dictionary;
+    const BYTE* const            dictEnd   = p + dictSize;
+    U32                          idx32;
 
     DEBUGLOG(4, "LZ4_loadDict (%i bytes from %p into %p)", dictSize, (void*)dictionary, (void*)LZ4_dict);
 
@@ -1612,29 +1787,31 @@ static int LZ4_loadDict_internal(LZ4_stream_t* LZ4_dict,
 
     if ((dictEnd - p) > 64 KB) p = dictEnd - 64 KB;
     dict->dictionary = p;
-    dict->dictSize = (U32)(dictEnd - p);
-    dict->tableType = (U32)tableType;
-    idx32 = dict->currentOffset - dict->dictSize;
+    dict->dictSize   = (U32)(dictEnd - p);
+    dict->tableType  = (U32)tableType;
+    idx32            = dict->currentOffset - dict->dictSize;
 
-    while (p <= dictEnd-HASH_UNIT) {
+    while (p <= dictEnd - HASH_UNIT) {
         U32 const h = LZ4_hashPosition(p, tableType);
         /* Note: overwriting => favors positions end of dictionary */
         LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
-        p+=3; idx32+=3;
+        p += 3;
+        idx32 += 3;
     }
 
     if (_ld == _ld_slow) {
         /* Fill hash table with additional references, to improve compression capability */
-        p = dict->dictionary;
+        p     = dict->dictionary;
         idx32 = dict->currentOffset - dict->dictSize;
-        while (p <= dictEnd-HASH_UNIT) {
-            U32 const h = LZ4_hashPosition(p, tableType);
+        while (p <= dictEnd - HASH_UNIT) {
+            U32 const h     = LZ4_hashPosition(p, tableType);
             U32 const limit = dict->currentOffset - 64 KB;
             if (LZ4_getIndexOnHash(h, dict->hashTable, tableType) <= limit) {
                 /* Note: not overwriting => favors positions beginning of dictionary */
                 LZ4_putIndexOnHash(idx32, h, dict->hashTable, tableType);
             }
-            p++; idx32++;
+            p++;
+            idx32++;
         }
     }
 
@@ -1653,11 +1830,10 @@ int LZ4_loadDictSlow(LZ4_stream_t* LZ4_dict, const char* dictionary, int dictSiz
 
 void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dictionaryStream)
 {
-    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL :
-        &(dictionaryStream->internal_donotuse);
+    const LZ4_stream_t_internal* dictCtx = (dictionaryStream == NULL) ? NULL
+                                                                      : &(dictionaryStream->internal_donotuse);
 
-    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)",
-             (void*)workingStream, (void*)dictionaryStream,
+    DEBUGLOG(4, "LZ4_attach_dictionary (%p, %p, size %u)", (void*)workingStream, (void*)dictionaryStream,
              dictCtx != NULL ? dictCtx->dictSize : 0);
 
     if (dictCtx != NULL) {
@@ -1679,18 +1855,18 @@ void LZ4_attach_dictionary(LZ4_stream_t* workingStream, const LZ4_stream_t* dict
     workingStream->internal_donotuse.dictCtx = dictCtx;
 }
 
-
 static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
 {
     assert(nextSize >= 0);
-    if (LZ4_dict->currentOffset + (unsigned)nextSize > 0x80000000) {   /* potential ptrdiff_t overflow (32-bits mode) */
+    if (LZ4_dict->currentOffset + (unsigned)nextSize >
+        0x80000000) { /* potential ptrdiff_t overflow (32-bits mode) */
         /* rescale hash table */
-        U32 const delta = LZ4_dict->currentOffset - 64 KB;
+        U32 const   delta   = LZ4_dict->currentOffset - 64 KB;
         const BYTE* dictEnd = LZ4_dict->dictionary + LZ4_dict->dictSize;
-        int i;
+        int         i;
         DEBUGLOG(4, "LZ4_renormDictT");
-        for (i=0; i<LZ4_HASH_SIZE_U32; i++) {
-            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i]=0;
+        for (i = 0; i < LZ4_HASH_SIZE_U32; i++) {
+            if (LZ4_dict->hashTable[i] < delta) LZ4_dict->hashTable[i] = 0;
             else LZ4_dict->hashTable[i] -= delta;
         }
         LZ4_dict->currentOffset = 64 KB;
@@ -1699,37 +1875,40 @@ static void LZ4_renormDictT(LZ4_stream_t_internal* LZ4_dict, int nextSize)
     }
 }
 
-
-int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
-                                const char* source, char* dest,
-                                int inputSize, int maxOutputSize,
-                                int acceleration)
+int LZ4_compress_fast_continue(LZ4_stream_t* LZ4_stream,
+                               const char*   source,
+                               char*         dest,
+                               int           inputSize,
+                               int           maxOutputSize,
+                               int           acceleration)
 {
-    const tableType_t tableType = byU32;
+    const tableType_t            tableType = byU32;
     LZ4_stream_t_internal* const streamPtr = &LZ4_stream->internal_donotuse;
     const char* dictEnd = streamPtr->dictSize ? (const char*)streamPtr->dictionary + streamPtr->dictSize : NULL;
 
     DEBUGLOG(5, "LZ4_compress_fast_continue (inputSize=%i, dictSize=%u)", inputSize, streamPtr->dictSize);
 
-    LZ4_renormDictT(streamPtr, inputSize);   /* fix index overflow */
+    LZ4_renormDictT(streamPtr, inputSize); /* fix index overflow */
     if (acceleration < 1) acceleration = LZ4_ACCELERATION_DEFAULT;
     if (acceleration > LZ4_ACCELERATION_MAX) acceleration = LZ4_ACCELERATION_MAX;
 
     /* invalidate tiny dictionaries */
-    if ( (streamPtr->dictSize < 4)     /* tiny dictionary : not enough for a hash */
-      && (dictEnd != source)           /* prefix mode */
-      && (inputSize > 0)               /* tolerance : don't lose history, in case next invocation would use prefix mode */
-      && (streamPtr->dictCtx == NULL)  /* usingDictCtx */
-      ) {
-        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize, (void*)streamPtr->dictionary);
+    if ((streamPtr->dictSize < 4) /* tiny dictionary : not enough for a hash */
+        && (dictEnd != source) /* prefix mode */
+        && (inputSize > 0) /* tolerance : don't lose history, in case next invocation would use prefix mode */
+        && (streamPtr->dictCtx == NULL) /* usingDictCtx */
+    ) {
+        DEBUGLOG(5, "LZ4_compress_fast_continue: dictSize(%u) at addr:%p is too small", streamPtr->dictSize,
+                 (void*)streamPtr->dictionary);
         /* remove dictionary existence from history, to employ faster prefix mode */
-        streamPtr->dictSize = 0;
+        streamPtr->dictSize   = 0;
         streamPtr->dictionary = (const BYTE*)source;
-        dictEnd = source;
+        dictEnd               = source;
     }
 
     /* Check overlapping input/dictionary space */
-    {   const char* const sourceEnd = source + inputSize;
+    {
+        const char* const sourceEnd = source + inputSize;
         if ((sourceEnd > (const char*)streamPtr->dictionary) && (sourceEnd < dictEnd)) {
             streamPtr->dictSize = (U32)(dictEnd - sourceEnd);
             if (streamPtr->dictSize > 64 KB) streamPtr->dictSize = 64 KB;
@@ -1741,13 +1920,16 @@ int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
     /* prefix mode : source data follows dictionary */
     if (dictEnd == source) {
         if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset))
-            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                        limitedOutput, tableType, withPrefix64k, dictSmall, acceleration);
         else
-            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
+            return LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                        limitedOutput, tableType, withPrefix64k, noDictIssue, acceleration);
     }
 
     /* external dictionary mode */
-    {   int result;
+    {
+        int result;
         if (streamPtr->dictCtx) {
             /* We depend here on the fact that dictCtx'es (produced by
              * LZ4_loadDict) guarantee that their tables contain no references
@@ -1761,44 +1943,51 @@ int LZ4_compress_fast_continue (LZ4_stream_t* LZ4_stream,
                  * so that the compression loop is only looking into one table.
                  */
                 LZ4_memcpy(streamPtr, streamPtr->dictCtx, sizeof(*streamPtr));
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, noDictIssue,
+                                              acceleration);
             } else {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingDictCtx, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingDictCtx, noDictIssue,
+                                              acceleration);
             }
-        } else {  /* small data <= 4 KB */
+        } else { /* small data <= 4 KB */
             if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, dictSmall, acceleration);
             } else {
-                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize, limitedOutput, tableType, usingExtDict, noDictIssue, acceleration);
+                result = LZ4_compress_generic(streamPtr, source, dest, inputSize, NULL, maxOutputSize,
+                                              limitedOutput, tableType, usingExtDict, noDictIssue,
+                                              acceleration);
             }
         }
         streamPtr->dictionary = (const BYTE*)source;
-        streamPtr->dictSize = (U32)inputSize;
+        streamPtr->dictSize   = (U32)inputSize;
         return result;
     }
 }
 
-
 /* Hidden debug function, to force-test external dictionary mode */
-int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
+int LZ4_compress_forceExtDict(LZ4_stream_t* LZ4_dict, const char* source, char* dest, int srcSize)
 {
     LZ4_stream_t_internal* const streamPtr = &LZ4_dict->internal_donotuse;
-    int result;
+    int                          result;
 
     LZ4_renormDictT(streamPtr, srcSize);
 
     if ((streamPtr->dictSize < 64 KB) && (streamPtr->dictSize < streamPtr->currentOffset)) {
-        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, dictSmall, 1);
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32,
+                                      usingExtDict, dictSmall, 1);
     } else {
-        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32, usingExtDict, noDictIssue, 1);
+        result = LZ4_compress_generic(streamPtr, source, dest, srcSize, NULL, 0, notLimited, byU32,
+                                      usingExtDict, noDictIssue, 1);
     }
 
     streamPtr->dictionary = (const BYTE*)source;
-    streamPtr->dictSize = (U32)srcSize;
+    streamPtr->dictSize   = (U32)srcSize;
 
     return result;
 }
-
 
 /*! LZ4_saveDict() :
  *  If previously compressed data block is not guaranteed to remain available at its memory location,
@@ -1807,14 +1996,18 @@ int LZ4_compress_forceExtDict (LZ4_stream_t* LZ4_dict, const char* source, char*
  *         one can therefore call LZ4_compress_fast_continue() right after.
  * @return : saved dictionary size in bytes (necessarily <= dictSize), or 0 if error.
  */
-int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
+int LZ4_saveDict(LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 {
     LZ4_stream_t_internal* const dict = &LZ4_dict->internal_donotuse;
 
     DEBUGLOG(5, "LZ4_saveDict : dictSize=%i, safeBuffer=%p", dictSize, (void*)safeBuffer);
 
-    if ((U32)dictSize > 64 KB) { dictSize = 64 KB; } /* useless to define a dictionary > 64 KB */
-    if ((U32)dictSize > dict->dictSize) { dictSize = (int)dict->dictSize; }
+    if ((U32)dictSize > 64 KB) {
+        dictSize = 64 KB;
+    } /* useless to define a dictionary > 64 KB */
+    if ((U32)dictSize > dict->dictSize) {
+        dictSize = (int)dict->dictSize;
+    }
 
     if (safeBuffer == NULL) assert(dictSize == 0);
     if (dictSize > 0) {
@@ -1824,12 +2017,10 @@ int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
     }
 
     dict->dictionary = (const BYTE*)safeBuffer;
-    dict->dictSize = (U32)dictSize;
+    dict->dictSize   = (U32)dictSize;
 
     return dictSize;
 }
-
-
 
 /*-*******************************
  *  Decompression functions
@@ -1837,9 +2028,8 @@ int LZ4_saveDict (LZ4_stream_t* LZ4_dict, char* safeBuffer, int dictSize)
 
 typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 
-#undef MIN
-#define MIN(a,b)    ( (a) < (b) ? (a) : (b) )
-
+#  undef MIN
+#  define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 /* variant for decompress_unsafe()
  * does not know end of input
@@ -1848,8 +2038,12 @@ typedef enum { decode_full_block = 0, partial_decode = 1 } earlyEnd_directive;
 static size_t read_long_length_no_check(const BYTE** pp)
 {
     size_t b, l = 0;
-    do { b = **pp; (*pp)++; l += b; } while (b==255);
-    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l/255 + 1)
+    do {
+        b = **pp;
+        (*pp)++;
+        l += b;
+    } while (b == 255);
+    DEBUGLOG(6, "read_long_length_no_check: +length=%zu using %zu input bytes", l, l / 255 + 1)
     return l;
 }
 
@@ -1862,20 +2056,18 @@ static size_t read_long_length_no_check(const BYTE** pp)
  * Note : this variant is not optimized for speed, just for maintenance.
  *        the goal is to remove support of decompress_fast*() variants by v2.0
 **/
-LZ4_FORCE_INLINE int
-LZ4_decompress_unsafe_generic(
-                 const BYTE* const istart,
-                 BYTE* const ostart,
-                 int decompressedSize,
+LZ4_FORCE_INLINE int LZ4_decompress_unsafe_generic(const BYTE* const istart,
+                                                   BYTE* const       ostart,
+                                                   int               decompressedSize,
 
-                 size_t prefixSize,
-                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
-                 const size_t dictSize         /* note: =0 if dictStart==NULL */
-                 )
+                                                   size_t prefixSize,
+                                                   const BYTE* const dictStart, /* only if dict==usingExtDict */
+                                                   const size_t dictSize /* note: =0 if dictStart==NULL */
+)
 {
-    const BYTE* ip = istart;
-    BYTE* op = (BYTE*)ostart;
-    BYTE* const oend = ostart + decompressedSize;
+    const BYTE*       ip          = istart;
+    BYTE*             op          = (BYTE*)ostart;
+    BYTE* const       oend        = ostart + decompressedSize;
     const BYTE* const prefixStart = ostart - prefixSize;
 
     DEBUGLOG(5, "LZ4_decompress_unsafe_generic");
@@ -1886,37 +2078,41 @@ LZ4_decompress_unsafe_generic(
         unsigned token = *ip++;
 
         /* literals */
-        {   size_t ll = token >> ML_BITS;
-            if (ll==15) {
+        {
+            size_t ll = token >> ML_BITS;
+            if (ll == 15) {
                 /* long literal length */
                 ll += read_long_length_no_check(&ip);
             }
-            if ((size_t)(oend-op) < ll) return -1; /* output buffer overflow */
+            if ((size_t)(oend - op) < ll) return -1; /* output buffer overflow */
             LZ4_memmove(op, ip, ll); /* support in-place decompression */
             op += ll;
             ip += ll;
-            if ((size_t)(oend-op) < MFLIMIT) {
-                if (op==oend) break;  /* end of block */
-                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend-op);
+            if ((size_t)(oend - op) < MFLIMIT) {
+                if (op == oend) break; /* end of block */
+                DEBUGLOG(5, "invalid: literals end at distance %zi from end of block", oend - op);
                 /* incorrect end of block :
                  * last match must start at least MFLIMIT==12 bytes before end of output block */
                 return -1;
-        }   }
+            }
+        }
 
         /* match */
-        {   size_t ml = token & 15;
-            size_t const offset = LZ4_readLE16(ip);
-            ip+=2;
+        {
+            size_t       ml     = token & 15;
+            const size_t offset = LZ4_readLE16(ip);
+            ip += 2;
 
-            if (ml==15) {
+            if (ml == 15) {
                 /* long literal length */
                 ml += read_long_length_no_check(&ip);
             }
             ml += MINMATCH;
 
-            if ((size_t)(oend-op) < ml) return -1; /* output buffer overflow */
+            if ((size_t)(oend - op) < ml) return -1; /* output buffer overflow */
 
-            {   const BYTE* match = op - offset;
+            {
+                const BYTE* match = op - offset;
 
                 /* out of range */
                 if (offset > (size_t)(op - prefixStart) + dictSize) {
@@ -1927,9 +2123,9 @@ LZ4_decompress_unsafe_generic(
                 /* check special case : extDict */
                 if (offset > (size_t)(op - prefixStart)) {
                     /* extDict scenario */
-                    const BYTE* const dictEnd = dictStart + dictSize;
-                    const BYTE* extMatch = dictEnd - (offset - (size_t)(op-prefixStart));
-                    size_t const extml = (size_t)(dictEnd - extMatch);
+                    const BYTE* const dictEnd  = dictStart + dictSize;
+                    const BYTE*       extMatch = dictEnd - (offset - (size_t)(op - prefixStart));
+                    const size_t      extml    = (size_t)(dictEnd - extMatch);
                     if (extml > ml) {
                         /* match entirely within extDict */
                         LZ4_memmove(op, extMatch, ml);
@@ -1945,13 +2141,16 @@ LZ4_decompress_unsafe_generic(
                 }
 
                 /* match copy - slow variant, supporting overlap copy */
-                {   size_t u;
-                    for (u=0; u<ml; u++) {
+                {
+                    size_t u;
+                    for (u = 0; u < ml; u++) {
                         op[u] = match[u];
-            }   }   }
+                    }
+                }
+            }
             op += ml;
-            if ((size_t)(oend-op) < LASTLITERALS) {
-                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend-op);
+            if ((size_t)(oend - op) < LASTLITERALS) {
+                DEBUGLOG(5, "invalid: match ends at distance %zi from end of block", oend - op);
                 /* incorrect end of block :
                  * last match must stop at least LASTLITERALS==5 bytes before end of output block */
                 return -1;
@@ -1961,7 +2160,6 @@ LZ4_decompress_unsafe_generic(
     return (int)(ip - istart);
 }
 
-
 /* Read the variable-length literal or match length.
  *
  * @ip : input pointer
@@ -1969,27 +2167,26 @@ LZ4_decompress_unsafe_generic(
  * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
  * @error (output) - error code.  Must be set to 0 before call.
 **/
-typedef size_t Rvl_t;
+typedef size_t     Rvl_t;
 static const Rvl_t rvl_error = (Rvl_t)(-1);
-LZ4_FORCE_INLINE Rvl_t
-read_variable_length(const BYTE** ip, const BYTE* ilimit,
-                     int initial_check)
+
+LZ4_FORCE_INLINE Rvl_t read_variable_length(const BYTE** ip, const BYTE* ilimit, int initial_check)
 {
     Rvl_t s, length = 0;
     assert(ip != NULL);
-    assert(*ip !=  NULL);
+    assert(*ip != NULL);
     assert(ilimit != NULL);
-    if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
+    if (initial_check && unlikely((*ip) >= ilimit)) { /* read limit reached */
         return rvl_error;
     }
     s = **ip;
     (*ip)++;
     length += s;
-    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+    if (unlikely((*ip) > ilimit)) { /* read limit reached */
         return rvl_error;
     }
     /* accumulator overflow detection (32-bit mode only) */
-    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1) / 2))) {
         return rvl_error;
     }
     if (likely(s != 255)) return length;
@@ -1997,11 +2194,11 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
         s = **ip;
         (*ip)++;
         length += s;
-        if (unlikely((*ip) > ilimit)) {    /* read limit reached */
+        if (unlikely((*ip) > ilimit)) { /* read limit reached */
             return rvl_error;
         }
         /* accumulator overflow detection (32-bit mode only) */
-        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1) / 2))) {
             return rvl_error;
         }
     } while (s == 255);
@@ -2016,59 +2213,61 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
  *  in order to remove useless branches during compilation optimization.
  */
 LZ4_FORCE_INLINE int
-LZ4_decompress_generic(
-                 const char* const src,
-                 char* const dst,
-                 int srcSize,
-                 int outputSize,         /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
+LZ4_decompress_generic(const char* const src,
+                       char* const       dst,
+                       int               srcSize,
+                       int outputSize, /* If endOnInput==endOnInputSize, this value is `dstCapacity` */
 
-                 earlyEnd_directive partialDecoding,  /* full, partial */
-                 dict_directive dict,                 /* noDict, withPrefix64k, usingExtDict */
-                 const BYTE* const lowPrefix,  /* always <= dst, == dst when no prefix */
-                 const BYTE* const dictStart,  /* only if dict==usingExtDict */
-                 const size_t dictSize         /* note : = 0 if noDict */
-                 )
+                       earlyEnd_directive partialDecoding, /* full, partial */
+                       dict_directive     dict, /* noDict, withPrefix64k, usingExtDict */
+                       const BYTE* const  lowPrefix, /* always <= dst, == dst when no prefix */
+                       const BYTE* const  dictStart, /* only if dict==usingExtDict */
+                       const size_t       dictSize /* note : = 0 if noDict */
+)
 {
-    if ((src == NULL) || (outputSize < 0)) { return -1; }
+    if ((src == NULL) || (outputSize < 0)) {
+        return -1;
+    }
 
-    {   const BYTE* ip = (const BYTE*) src;
+    {
+        const BYTE*       ip   = (const BYTE*)src;
         const BYTE* const iend = ip + srcSize;
 
-        BYTE* op = (BYTE*) dst;
+        BYTE*       op   = (BYTE*)dst;
         BYTE* const oend = op + outputSize;
-        BYTE* cpy;
+        BYTE*       cpy;
 
         const BYTE* const dictEnd = (dictStart == NULL) ? NULL : dictStart + dictSize;
 
         const int checkOffset = (dictSize < (int)(64 KB));
-
 
         /* Set up the "end" pointers for the shortcut. */
         const BYTE* const shortiend = iend - 14 /*maxLL*/ - 2 /*offset*/;
         const BYTE* const shortoend = oend - 14 /*maxLL*/ - 18 /*maxML*/;
 
         const BYTE* match;
-        size_t offset;
-        unsigned token;
-        size_t length;
-
+        size_t      offset;
+        unsigned    token;
+        size_t      length;
 
         DEBUGLOG(5, "LZ4_decompress_generic (srcSize:%i, dstSize:%i)", srcSize, outputSize);
 
         /* Special cases */
         assert(lowPrefix <= op);
-        if (unlikely(outputSize==0)) {
+        if (unlikely(outputSize == 0)) {
             /* Empty output buffer */
             if (partialDecoding) return 0;
-            return ((srcSize==1) && (*ip==0)) ? 0 : -1;
+            return ((srcSize == 1) && (*ip == 0)) ? 0 : -1;
         }
-        if (unlikely(srcSize==0)) { return -1; }
+        if (unlikely(srcSize == 0)) {
+            return -1;
+        }
 
-    /* LZ4_FAST_DEC_LOOP:
+        /* LZ4_FAST_DEC_LOOP:
      * designed for modern OoO performance cpus,
      * where copying reliably 32-bytes is preferable to an unpredictable branch.
      * note : fast loop may show a regression for some client arm chips. */
-#if LZ4_FAST_DEC_LOOP
+#  if LZ4_FAST_DEC_LOOP
         if ((oend - op) < FASTLOOP_SAFE_DISTANCE) {
             DEBUGLOG(6, "move to safe decode loop");
             goto safe_decode;
@@ -2080,48 +2279,57 @@ LZ4_decompress_generic(
             /* Main fastloop assertion: We can always wildcopy FASTLOOP_SAFE_DISTANCE */
             assert(oend - op >= FASTLOOP_SAFE_DISTANCE);
             assert(ip < iend);
-            token = *ip++;
-            length = token >> ML_BITS;  /* literal length */
-            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            token  = *ip++;
+            length = token >> ML_BITS; /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                const size_t addl = read_variable_length(&ip, iend - RUN_MASK, 1);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
                 }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
-                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)(op))) {
+                    goto _output_error;
+                } /* overflow detection */
+                if (unlikely((uptrval)(ip) + length < (uptrval)(ip))) {
+                    goto _output_error;
+                } /* overflow detection */
 
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
-                if ((op+length>oend-32) || (ip+length>iend-32)) { goto safe_literal_copy; }
-                LZ4_wildCopy32(op, ip, op+length);
-                ip += length; op += length;
-            } else if (ip <= iend-(16 + 1/*max lit + offset + nextToken*/)) {
+                if ((op + length > oend - 32) || (ip + length > iend - 32)) {
+                    goto safe_literal_copy;
+                }
+                LZ4_wildCopy32(op, ip, op + length);
+                ip += length;
+                op += length;
+            } else if (ip <= iend - (16 + 1 /*max lit + offset + nextToken*/)) {
                 /* We don't need to check oend, since we check it once for each loop below */
                 DEBUGLOG(7, "copy %u bytes in a 16-bytes stripe", (unsigned)length);
                 /* Literals can only be <= 14, but hope compilers optimize better when copy by a register size */
                 LZ4_memcpy(op, ip, 16);
-                ip += length; op += length;
+                ip += length;
+                op += length;
             } else {
                 goto safe_literal_copy;
             }
 
             /* get offset */
-            offset = LZ4_readLE16(ip); ip+=2;
-            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op-(BYTE*)dst), (unsigned)offset);
+            offset = LZ4_readLE16(ip);
+            ip += 2;
+            DEBUGLOG(6, "blockPos%6u: offset = %u", (unsigned)(op - (BYTE*)dst), (unsigned)offset);
             match = op - offset;
-            assert(match <= op);  /* overflow check */
+            assert(match <= op); /* overflow check */
 
             /* get matchlength */
             length = token & ML_MASK;
-            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
+            DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length + MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                const size_t addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
@@ -2129,7 +2337,9 @@ LZ4_decompress_generic(
                 length += addl;
                 length += MINMATCH;
                 DEBUGLOG(7, "  long match length == %u", (unsigned)length);
-                if (unlikely((uptrval)(op)+length<(uptrval)op)) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)op)) {
+                    goto _output_error;
+                } /* overflow detection */
                 if (op + length >= oend - FASTLOOP_SAFE_DISTANCE) {
                     goto safe_match_copy;
                 }
@@ -2148,71 +2358,77 @@ LZ4_decompress_generic(
                         assert(op + 18 <= oend);
 
                         LZ4_memcpy(op, match, 8);
-                        LZ4_memcpy(op+8, match+8, 8);
-                        LZ4_memcpy(op+16, match+16, 2);
+                        LZ4_memcpy(op + 8, match + 8, 8);
+                        LZ4_memcpy(op + 16, match + 16, 2);
                         op += length;
                         continue;
-            }   }   }
+                    }
+                }
+            }
 
-            if ( checkOffset && (unlikely(match + dictSize < lowPrefix)) ) {
-                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op-lowPrefix, op-match);
+            if (checkOffset && (unlikely(match + dictSize < lowPrefix))) {
+                DEBUGLOG(5, "Error : pos=%zi, offset=%zi => outside buffers", op - lowPrefix, op - match);
                 goto _output_error;
             }
             /* match starting within external dictionary */
-            if ((dict==usingExtDict) && (match < lowPrefix)) {
+            if ((dict == usingExtDict) && (match < lowPrefix)) {
                 assert(dictEnd != NULL);
-                if (unlikely(op+length > oend-LASTLITERALS)) {
+                if (unlikely(op + length > oend - LASTLITERALS)) {
                     if (partialDecoding) {
                         DEBUGLOG(7, "partialDecoding: dictionary match, close to dstEnd");
-                        length = MIN(length, (size_t)(oend-op));
+                        length = MIN(length, (size_t)(oend - op));
                     } else {
                         DEBUGLOG(6, "end-of-block condition violated")
                         goto _output_error;
-                }   }
+                    }
+                }
 
-                if (length <= (size_t)(lowPrefix-match)) {
+                if (length <= (size_t)(lowPrefix - match)) {
                     /* match fits entirely within external dictionary : just copy */
-                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    LZ4_memmove(op, dictEnd - (lowPrefix - match), length);
                     op += length;
                 } else {
                     /* match stretches into both external dictionary and current block */
-                    size_t const copySize = (size_t)(lowPrefix - match);
-                    size_t const restSize = length - copySize;
+                    const size_t copySize = (size_t)(lowPrefix - match);
+                    const size_t restSize = length - copySize;
                     LZ4_memcpy(op, dictEnd - copySize, copySize);
                     op += copySize;
-                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                    if (restSize > (size_t)(op - lowPrefix)) { /* overlap copy */
                         BYTE* const endOfMatch = op + restSize;
-                        const BYTE* copyFrom = lowPrefix;
-                        while (op < endOfMatch) { *op++ = *copyFrom++; }
+                        const BYTE* copyFrom   = lowPrefix;
+                        while (op < endOfMatch) {
+                            *op++ = *copyFrom++;
+                        }
                     } else {
                         LZ4_memcpy(op, lowPrefix, restSize);
                         op += restSize;
-                }   }
+                    }
+                }
                 continue;
             }
 
             /* copy match within block */
             cpy = op + length;
 
-            assert((op <= oend) && (oend-op >= 32));
-            if (unlikely(offset<16)) {
+            assert((op <= oend) && (oend - op >= 32));
+            if (unlikely(offset < 16)) {
                 LZ4_memcpy_using_offset(op, match, cpy, offset);
             } else {
                 LZ4_wildCopy32(op, match, cpy);
             }
 
-            op = cpy;   /* wildcopy correction */
+            op = cpy; /* wildcopy correction */
         }
-    safe_decode:
-#endif
+safe_decode:
+#  endif
 
         /* Main Loop : decode remaining sequences where output < FASTLOOP_SAFE_DISTANCE */
         DEBUGLOG(6, "using safe decode loop");
         while (1) {
             assert(ip < iend);
-            token = *ip++;
-            length = token >> ML_BITS;  /* literal length */
-            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            token  = *ip++;
+            length = token >> ML_BITS; /* literal length */
+            DEBUGLOG(7, "blockPos%6u: litLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
             /* A two-stage shortcut for the most common case:
              * 1) If the literal length is 0..14, and there is enough space,
@@ -2223,29 +2439,30 @@ LZ4_decompress_generic(
              * those 18 bytes earlier, upon entering the shortcut (in other words,
              * there is a combined check for both stages).
              */
-            if ( (length != RUN_MASK)
+            if ((length != RUN_MASK)
                 /* strictly "less than" on input, to re-enter the loop with at least one byte */
-              && likely((ip < shortiend) & (op <= shortoend)) ) {
+                && likely((ip < shortiend) & (op <= shortoend))) {
                 /* Copy the literals */
                 LZ4_memcpy(op, ip, 16);
-                op += length; ip += length;
+                op += length;
+                ip += length;
 
                 /* The second stage: prepare for match copying, decode full info.
                  * If it doesn't work out, the info won't be wasted. */
                 length = token & ML_MASK; /* match length */
-                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op-(BYTE*)dst), (unsigned)length, (unsigned)length + 4);
-                offset = LZ4_readLE16(ip); ip += 2;
+                DEBUGLOG(7, "blockPos%6u: matchLength token = %u (len=%u)", (unsigned)(op - (BYTE*)dst),
+                         (unsigned)length, (unsigned)length + 4);
+                offset = LZ4_readLE16(ip);
+                ip += 2;
                 match = op - offset;
                 assert(match <= op); /* check overflow */
 
                 /* Do not deal with overlapping matches. */
-                if ( (length != ML_MASK)
-                  && (offset >= 8)
-                  && (dict==withPrefix64k || match >= lowPrefix) ) {
+                if ((length != ML_MASK) && (offset >= 8) && (dict == withPrefix64k || match >= lowPrefix)) {
                     /* Copy the match. */
                     LZ4_memcpy(op + 0, match + 0, 8);
                     LZ4_memcpy(op + 8, match + 8, 8);
-                    LZ4_memcpy(op +16, match +16, 2);
+                    LZ4_memcpy(op + 16, match + 16, 2);
                     op += length + MINMATCH;
                     /* Both stages worked, load the next token. */
                     continue;
@@ -2258,21 +2475,27 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
-                if (addl == rvl_error) { goto _output_error; }
+                const size_t addl = read_variable_length(&ip, iend - RUN_MASK, 1);
+                if (addl == rvl_error) {
+                    goto _output_error;
+                }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
-                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)(op))) {
+                    goto _output_error;
+                } /* overflow detection */
+                if (unlikely((uptrval)(ip) + length < (uptrval)(ip))) {
+                    goto _output_error;
+                } /* overflow detection */
             }
 
-#if LZ4_FAST_DEC_LOOP
-        safe_literal_copy:
-#endif
+#  if LZ4_FAST_DEC_LOOP
+safe_literal_copy:
+#  endif
             /* copy literals */
-            cpy = op+length;
+            cpy = op + length;
 
             LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
-            if ((cpy>oend-MFLIMIT) || (ip+length>iend-(2+1+LASTLITERALS))) {
+            if ((cpy > oend - MFLIMIT) || (ip + length > iend - (2 + 1 + LASTLITERALS))) {
                 /* We've either hit the input parsing restriction or the output parsing restriction.
                  * In the normal scenario, decoding a full block, it must be the last sequence,
                  * otherwise it's an error (invalid input or dimensions).
@@ -2289,31 +2512,34 @@ LZ4_decompress_generic(
                     /* Finishing in the middle of a literals segment,
                      * due to lack of input.
                      */
-                    if (ip+length > iend) {
-                        length = (size_t)(iend-ip);
-                        cpy = op + length;
+                    if (ip + length > iend) {
+                        length = (size_t)(iend - ip);
+                        cpy    = op + length;
                     }
                     /* Finishing in the middle of a literals segment,
                      * due to lack of output space.
                      */
                     if (cpy > oend) {
                         cpy = oend;
-                        assert(op<=oend);
-                        length = (size_t)(oend-op);
+                        assert(op <= oend);
+                        length = (size_t)(oend - op);
                     }
                 } else {
-                     /* We must be on the last sequence (or invalid) because of the parsing limitations
+                    /* We must be on the last sequence (or invalid) because of the parsing limitations
                       * so check that we exactly consume the input and don't overrun the output buffer.
                       */
-                    if ((ip+length != iend) || (cpy > oend)) {
+                    if ((ip + length != iend) || (cpy > oend)) {
                         DEBUGLOG(5, "should have been last run of literals")
-                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", (void*)ip, (int)length, (void*)(ip+length), (void*)iend);
-                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", (void*)cpy, (void*)(oend-MFLIMIT));
-                        DEBUGLOG(5, "after writing %u bytes / %i bytes available", (unsigned)(op-(BYTE*)dst), outputSize);
+                        DEBUGLOG(5, "ip(%p) + length(%i) = %p != iend (%p)", (void*)ip, (int)length,
+                                 (void*)(ip + length), (void*)iend);
+                        DEBUGLOG(5, "or cpy(%p) > (oend-MFLIMIT)(%p)", (void*)cpy, (void*)(oend - MFLIMIT));
+                        DEBUGLOG(5, "after writing %u bytes / %i bytes available",
+                                 (unsigned)(op - (BYTE*)dst), outputSize);
                         goto _output_error;
                     }
                 }
-                LZ4_memmove(op, ip, length);  /* supports overlapping memory regions, for in-place decompression scenarios */
+                LZ4_memmove(op, ip,
+                            length); /* supports overlapping memory regions, for in-place decompression scenarios */
                 ip += length;
                 op += length;
                 /* Necessarily EOF when !partialDecoding.
@@ -2321,61 +2547,69 @@ LZ4_decompress_generic(
                  * filled the output buffer or
                  * can't proceed with reading an offset for following match.
                  */
-                if (!partialDecoding || (cpy == oend) || (ip >= (iend-2))) {
+                if (!partialDecoding || (cpy == oend) || (ip >= (iend - 2))) {
                     break;
                 }
             } else {
-                LZ4_wildCopy8(op, ip, cpy);   /* can overwrite up to 8 bytes beyond cpy */
-                ip += length; op = cpy;
+                LZ4_wildCopy8(op, ip, cpy); /* can overwrite up to 8 bytes beyond cpy */
+                ip += length;
+                op = cpy;
             }
 
             /* get offset */
-            offset = LZ4_readLE16(ip); ip+=2;
+            offset = LZ4_readLE16(ip);
+            ip += 2;
             match = op - offset;
 
             /* get matchlength */
             length = token & ML_MASK;
-            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op-(BYTE*)dst), (unsigned)length);
+            DEBUGLOG(7, "blockPos%6u: matchLength token = %u", (unsigned)(op - (BYTE*)dst), (unsigned)length);
 
-    _copy_match:
+_copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
-                if (addl == rvl_error) { goto _output_error; }
+                const size_t addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                if (addl == rvl_error) {
+                    goto _output_error;
+                }
                 length += addl;
-                if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */
+                if (unlikely((uptrval)(op) + length < (uptrval)op))
+                    goto _output_error; /* overflow detection */
             }
             length += MINMATCH;
 
-#if LZ4_FAST_DEC_LOOP
-        safe_match_copy:
-#endif
-            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix))) goto _output_error;   /* Error : offset outside buffers */
+#  if LZ4_FAST_DEC_LOOP
+safe_match_copy:
+#  endif
+            if ((checkOffset) && (unlikely(match + dictSize < lowPrefix)))
+                goto _output_error; /* Error : offset outside buffers */
             /* match starting within external dictionary */
-            if ((dict==usingExtDict) && (match < lowPrefix)) {
+            if ((dict == usingExtDict) && (match < lowPrefix)) {
                 assert(dictEnd != NULL);
-                if (unlikely(op+length > oend-LASTLITERALS)) {
-                    if (partialDecoding) length = MIN(length, (size_t)(oend-op));
-                    else goto _output_error;   /* doesn't respect parsing restriction */
+                if (unlikely(op + length > oend - LASTLITERALS)) {
+                    if (partialDecoding) length = MIN(length, (size_t)(oend - op));
+                    else goto _output_error; /* doesn't respect parsing restriction */
                 }
 
-                if (length <= (size_t)(lowPrefix-match)) {
+                if (length <= (size_t)(lowPrefix - match)) {
                     /* match fits entirely within external dictionary : just copy */
-                    LZ4_memmove(op, dictEnd - (lowPrefix-match), length);
+                    LZ4_memmove(op, dictEnd - (lowPrefix - match), length);
                     op += length;
                 } else {
                     /* match stretches into both external dictionary and current block */
-                    size_t const copySize = (size_t)(lowPrefix - match);
-                    size_t const restSize = length - copySize;
+                    const size_t copySize = (size_t)(lowPrefix - match);
+                    const size_t restSize = length - copySize;
                     LZ4_memcpy(op, dictEnd - copySize, copySize);
                     op += copySize;
-                    if (restSize > (size_t)(op - lowPrefix)) {  /* overlap copy */
+                    if (restSize > (size_t)(op - lowPrefix)) { /* overlap copy */
                         BYTE* const endOfMatch = op + restSize;
-                        const BYTE* copyFrom = lowPrefix;
-                        while (op < endOfMatch) *op++ = *copyFrom++;
+                        const BYTE* copyFrom   = lowPrefix;
+                        while (op < endOfMatch)
+                            *op++ = *copyFrom++;
                     } else {
                         LZ4_memcpy(op, lowPrefix, restSize);
                         op += restSize;
-                }   }
+                    }
+                }
                 continue;
             }
             assert(match >= lowPrefix);
@@ -2384,29 +2618,33 @@ LZ4_decompress_generic(
             cpy = op + length;
 
             /* partialDecoding : may end anywhere within the block */
-            assert(op<=oend);
-            if (partialDecoding && (cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
-                size_t const mlen = MIN(length, (size_t)(oend-op));
+            assert(op <= oend);
+            if (partialDecoding && (cpy > oend - MATCH_SAFEGUARD_DISTANCE)) {
+                const size_t      mlen     = MIN(length, (size_t)(oend - op));
                 const BYTE* const matchEnd = match + mlen;
-                BYTE* const copyEnd = op + mlen;
-                if (matchEnd > op) {   /* overlap copy */
-                    while (op < copyEnd) { *op++ = *match++; }
+                BYTE* const       copyEnd  = op + mlen;
+                if (matchEnd > op) { /* overlap copy */
+                    while (op < copyEnd) {
+                        *op++ = *match++;
+                    }
                 } else {
                     LZ4_memcpy(op, match, mlen);
                 }
                 op = copyEnd;
-                if (op == oend) { break; }
+                if (op == oend) {
+                    break;
+                }
                 continue;
             }
 
-            if (unlikely(offset<8)) {
-                LZ4_write32(op, 0);   /* silence msan warning when offset==0 */
+            if (unlikely(offset < 8)) {
+                LZ4_write32(op, 0); /* silence msan warning when offset==0 */
                 op[0] = match[0];
                 op[1] = match[1];
                 op[2] = match[2];
                 op[3] = match[3];
                 match += inc32table[offset];
-                LZ4_memcpy(op+4, match, 4);
+                LZ4_memcpy(op + 4, match, 4);
                 match -= dec64table[offset];
             } else {
                 LZ4_memcpy(op, match, 8);
@@ -2414,136 +2652,153 @@ LZ4_decompress_generic(
             }
             op += 8;
 
-            if (unlikely(cpy > oend-MATCH_SAFEGUARD_DISTANCE)) {
-                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH-1);
-                if (cpy > oend-LASTLITERALS) { goto _output_error; } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
+            if (unlikely(cpy > oend - MATCH_SAFEGUARD_DISTANCE)) {
+                BYTE* const oCopyLimit = oend - (WILDCOPYLENGTH - 1);
+                if (cpy > oend - LASTLITERALS) {
+                    goto _output_error;
+                } /* Error : last LASTLITERALS bytes must be literals (uncompressed) */
                 if (op < oCopyLimit) {
                     LZ4_wildCopy8(op, match, oCopyLimit);
                     match += oCopyLimit - op;
                     op = oCopyLimit;
                 }
-                while (op < cpy) { *op++ = *match++; }
+                while (op < cpy) {
+                    *op++ = *match++;
+                }
             } else {
                 LZ4_memcpy(op, match, 8);
-                if (length > 16) { LZ4_wildCopy8(op+8, match+8, cpy); }
+                if (length > 16) {
+                    LZ4_wildCopy8(op + 8, match + 8, cpy);
+                }
             }
-            op = cpy;   /* wildcopy correction */
+            op = cpy; /* wildcopy correction */
         }
 
         /* end of decoding */
-        DEBUGLOG(5, "decoded %i bytes", (int) (((char*)op)-dst));
-        return (int) (((char*)op)-dst);     /* Nb of output bytes decoded */
+        DEBUGLOG(5, "decoded %i bytes", (int)(((char*)op) - dst));
+        return (int)(((char*)op) - dst); /* Nb of output bytes decoded */
 
         /* Overflow error detected */
-    _output_error:
-        return (int) (-(((const char*)ip)-src))-1;
+_output_error:
+        return (int)(-(((const char*)ip) - src)) - 1;
     }
 }
-
 
 /*===== Instantiate the API decoding functions. =====*/
 
 LZ4_FORCE_O2
 int LZ4_decompress_safe(const char* source, char* dest, int compressedSize, int maxDecompressedSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize,
-                                  decode_full_block, noDict,
-                                  (BYTE*)dest, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxDecompressedSize, decode_full_block,
+                                  noDict, (BYTE*)dest, NULL, 0);
 }
 
 LZ4_FORCE_O2
 int LZ4_decompress_safe_partial(const char* src, char* dst, int compressedSize, int targetOutputSize, int dstCapacity)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity,
-                                  partial_decode,
-                                  noDict, (BYTE*)dst, NULL, 0);
+    return LZ4_decompress_generic(src, dst, compressedSize, dstCapacity, partial_decode, noDict, (BYTE*)dst,
+                                  NULL, 0);
 }
 
 LZ4_FORCE_O2
 int LZ4_decompress_fast(const char* source, char* dest, int originalSize)
 {
+    if (originalSize < 0) return -1; /* SECURITY: Negative size validation */
     DEBUGLOG(5, "LZ4_decompress_fast");
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                0, NULL, 0);
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 0, NULL, 0);
 }
 
 /*===== Instantiate a few more decoding cases, used more than once. =====*/
 
 LZ4_FORCE_O2 /* Exported, an obsolete API function. */
-int LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
+    int
+    LZ4_decompress_safe_withPrefix64k(const char* source, char* dest, int compressedSize, int maxOutputSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, withPrefix64k,
-                                  (BYTE*)dest - 64 KB, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  withPrefix64k, (BYTE*)dest - 64 KB, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_partial_withPrefix64k(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity)
+static int LZ4_decompress_safe_partial_withPrefix64k(const char* source,
+                                                     char*       dest,
+                                                     int         compressedSize,
+                                                     int         targetOutputSize,
+                                                     int         dstCapacity)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, withPrefix64k,
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, withPrefix64k,
                                   (BYTE*)dest - 64 KB, NULL, 0);
 }
 
 /* Another obsolete API function, paired with the previous one. */
 int LZ4_decompress_fast_withPrefix64k(const char* source, char* dest, int originalSize)
 {
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                64 KB, NULL, 0);
+    if (originalSize < 0) return -1; /* SECURITY: Negative size validation */
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 64 KB, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_withSmallPrefix(const char* source, char* dest, int compressedSize, int maxOutputSize,
-                                               size_t prefixSize)
+static int LZ4_decompress_safe_withSmallPrefix(const char* source,
+                                               char*       dest,
+                                               int         compressedSize,
+                                               int         maxOutputSize,
+                                               size_t      prefixSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, noDict,
-                                  (BYTE*)dest-prefixSize, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block, noDict,
+                                  (BYTE*)dest - prefixSize, NULL, 0);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity,
-                                               size_t prefixSize)
+static int LZ4_decompress_safe_partial_withSmallPrefix(const char* source,
+                                                       char*       dest,
+                                                       int         compressedSize,
+                                                       int         targetOutputSize,
+                                                       int         dstCapacity,
+                                                       size_t      prefixSize)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, noDict,
-                                  (BYTE*)dest-prefixSize, NULL, 0);
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, noDict,
+                                  (BYTE*)dest - prefixSize, NULL, 0);
 }
 
 LZ4_FORCE_O2
-int LZ4_decompress_safe_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int maxOutputSize,
-                                     const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_forceExtDict(const char* source,
+                                     char*       dest,
+                                     int         compressedSize,
+                                     int         maxOutputSize,
+                                     const void* dictStart,
+                                     size_t      dictSize)
 {
     DEBUGLOG(5, "LZ4_decompress_safe_forceExtDict");
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, usingExtDict,
-                                  (BYTE*)dest, (const BYTE*)dictStart, dictSize);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  usingExtDict, (BYTE*)dest, (const BYTE*)dictStart, dictSize);
 }
 
 LZ4_FORCE_O2
-int LZ4_decompress_safe_partial_forceExtDict(const char* source, char* dest,
-                                     int compressedSize, int targetOutputSize, int dstCapacity,
-                                     const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_partial_forceExtDict(const char* source,
+                                             char*       dest,
+                                             int         compressedSize,
+                                             int         targetOutputSize,
+                                             int         dstCapacity,
+                                             const void* dictStart,
+                                             size_t      dictSize)
 {
     dstCapacity = MIN(targetOutputSize, dstCapacity);
-    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity,
-                                  partial_decode, usingExtDict,
+    return LZ4_decompress_generic(source, dest, compressedSize, dstCapacity, partial_decode, usingExtDict,
                                   (BYTE*)dest, (const BYTE*)dictStart, dictSize);
 }
 
 LZ4_FORCE_O2
-static int LZ4_decompress_fast_extDict(const char* source, char* dest, int originalSize,
-                                       const void* dictStart, size_t dictSize)
+static int LZ4_decompress_fast_extDict(const char* source,
+                                       char*       dest,
+                                       int         originalSize,
+                                       const void* dictStart,
+                                       size_t      dictSize)
 {
-    return LZ4_decompress_unsafe_generic(
-                (const BYTE*)source, (BYTE*)dest, originalSize,
-                0, (const BYTE*)dictStart, dictSize);
+    if (originalSize < 0) return -1; /* SECURITY: Negative size validation */
+    return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, 0,
+                                         (const BYTE*)dictStart, dictSize);
 }
 
 /* The "double dictionary" mode, for use with e.g. ring buffers: the first part
@@ -2551,30 +2806,36 @@ static int LZ4_decompress_fast_extDict(const char* source, char* dest, int origi
  * These routines are used only once, in LZ4_decompress_*_continue().
  */
 LZ4_FORCE_INLINE
-int LZ4_decompress_safe_doubleDict(const char* source, char* dest, int compressedSize, int maxOutputSize,
-                                   size_t prefixSize, const void* dictStart, size_t dictSize)
+int LZ4_decompress_safe_doubleDict(const char* source,
+                                   char*       dest,
+                                   int         compressedSize,
+                                   int         maxOutputSize,
+                                   size_t      prefixSize,
+                                   const void* dictStart,
+                                   size_t      dictSize)
 {
-    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize,
-                                  decode_full_block, usingExtDict,
-                                  (BYTE*)dest-prefixSize, (const BYTE*)dictStart, dictSize);
+    return LZ4_decompress_generic(source, dest, compressedSize, maxOutputSize, decode_full_block,
+                                  usingExtDict, (BYTE*)dest - prefixSize, (const BYTE*)dictStart, dictSize);
 }
 
 /*===== streaming decompression functions =====*/
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamDecode_t* LZ4_createStreamDecode(void)
 {
     LZ4_STATIC_ASSERT(sizeof(LZ4_streamDecode_t) >= sizeof(LZ4_streamDecode_t_internal));
-    return (LZ4_streamDecode_t*) ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
+    return (LZ4_streamDecode_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamDecode_t));
 }
 
-int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
+int LZ4_freeStreamDecode(LZ4_streamDecode_t* LZ4_stream)
 {
-    if (LZ4_stream == NULL) { return 0; }  /* support free on NULL */
+    if (LZ4_stream == NULL) {
+        return 0;
+    } /* support free on NULL */
     FREEMEM(LZ4_stream);
     return 0;
 }
-#endif
+#  endif
 
 /*! LZ4_setStreamDecode() :
  *  Use this function to instruct where to find the dictionary.
@@ -2582,15 +2843,15 @@ int LZ4_freeStreamDecode (LZ4_streamDecode_t* LZ4_stream)
  *  Loading a size of 0 is allowed (same effect as no dictionary).
  * @return : 1 if OK, 0 if error
  */
-int LZ4_setStreamDecode (LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
+int LZ4_setStreamDecode(LZ4_streamDecode_t* LZ4_streamDecode, const char* dictionary, int dictSize)
 {
     LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
-    lz4sd->prefixSize = (size_t)dictSize;
+    lz4sd->prefixSize                  = (size_t)dictSize;
     if (dictSize) {
         assert(dictionary != NULL);
-        lz4sd->prefixEnd = (const BYTE*) dictionary + dictSize;
+        lz4sd->prefixEnd = (const BYTE*)dictionary + dictSize;
     } else {
-        lz4sd->prefixEnd = (const BYTE*) dictionary;
+        lz4sd->prefixEnd = (const BYTE*)dictionary;
     }
     lz4sd->externalDict = NULL;
     lz4sd->extDictSize  = 0;
@@ -2624,10 +2885,14 @@ int LZ4_decoderRingBufferSize(int maxBlockSize)
     and indicate where it stands using LZ4_setStreamDecode()
 */
 LZ4_FORCE_O2
-int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const char* source, char* dest, int compressedSize, int maxOutputSize)
+int LZ4_decompress_safe_continue(LZ4_streamDecode_t* LZ4_streamDecode,
+                                 const char*         source,
+                                 char*               dest,
+                                 int                 compressedSize,
+                                 int                 maxOutputSize)
 {
     LZ4_streamDecode_t_internal* lz4sd = &LZ4_streamDecode->internal_donotuse;
-    int result;
+    int                          result;
 
     if (lz4sd->prefixSize == 0) {
         /* The first call, no dictionary yet. */
@@ -2635,7 +2900,7 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
         result = LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)result;
-        lz4sd->prefixEnd = (BYTE*)dest + result;
+        lz4sd->prefixEnd  = (BYTE*)dest + result;
     } else if (lz4sd->prefixEnd == (BYTE*)dest) {
         /* They're rolling the current segment. */
         if (lz4sd->prefixSize >= 64 KB - 1)
@@ -2648,13 +2913,13 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
                                                     lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize += (size_t)result;
-        lz4sd->prefixEnd  += result;
+        lz4sd->prefixEnd += result;
     } else {
         /* The buffer wraps around, or they're switching to another buffer. */
-        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->extDictSize  = lz4sd->prefixSize;
         lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
-        result = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
-                                                  lz4sd->externalDict, lz4sd->extDictSize);
+        result              = LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize,
+                                                               lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)result;
         lz4sd->prefixEnd  = (BYTE*)dest + result;
@@ -2663,14 +2928,16 @@ int LZ4_decompress_safe_continue (LZ4_streamDecode_t* LZ4_streamDecode, const ch
     return result;
 }
 
-LZ4_FORCE_O2 int
-LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
-                        const char* source, char* dest, int originalSize)
+LZ4_FORCE_O2 int LZ4_decompress_fast_continue(LZ4_streamDecode_t* LZ4_streamDecode,
+                                              const char*         source,
+                                              char*               dest,
+                                              int                 originalSize)
 {
-    LZ4_streamDecode_t_internal* const lz4sd =
-        (assert(LZ4_streamDecode!=NULL), &LZ4_streamDecode->internal_donotuse);
-    int result;
+    LZ4_streamDecode_t_internal* const lz4sd = (assert(LZ4_streamDecode != NULL),
+                                                &LZ4_streamDecode->internal_donotuse);
+    int                                result;
 
+    if (originalSize < 0) return -1; /* SECURITY: Negative size validation */
     DEBUGLOG(5, "LZ4_decompress_fast_continue (toDecodeSize=%i)", originalSize);
     assert(originalSize >= 0);
 
@@ -2680,22 +2947,20 @@ LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
         result = LZ4_decompress_fast(source, dest, originalSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)originalSize;
-        lz4sd->prefixEnd = (BYTE*)dest + originalSize;
+        lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
     } else if (lz4sd->prefixEnd == (BYTE*)dest) {
         DEBUGLOG(5, "continue using existing prefix");
-        result = LZ4_decompress_unsafe_generic(
-                        (const BYTE*)source, (BYTE*)dest, originalSize,
-                        lz4sd->prefixSize,
-                        lz4sd->externalDict, lz4sd->extDictSize);
+        result = LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize,
+                                               lz4sd->prefixSize, lz4sd->externalDict, lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize += (size_t)originalSize;
-        lz4sd->prefixEnd  += originalSize;
+        lz4sd->prefixEnd += originalSize;
     } else {
         DEBUGLOG(5, "prefix becomes extDict");
-        lz4sd->extDictSize = lz4sd->prefixSize;
+        lz4sd->extDictSize  = lz4sd->prefixSize;
         lz4sd->externalDict = lz4sd->prefixEnd - lz4sd->extDictSize;
-        result = LZ4_decompress_fast_extDict(source, dest, originalSize,
-                                             lz4sd->externalDict, lz4sd->extDictSize);
+        result              = LZ4_decompress_fast_extDict(source, dest, originalSize, lz4sd->externalDict,
+                                                          lz4sd->extDictSize);
         if (result <= 0) return result;
         lz4sd->prefixSize = (size_t)originalSize;
         lz4sd->prefixEnd  = (BYTE*)dest + originalSize;
@@ -2704,7 +2969,6 @@ LZ4_decompress_fast_continue (LZ4_streamDecode_t* LZ4_streamDecode,
     return result;
 }
 
-
 /*
 Advanced decoding functions :
 *_usingDict() :
@@ -2712,46 +2976,64 @@ Advanced decoding functions :
     the dictionary must be explicitly provided within parameters
 */
 
-int LZ4_decompress_safe_usingDict(const char* source, char* dest, int compressedSize, int maxOutputSize, const char* dictStart, int dictSize)
+int LZ4_decompress_safe_usingDict(const char* source,
+                                  char*       dest,
+                                  int         compressedSize,
+                                  int         maxOutputSize,
+                                  const char* dictStart,
+                                  int         dictSize)
 {
-    if (dictSize==0)
-        return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
-    if (dictStart+dictSize == dest) {
+    if (dictSize == 0) return LZ4_decompress_safe(source, dest, compressedSize, maxOutputSize);
+    if (dictStart + dictSize == dest) {
         if (dictSize >= 64 KB - 1) {
             return LZ4_decompress_safe_withPrefix64k(source, dest, compressedSize, maxOutputSize);
         }
         assert(dictSize >= 0);
-        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize, (size_t)dictSize);
+        return LZ4_decompress_safe_withSmallPrefix(source, dest, compressedSize, maxOutputSize,
+                                                   (size_t)dictSize);
     }
     assert(dictSize >= 0);
-    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart, (size_t)dictSize);
+    return LZ4_decompress_safe_forceExtDict(source, dest, compressedSize, maxOutputSize, dictStart,
+                                            (size_t)dictSize);
 }
 
-int LZ4_decompress_safe_partial_usingDict(const char* source, char* dest, int compressedSize, int targetOutputSize, int dstCapacity, const char* dictStart, int dictSize)
+int LZ4_decompress_safe_partial_usingDict(const char* source,
+                                          char*       dest,
+                                          int         compressedSize,
+                                          int         targetOutputSize,
+                                          int         dstCapacity,
+                                          const char* dictStart,
+                                          int         dictSize)
 {
-    if (dictSize==0)
+    if (dictSize == 0)
         return LZ4_decompress_safe_partial(source, dest, compressedSize, targetOutputSize, dstCapacity);
-    if (dictStart+dictSize == dest) {
+    if (dictStart + dictSize == dest) {
         if (dictSize >= 64 KB - 1) {
-            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize, dstCapacity);
+            return LZ4_decompress_safe_partial_withPrefix64k(source, dest, compressedSize, targetOutputSize,
+                                                             dstCapacity);
         }
         assert(dictSize >= 0);
-        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize, dstCapacity, (size_t)dictSize);
+        return LZ4_decompress_safe_partial_withSmallPrefix(source, dest, compressedSize, targetOutputSize,
+                                                           dstCapacity, (size_t)dictSize);
     }
     assert(dictSize >= 0);
-    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize, dstCapacity, dictStart, (size_t)dictSize);
+    return LZ4_decompress_safe_partial_forceExtDict(source, dest, compressedSize, targetOutputSize,
+                                                    dstCapacity, dictStart, (size_t)dictSize);
 }
 
-int LZ4_decompress_fast_usingDict(const char* source, char* dest, int originalSize, const char* dictStart, int dictSize)
+int LZ4_decompress_fast_usingDict(const char* source,
+                                  char*       dest,
+                                  int         originalSize,
+                                  const char* dictStart,
+                                  int         dictSize)
 {
-    if (dictSize==0 || dictStart+dictSize == dest)
-        return LZ4_decompress_unsafe_generic(
-                        (const BYTE*)source, (BYTE*)dest, originalSize,
-                        (size_t)dictSize, NULL, 0);
+    if (originalSize < 0) return -1; /* SECURITY: Negative size validation */
+    if (dictSize == 0 || dictStart + dictSize == dest)
+        return LZ4_decompress_unsafe_generic((const BYTE*)source, (BYTE*)dest, originalSize, (size_t)dictSize,
+                                             NULL, 0);
     assert(dictSize >= 0);
     return LZ4_decompress_fast_extDict(source, dest, originalSize, dictStart, (size_t)dictSize);
 }
-
 
 /*=*************************************************
 *  Obsolete Functions
@@ -2761,23 +3043,32 @@ int LZ4_compress_limitedOutput(const char* source, char* dest, int inputSize, in
 {
     return LZ4_compress_default(source, dest, inputSize, maxOutputSize);
 }
+
 int LZ4_compress(const char* src, char* dest, int srcSize)
 {
     return LZ4_compress_default(src, dest, srcSize, LZ4_compressBound(srcSize));
 }
-int LZ4_compress_limitedOutput_withState (void* state, const char* src, char* dst, int srcSize, int dstSize)
+
+int LZ4_compress_limitedOutput_withState(void* state, const char* src, char* dst, int srcSize, int dstSize)
 {
     return LZ4_compress_fast_extState(state, src, dst, srcSize, dstSize, 1);
 }
-int LZ4_compress_withState (void* state, const char* src, char* dst, int srcSize)
+
+int LZ4_compress_withState(void* state, const char* src, char* dst, int srcSize)
 {
     return LZ4_compress_fast_extState(state, src, dst, srcSize, LZ4_compressBound(srcSize), 1);
 }
-int LZ4_compress_limitedOutput_continue (LZ4_stream_t* LZ4_stream, const char* src, char* dst, int srcSize, int dstCapacity)
+
+int LZ4_compress_limitedOutput_continue(LZ4_stream_t* LZ4_stream,
+                                        const char*   src,
+                                        char*         dst,
+                                        int           srcSize,
+                                        int           dstCapacity)
 {
     return LZ4_compress_fast_continue(LZ4_stream, src, dst, srcSize, dstCapacity, 1);
 }
-int LZ4_compress_continue (LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
+
+int LZ4_compress_continue(LZ4_stream_t* LZ4_stream, const char* source, char* dest, int inputSize)
 {
     return LZ4_compress_fast_continue(LZ4_stream, source, dest, inputSize, LZ4_compressBound(inputSize), 1);
 }
@@ -2788,18 +3079,22 @@ They are only provided here for compatibility with older user programs.
 - LZ4_uncompress is totally equivalent to LZ4_decompress_fast
 - LZ4_uncompress_unknownOutputSize is totally equivalent to LZ4_decompress_safe
 */
-int LZ4_uncompress (const char* source, char* dest, int outputSize)
+int LZ4_uncompress(const char* source, char* dest, int outputSize)
 {
     return LZ4_decompress_fast(source, dest, outputSize);
 }
-int LZ4_uncompress_unknownOutputSize (const char* source, char* dest, int isize, int maxOutputSize)
+
+int LZ4_uncompress_unknownOutputSize(const char* source, char* dest, int isize, int maxOutputSize)
 {
     return LZ4_decompress_safe(source, dest, isize, maxOutputSize);
 }
 
 /* Obsolete Streaming functions */
 
-int LZ4_sizeofStreamState(void) { return sizeof(LZ4_stream_t); }
+int LZ4_sizeofStreamState(void)
+{
+    return sizeof(LZ4_stream_t);
+}
 
 int LZ4_resetStreamState(void* state, char* inputBuffer)
 {
@@ -2808,18 +3103,18 @@ int LZ4_resetStreamState(void* state, char* inputBuffer)
     return 0;
 }
 
-#if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-void* LZ4_create (char* inputBuffer)
+#  if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
+void* LZ4_create(char* inputBuffer)
 {
     (void)inputBuffer;
     return LZ4_createStream();
 }
-#endif
+#  endif
 
-char* LZ4_slideInputBuffer (void* state)
+char* LZ4_slideInputBuffer(void* state)
 {
     /* avoid const char * -> char * conversion warning */
-    return (char *)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
+    return (char*)(uptrval)((LZ4_stream_t*)state)->internal_donotuse.dictionary;
 }
 
-#endif   /* LZ4_COMMONDEFS_ONLY */
+#endif /* LZ4_COMMONDEFS_ONLY */

--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -40,7 +40,6 @@
  * (see Memory Routines below).
  */
 
-
 /*-************************************
 *  Compiler Options
 **************************************/
@@ -48,7 +47,6 @@
 #ifdef _MSC_VER    /* Visual Studio */
 #  pragma warning(disable : 4127)   /* disable: C4127: conditional expression is constant */
 #endif
-
 
 /*-************************************
 *  Tuning parameters
@@ -62,7 +60,6 @@
 #  define LZ4F_HEAPMODE 0
 #endif
 
-
 /*-************************************
 *  Library declarations
 **************************************/
@@ -74,7 +71,6 @@
 #include "lz4hc.h"
 #define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"
-
 
 /*-************************************
 *  Memory routines
@@ -88,13 +84,13 @@
 
 #include <string.h>   /* memset, memcpy, memmove */
 #ifndef LZ4_SRC_INCLUDED  /* avoid redefinition when sources are coalesced */
-#  define MEM_INIT(p,v,s)   memset((p),(v),(s))
+#  define MEM_INIT(p, v, s) memset((p), (v), (s))
 #endif
 
 #ifndef LZ4_SRC_INCLUDED   /* avoid redefinition when sources are coalesced */
 #  include <stdlib.h>   /* malloc, calloc, free */
 #  define ALLOC(s)          malloc(s)
-#  define ALLOC_AND_ZERO(s) calloc(1,(s))
+#  define ALLOC_AND_ZERO(s) calloc(1, (s))
 #  define FREEMEM(p)        free(p)
 #endif
 
@@ -109,10 +105,12 @@ static void* LZ4F_calloc(size_t s, LZ4F_CustomMem cmem)
         return ALLOC_AND_ZERO(s);
     }
     /* only custom alloc defined : use it, and combine it with memset() */
-    {   void* const p = cmem.customAlloc(cmem.opaqueState, s);
+    {
+        void* const p = cmem.customAlloc(cmem.opaqueState, s);
         if (p != NULL) MEM_INIT(p, 0, s);
         return p;
-}   }
+    }
+}
 
 static void* LZ4F_malloc(size_t s, LZ4F_CustomMem cmem)
 {
@@ -136,11 +134,10 @@ static void LZ4F_free(void* p, LZ4F_CustomMem cmem)
     FREEMEM(p);
 }
 
-
 /*-************************************
 *  Debug
 **************************************/
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=1)
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 1)
 #  include <assert.h>
 #else
 #  ifndef assert
@@ -148,98 +145,104 @@ static void LZ4F_free(void* p, LZ4F_CustomMem cmem)
 #  endif
 #endif
 
-#define LZ4F_STATIC_ASSERT(c)    { enum { LZ4F_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
+#define LZ4F_STATIC_ASSERT(c)                           \
+    {                                                   \
+        enum { LZ4F_static_assert = 1 / (int)(!!(c)) }; \
+    }   /* use only *after* variable declarations */
 
-#if defined(LZ4_DEBUG) && (LZ4_DEBUG>=2) && !defined(DEBUGLOG)
+#undef DEBUGLOG
+#if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
 #  include <stdio.h>
 static int g_debuglog_enable = 1;
-#  define DEBUGLOG(l, ...) {                                  \
-                if ((g_debuglog_enable) && (l<=LZ4_DEBUG)) {  \
-                    fprintf(stderr, __FILE__ " %i: ", __LINE__ );  \
-                    fprintf(stderr, __VA_ARGS__);             \
-                    fprintf(stderr, " \n");                   \
-            }   }
+#  define DEBUGLOG(l, ...)                                 \
+      {                                                    \
+          if ((g_debuglog_enable) && (l <= LZ4_DEBUG)) {   \
+              fprintf(stderr, __FILE__ " %i: ", __LINE__); \
+              fprintf(stderr, __VA_ARGS__);                \
+              fprintf(stderr, " \n");                      \
+          }                                                \
+      }
 #else
-#  define DEBUGLOG(l, ...)      {}    /* disabled */
+#  define DEBUGLOG(l, ...) \
+      {                    \
+      }    /* disabled */
 #endif
-
 
 /*-************************************
 *  Basic Types
 **************************************/
 #ifndef LZ4_SRC_INCLUDED
-# if !defined (__VMS) && (defined (__cplusplus) || (defined (__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */) )
-#   include <stdint.h>
-    typedef  uint8_t BYTE;
-    typedef uint16_t U16;
-    typedef uint32_t U32;
-    typedef  int32_t S32;
-    typedef uint64_t U64;
-# else
-    typedef unsigned char      BYTE;
-    typedef unsigned short     U16;
-    typedef unsigned int       U32;
-    typedef   signed int       S32;
-    typedef unsigned long long U64;
-# endif
+#  if !defined(__VMS) && \
+      (defined(__cplusplus) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 */))
+#    include <stdint.h>
+typedef uint8_t  BYTE;
+typedef uint16_t U16;
+typedef uint32_t U32;
+typedef int32_t  S32;
+typedef uint64_t U64;
+#  else
+typedef unsigned char      BYTE;
+typedef unsigned short     U16;
+typedef unsigned int       U32;
+typedef signed int         S32;
+typedef unsigned long long U64;
+#  endif
 #endif
 
-
 /* unoptimized version; solves endianness & alignment issues */
-static U32 LZ4F_readLE32 (const void* src)
+static U32 LZ4F_readLE32(const void* src)
 {
-    const BYTE* const srcPtr = (const BYTE*)src;
-    U32 value32 = srcPtr[0];
-    value32 |= ((U32)srcPtr[1])<< 8;
-    value32 |= ((U32)srcPtr[2])<<16;
-    value32 |= ((U32)srcPtr[3])<<24;
+    const BYTE* const srcPtr  = (const BYTE*)src;
+    U32               value32 = srcPtr[0];
+    value32 |= ((U32)srcPtr[1]) << 8;
+    value32 |= ((U32)srcPtr[2]) << 16;
+    value32 |= ((U32)srcPtr[3]) << 24;
     return value32;
 }
 
-static void LZ4F_writeLE32 (void* dst, U32 value32)
+static void LZ4F_writeLE32(void* dst, U32 value32)
 {
     BYTE* const dstPtr = (BYTE*)dst;
-    dstPtr[0] = (BYTE)value32;
-    dstPtr[1] = (BYTE)(value32 >> 8);
-    dstPtr[2] = (BYTE)(value32 >> 16);
-    dstPtr[3] = (BYTE)(value32 >> 24);
+    dstPtr[0]          = (BYTE)value32;
+    dstPtr[1]          = (BYTE)(value32 >> 8);
+    dstPtr[2]          = (BYTE)(value32 >> 16);
+    dstPtr[3]          = (BYTE)(value32 >> 24);
 }
 
-static U64 LZ4F_readLE64 (const void* src)
+static U64 LZ4F_readLE64(const void* src)
 {
-    const BYTE* const srcPtr = (const BYTE*)src;
-    U64 value64 = srcPtr[0];
-    value64 |= ((U64)srcPtr[1]<<8);
-    value64 |= ((U64)srcPtr[2]<<16);
-    value64 |= ((U64)srcPtr[3]<<24);
-    value64 |= ((U64)srcPtr[4]<<32);
-    value64 |= ((U64)srcPtr[5]<<40);
-    value64 |= ((U64)srcPtr[6]<<48);
-    value64 |= ((U64)srcPtr[7]<<56);
+    const BYTE* const srcPtr  = (const BYTE*)src;
+    U64               value64 = srcPtr[0];
+    value64 |= ((U64)srcPtr[1] << 8);
+    value64 |= ((U64)srcPtr[2] << 16);
+    value64 |= ((U64)srcPtr[3] << 24);
+    value64 |= ((U64)srcPtr[4] << 32);
+    value64 |= ((U64)srcPtr[5] << 40);
+    value64 |= ((U64)srcPtr[6] << 48);
+    value64 |= ((U64)srcPtr[7] << 56);
     return value64;
 }
 
-static void LZ4F_writeLE64 (void* dst, U64 value64)
+static void LZ4F_writeLE64(void* dst, U64 value64)
 {
     BYTE* const dstPtr = (BYTE*)dst;
-    dstPtr[0] = (BYTE)value64;
-    dstPtr[1] = (BYTE)(value64 >> 8);
-    dstPtr[2] = (BYTE)(value64 >> 16);
-    dstPtr[3] = (BYTE)(value64 >> 24);
-    dstPtr[4] = (BYTE)(value64 >> 32);
-    dstPtr[5] = (BYTE)(value64 >> 40);
-    dstPtr[6] = (BYTE)(value64 >> 48);
-    dstPtr[7] = (BYTE)(value64 >> 56);
+    dstPtr[0]          = (BYTE)value64;
+    dstPtr[1]          = (BYTE)(value64 >> 8);
+    dstPtr[2]          = (BYTE)(value64 >> 16);
+    dstPtr[3]          = (BYTE)(value64 >> 24);
+    dstPtr[4]          = (BYTE)(value64 >> 32);
+    dstPtr[5]          = (BYTE)(value64 >> 40);
+    dstPtr[6]          = (BYTE)(value64 >> 48);
+    dstPtr[7]          = (BYTE)(value64 >> 56);
 }
-
 
 /*-************************************
 *  Constants
 **************************************/
 #ifndef LZ4_SRC_INCLUDED   /* avoid double definition */
-#  define KB *(1<<10)
-#  define MB *(1<<20)
-#  define GB *(1<<30)
+#  define KB *(1 << 10)
+#  define MB *(1 << 20)
+#  define GB *(1 << 30)
 #endif
 
 #define _1BIT  0x01
@@ -249,52 +252,49 @@ static void LZ4F_writeLE64 (void* dst, U64 value64)
 #define _8BITS 0xFF
 
 #define LZ4F_BLOCKUNCOMPRESSED_FLAG 0x80000000U
-#define LZ4F_BLOCKSIZEID_DEFAULT LZ4F_max64KB
+#define LZ4F_BLOCKSIZEID_DEFAULT    LZ4F_max64KB
 
 static const size_t minFHSize = LZ4F_HEADER_SIZE_MIN;   /*  7 */
 static const size_t maxFHSize = LZ4F_HEADER_SIZE_MAX;   /* 19 */
-static const size_t BHSize = LZ4F_BLOCK_HEADER_SIZE;  /* block header : size, and compress flag */
-static const size_t BFSize = LZ4F_BLOCK_CHECKSUM_SIZE;  /* block footer : checksum (optional) */
-
+static const size_t BHSize    = LZ4F_BLOCK_HEADER_SIZE;  /* block header : size, and compress flag */
+static const size_t BFSize    = LZ4F_BLOCK_CHECKSUM_SIZE;  /* block footer : checksum (optional) */
 
 /*-************************************
 *  Structures and local types
 **************************************/
 
-typedef enum { LZ4B_COMPRESSED, LZ4B_UNCOMPRESSED} LZ4F_BlockCompressMode_e;
+typedef enum { LZ4B_COMPRESSED, LZ4B_UNCOMPRESSED } LZ4F_BlockCompressMode_e;
+
 typedef enum { ctxNone, ctxFast, ctxHC } LZ4F_CtxType_e;
 
-typedef struct LZ4F_cctx_s
-{
-    LZ4F_CustomMem cmem;
+typedef struct LZ4F_cctx_s {
+    LZ4F_CustomMem     cmem;
     LZ4F_preferences_t prefs;
-    U32    version;
-    U32    cStage;     /* 0 : compression uninitialized ; 1 : initialized, can compress */
-    const LZ4F_CDict* cdict;
-    size_t maxBlockSize;
-    size_t maxBufferSize;
-    BYTE*  tmpBuff;    /* internal buffer, for streaming */
-    BYTE*  tmpIn;      /* starting position of data compress within internal buffer (>= tmpBuff) */
-    size_t tmpInSize;  /* amount of data to compress after tmpIn */
-    U64    totalInSize;
-    XXH32_state_t xxh;
-    void*  lz4CtxPtr;
-    U16    lz4CtxAlloc; /* sized for: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
-    U16    lz4CtxType;  /* in use as: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
-    LZ4F_BlockCompressMode_e  blockCompressMode;
+    U32                version;
+    U32                cStage;     /* 0 : compression uninitialized ; 1 : initialized, can compress */
+    const LZ4F_CDict*  cdict;
+    size_t             maxBlockSize;
+    size_t             maxBufferSize;
+    BYTE*              tmpBuff;    /* internal buffer, for streaming */
+    BYTE*              tmpIn; /* starting position of data compress within internal buffer (>= tmpBuff) */
+    size_t             tmpInSize; /* amount of data to compress after tmpIn */
+    U64                totalInSize;
+    XXH32_state_t      xxh;
+    void*              lz4CtxPtr;
+    U16                lz4CtxAlloc; /* sized for: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
+    U16                lz4CtxType; /* in use as: 0 = none, 1 = lz4 ctx, 2 = lz4hc ctx */
+    LZ4F_BlockCompressMode_e blockCompressMode;
 } LZ4F_cctx_t;
-
 
 /*-************************************
 *  Error management
 **************************************/
 #define LZ4F_GENERATE_STRING(STRING) #STRING,
-static const char* LZ4F_errorStrings[] = { LZ4F_LIST_ERRORS(LZ4F_GENERATE_STRING) };
-
+static const char* LZ4F_errorStrings[] = {LZ4F_LIST_ERRORS(LZ4F_GENERATE_STRING)};
 
 unsigned LZ4F_isError(LZ4F_errorCode_t code)
 {
-    return (code > (LZ4F_errorCode_t)(-LZ4F_ERROR_maxCode));
+    return code > (LZ4F_errorCode_t)(-LZ4F_ERROR_maxCode);
 }
 
 const char* LZ4F_getErrorName(LZ4F_errorCode_t code)
@@ -314,58 +314,67 @@ static LZ4F_errorCode_t LZ4F_returnErrorCode(LZ4F_errorCodes code)
 {
     /* A compilation error here means sizeof(ptrdiff_t) is not large enough */
     LZ4F_STATIC_ASSERT(sizeof(ptrdiff_t) >= sizeof(size_t));
-    return (LZ4F_errorCode_t)-(ptrdiff_t)code;
+    return (LZ4F_errorCode_t) - (ptrdiff_t)code;
 }
 
-#define RETURN_ERROR(e) return LZ4F_returnErrorCode(LZ4F_ERROR_ ## e)
+#define RETURN_ERROR(e) return LZ4F_returnErrorCode(LZ4F_ERROR_##e)
 
-#define RETURN_ERROR_IF(c,e) do {  \
-        if (c) {                   \
+#define RETURN_ERROR_IF(c, e)          \
+    do {                               \
+        if (c) {                       \
             DEBUGLOG(3, "Error: " #c); \
-            RETURN_ERROR(e);       \
-        }                          \
+            RETURN_ERROR(e);           \
+        }                              \
     } while (0)
 
-#define FORWARD_IF_ERROR(r) do { if (LZ4F_isError(r)) return (r); } while (0)
+#define FORWARD_IF_ERROR(r)              \
+    do {                                 \
+        if (LZ4F_isError(r)) return (r); \
+    } while (0)
 
-unsigned LZ4F_getVersion(void) { return LZ4F_VERSION; }
+unsigned LZ4F_getVersion(void)
+{
+    return LZ4F_VERSION;
+}
 
-int LZ4F_compressionLevel_max(void) { return LZ4HC_CLEVEL_MAX; }
+int LZ4F_compressionLevel_max(void)
+{
+    return LZ4HC_CLEVEL_MAX;
+}
 
 size_t LZ4F_getBlockSize(LZ4F_blockSizeID_t blockSizeID)
 {
-    static const size_t blockSizes[4] = { 64 KB, 256 KB, 1 MB, 4 MB };
+    static const size_t blockSizes[4] = {64 KB, 256 KB, 1 MB, 4 MB};
 
     if (blockSizeID == 0) blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
-    if (blockSizeID < LZ4F_max64KB || blockSizeID > LZ4F_max4MB)
-        RETURN_ERROR(maxBlockSize_invalid);
-    {   int const blockSizeIdx = (int)blockSizeID - (int)LZ4F_max64KB;
+    if (blockSizeID < LZ4F_max64KB || blockSizeID > LZ4F_max4MB) RETURN_ERROR(maxBlockSize_invalid);
+    {
+        const int blockSizeIdx = (int)blockSizeID - (int)LZ4F_max64KB;
         return blockSizes[blockSizeIdx];
-}   }
+    }
+}
 
 /*-************************************
 *  Private functions
 **************************************/
-#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
+#undef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static BYTE LZ4F_headerChecksum (const void* header, size_t length)
+static BYTE LZ4F_headerChecksum(const void* header, size_t length)
 {
     U32 const xxh = XXH32(header, length, 0);
     return (BYTE)(xxh >> 8);
 }
 
-
 /*-************************************
 *  Simple-pass compression functions
 **************************************/
-static LZ4F_blockSizeID_t LZ4F_optimalBSID(const LZ4F_blockSizeID_t requestedBSID,
-                                           const size_t srcSize)
+static LZ4F_blockSizeID_t LZ4F_optimalBSID(const LZ4F_blockSizeID_t requestedBSID, const size_t srcSize)
 {
     LZ4F_blockSizeID_t proposedBSID = LZ4F_max64KB;
-    size_t maxBlockSize = 64 KB;
+    size_t             maxBlockSize = 64 KB;
     while (requestedBSID > proposedBSID) {
-        if (srcSize <= maxBlockSize)
-            return proposedBSID;
+        if (srcSize <= maxBlockSize) return proposedBSID;
         proposedBSID = (LZ4F_blockSizeID_t)((int)proposedBSID + 1);
         maxBlockSize <<= 2;
     }
@@ -378,45 +387,44 @@ static LZ4F_blockSizeID_t LZ4F_optimalBSID(const LZ4F_blockSizeID_t requestedBSI
  * @return is always the same for a srcSize and prefsPtr, so it can be relied upon to size reusable buffers.
  *  When srcSize==0, LZ4F_compressBound() provides an upper bound for LZ4F_flush() and LZ4F_compressEnd() operations.
  */
-static size_t LZ4F_compressBound_internal(size_t srcSize,
-                                    const LZ4F_preferences_t* preferencesPtr,
-                                          size_t alreadyBuffered)
+static size_t
+LZ4F_compressBound_internal(size_t srcSize, const LZ4F_preferences_t* preferencesPtr, size_t alreadyBuffered)
 {
-    LZ4F_preferences_t prefsNull = LZ4F_INIT_PREFERENCES;
-    prefsNull.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;   /* worst case */
-    prefsNull.frameInfo.blockChecksumFlag = LZ4F_blockChecksumEnabled;   /* worst case */
-    {   const LZ4F_preferences_t* const prefsPtr = (preferencesPtr==NULL) ? &prefsNull : preferencesPtr;
-        U32 const flush = prefsPtr->autoFlush | (srcSize==0);
-        LZ4F_blockSizeID_t const blockID = prefsPtr->frameInfo.blockSizeID;
-        size_t const blockSize = LZ4F_getBlockSize(blockID);
-        size_t const maxBuffered = blockSize - 1;
-        size_t const bufferedSize = MIN(alreadyBuffered, maxBuffered);
-        size_t const maxSrcSize = srcSize + bufferedSize;
-        unsigned const nbFullBlocks = (unsigned)(maxSrcSize / blockSize);
-        size_t const partialBlockSize = maxSrcSize & (blockSize-1);
-        size_t const lastBlockSize = flush ? partialBlockSize : 0;
-        unsigned const nbBlocks = nbFullBlocks + (lastBlockSize>0);
+    LZ4F_preferences_t prefsNull            = LZ4F_INIT_PREFERENCES;
+    prefsNull.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled; /* worst case */
+    prefsNull.frameInfo.blockChecksumFlag   = LZ4F_blockChecksumEnabled; /* worst case */
+    {
+        const LZ4F_preferences_t* const prefsPtr     = (preferencesPtr == NULL) ? &prefsNull : preferencesPtr;
+        U32 const                       flush        = prefsPtr->autoFlush | (srcSize == 0);
+        const LZ4F_blockSizeID_t        blockID      = prefsPtr->frameInfo.blockSizeID;
+        const size_t                    blockSize    = LZ4F_getBlockSize(blockID);
+        const size_t                    maxBuffered  = blockSize - 1;
+        const size_t                    bufferedSize = MIN(alreadyBuffered, maxBuffered);
+        const size_t                    maxSrcSize   = srcSize + bufferedSize;
+        const unsigned                  nbFullBlocks = (unsigned)(maxSrcSize / blockSize);
+        const size_t                    partialBlockSize = maxSrcSize & (blockSize - 1);
+        const size_t                    lastBlockSize    = flush ? partialBlockSize : 0;
+        const unsigned                  nbBlocks         = nbFullBlocks + (lastBlockSize > 0);
 
-        size_t const blockCRCSize = BFSize * prefsPtr->frameInfo.blockChecksumFlag;
-        size_t const frameEnd = BHSize + (prefsPtr->frameInfo.contentChecksumFlag*BFSize);
+        const size_t blockCRCSize = BFSize * prefsPtr->frameInfo.blockChecksumFlag;
+        const size_t frameEnd     = BHSize + (prefsPtr->frameInfo.contentChecksumFlag * BFSize);
 
-        return ((BHSize + blockCRCSize) * nbBlocks) +
-               (blockSize * nbFullBlocks) + lastBlockSize + frameEnd;
+        return ((BHSize + blockCRCSize) * nbBlocks) + (blockSize * nbFullBlocks) + lastBlockSize + frameEnd;
     }
 }
 
 size_t LZ4F_compressFrameBound(size_t srcSize, const LZ4F_preferences_t* preferencesPtr)
 {
     LZ4F_preferences_t prefs;
-    size_t const headerSize = maxFHSize;      /* max header size, including optional fields */
+    const size_t       headerSize = maxFHSize; /* max header size, including optional fields */
 
-    if (preferencesPtr!=NULL) prefs = *preferencesPtr;
+    if (preferencesPtr != NULL) prefs = *preferencesPtr;
     else MEM_INIT(&prefs, 0, sizeof(prefs));
     prefs.autoFlush = 1;
 
-    return headerSize + LZ4F_compressBound_internal(srcSize, &prefs, 0);;
+    return headerSize + LZ4F_compressBound_internal(srcSize, &prefs, 0);
+    ;
 }
-
 
 /*! LZ4F_compressFrame_usingCDict() :
  *  Compress srcBuffer using a dictionary, in a single step.
@@ -427,54 +435,62 @@ size_t LZ4F_compressFrameBound(size_t srcSize, const LZ4F_preferences_t* prefere
  * @return : number of bytes written into dstBuffer,
  *           or an error code if it fails (can be tested using LZ4F_isError())
  */
-size_t LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
-                                     void* dstBuffer, size_t dstCapacity,
-                               const void* srcBuffer, size_t srcSize,
-                               const LZ4F_CDict* cdict,
-                               const LZ4F_preferences_t* preferencesPtr)
+size_t LZ4F_compressFrame_usingCDict(LZ4F_cctx*                cctx,
+                                     void*                     dstBuffer,
+                                     size_t                    dstCapacity,
+                                     const void*               srcBuffer,
+                                     size_t                    srcSize,
+                                     const LZ4F_CDict*         cdict,
+                                     const LZ4F_preferences_t* preferencesPtr)
 {
-    LZ4F_preferences_t prefs;
+    LZ4F_preferences_t     prefs;
     LZ4F_compressOptions_t options;
-    BYTE* const dstStart = (BYTE*) dstBuffer;
-    BYTE* dstPtr = dstStart;
-    BYTE* const dstEnd = dstStart + dstCapacity;
+    BYTE* const            dstStart = (BYTE*)dstBuffer;
+    BYTE*                  dstPtr   = dstStart;
+    BYTE* const            dstEnd   = dstStart + dstCapacity;
 
     DEBUGLOG(4, "LZ4F_compressFrame_usingCDict (srcSize=%u)", (unsigned)srcSize);
-    if (preferencesPtr!=NULL)
-        prefs = *preferencesPtr;
-    else
-        MEM_INIT(&prefs, 0, sizeof(prefs));
+    if (preferencesPtr != NULL) prefs = *preferencesPtr;
+    else MEM_INIT(&prefs, 0, sizeof(prefs));
     if (prefs.frameInfo.contentSize != 0)
-        prefs.frameInfo.contentSize = (U64)srcSize;   /* auto-correct content size if selected (!=0) */
+        prefs.frameInfo.contentSize = (U64)srcSize; /* auto-correct content size if selected (!=0) */
 
     prefs.frameInfo.blockSizeID = LZ4F_optimalBSID(prefs.frameInfo.blockSizeID, srcSize);
-    prefs.autoFlush = 1;
+    prefs.autoFlush             = 1;
     if (srcSize <= LZ4F_getBlockSize(prefs.frameInfo.blockSizeID))
-        prefs.frameInfo.blockMode = LZ4F_blockIndependent;   /* only one block => no need for inter-block link */
+        prefs.frameInfo.blockMode = LZ4F_blockIndependent; /* only one block => no need for inter-block link */
 
     MEM_INIT(&options, 0, sizeof(options));
     options.stableSrc = 1;
 
     RETURN_ERROR_IF(dstCapacity < LZ4F_compressFrameBound(srcSize, &prefs), dstMaxSize_tooSmall);
 
-    { size_t const headerSize = LZ4F_compressBegin_usingCDict(cctx, dstBuffer, dstCapacity, cdict, &prefs);  /* write header */
-      FORWARD_IF_ERROR(headerSize);
-      dstPtr += headerSize;   /* header size */ }
+    {
+        const size_t headerSize = LZ4F_compressBegin_usingCDict(cctx, dstBuffer, dstCapacity, cdict,
+                                                                &prefs); /* write header */
+        FORWARD_IF_ERROR(headerSize);
+        dstPtr += headerSize; /* header size */
+    }
 
     assert(dstEnd >= dstPtr);
-    { size_t const cSize = LZ4F_compressUpdate(cctx, dstPtr, (size_t)(dstEnd-dstPtr), srcBuffer, srcSize, &options);
-      FORWARD_IF_ERROR(cSize);
-      dstPtr += cSize; }
+    {
+        const size_t cSize = LZ4F_compressUpdate(cctx, dstPtr, (size_t)(dstEnd - dstPtr), srcBuffer, srcSize,
+                                                 &options);
+        FORWARD_IF_ERROR(cSize);
+        dstPtr += cSize;
+    }
 
     assert(dstEnd >= dstPtr);
-    { size_t const tailSize = LZ4F_compressEnd(cctx, dstPtr, (size_t)(dstEnd-dstPtr), &options);   /* flush last block, and generate suffix */
-      FORWARD_IF_ERROR(tailSize);
-      dstPtr += tailSize; }
+    {
+        const size_t tailSize = LZ4F_compressEnd(cctx, dstPtr, (size_t)(dstEnd - dstPtr),
+                                                 &options); /* flush last block, and generate suffix */
+        FORWARD_IF_ERROR(tailSize);
+        dstPtr += tailSize;
+    }
 
     assert(dstEnd >= dstStart);
     return (size_t)(dstPtr - dstStart);
 }
-
 
 /*! LZ4F_compressFrame() :
  *  Compress an entire srcBuffer into a valid LZ4 frame, in a single step.
@@ -483,9 +499,11 @@ size_t LZ4F_compressFrame_usingCDict(LZ4F_cctx* cctx,
  * @return : number of bytes written into dstBuffer.
  *           or an error code if it fails (can be tested using LZ4F_isError())
  */
-size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
-                    const void* srcBuffer, size_t srcSize,
-                    const LZ4F_preferences_t* preferencesPtr)
+size_t LZ4F_compressFrame(void*                     dstBuffer,
+                          size_t                    dstCapacity,
+                          const void*               srcBuffer,
+                          size_t                    srcSize,
+                          const LZ4F_preferences_t* preferencesPtr)
 {
     size_t result;
 #if (LZ4F_HEAPMODE)
@@ -493,63 +511,56 @@ size_t LZ4F_compressFrame(void* dstBuffer, size_t dstCapacity,
     result = LZ4F_createCompressionContext(&cctxPtr, LZ4F_VERSION);
     FORWARD_IF_ERROR(result);
 #else
-    LZ4F_cctx_t cctx;
-    LZ4_stream_t lz4ctx;
+    LZ4F_cctx_t        cctx;
+    LZ4_stream_t       lz4ctx;
     LZ4F_cctx_t* const cctxPtr = &cctx;
 
     MEM_INIT(&cctx, 0, sizeof(cctx));
     cctx.version = LZ4F_VERSION;
-    cctx.maxBufferSize = 5 MB;   /* mess with real buffer size to prevent dynamic allocation; works only because autoflush==1 & stableSrc==1 */
-    if ( preferencesPtr == NULL
-      || preferencesPtr->compressionLevel < LZ4HC_CLEVEL_MIN ) {
+    cctx.maxBufferSize = 5 MB; /* mess with real buffer size to prevent dynamic allocation; works only because autoflush==1 & stableSrc==1 */
+    if (preferencesPtr == NULL || preferencesPtr->compressionLevel < LZ4HC_CLEVEL_MIN) {
         LZ4_initStream(&lz4ctx, sizeof(lz4ctx));
-        cctxPtr->lz4CtxPtr = &lz4ctx;
+        cctxPtr->lz4CtxPtr   = &lz4ctx;
         cctxPtr->lz4CtxAlloc = 1;
-        cctxPtr->lz4CtxType = ctxFast;
+        cctxPtr->lz4CtxType  = ctxFast;
     }
 #endif
     DEBUGLOG(4, "LZ4F_compressFrame");
 
-    result = LZ4F_compressFrame_usingCDict(cctxPtr, dstBuffer, dstCapacity,
-                                           srcBuffer, srcSize,
-                                           NULL, preferencesPtr);
+    result = LZ4F_compressFrame_usingCDict(cctxPtr, dstBuffer, dstCapacity, srcBuffer, srcSize, NULL,
+                                           preferencesPtr);
 
 #if (LZ4F_HEAPMODE)
     LZ4F_freeCompressionContext(cctxPtr);
 #else
-    if ( preferencesPtr != NULL
-      && preferencesPtr->compressionLevel >= LZ4HC_CLEVEL_MIN ) {
+    if (preferencesPtr != NULL && preferencesPtr->compressionLevel >= LZ4HC_CLEVEL_MIN) {
         LZ4F_free(cctxPtr->lz4CtxPtr, cctxPtr->cmem);
     }
 #endif
     return result;
 }
 
-
 /*-***************************************************
 *   Dictionary compression
 *****************************************************/
 
 struct LZ4F_CDict_s {
-    LZ4F_CustomMem cmem;
-    void* dictContent;
-    LZ4_stream_t* fastCtx;
+    LZ4F_CustomMem  cmem;
+    void*           dictContent;
+    LZ4_stream_t*   fastCtx;
     LZ4_streamHC_t* HCCtx;
 }; /* typedef'd to LZ4F_CDict within lz4frame_static.h */
 
-LZ4F_CDict*
-LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t dictSize)
+LZ4F_CDict* LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t dictSize)
 {
     const char* dictStart = (const char*)dictBuffer;
-    LZ4F_CDict* cdict = NULL;
+    LZ4F_CDict* cdict     = NULL;
 
     DEBUGLOG(4, "LZ4F_createCDict_advanced");
 
-    if (!dictStart)
-        return NULL;
+    if (!dictStart) return NULL;
     cdict = (LZ4F_CDict*)LZ4F_malloc(sizeof(*cdict), cmem);
-    if (!cdict)
-        return NULL;
+    if (!cdict) return NULL;
 
     cdict->cmem = cmem;
     if (dictSize > 64 KB) {
@@ -559,7 +570,7 @@ LZ4F_createCDict_advanced(LZ4F_CustomMem cmem, const void* dictBuffer, size_t di
     cdict->dictContent = LZ4F_malloc(dictSize, cmem);
     /* note: using @cmem to allocate => can't use default create */
     cdict->fastCtx = (LZ4_stream_t*)LZ4F_malloc(sizeof(LZ4_stream_t), cmem);
-    cdict->HCCtx = (LZ4_streamHC_t*)LZ4F_malloc(sizeof(LZ4_streamHC_t), cmem);
+    cdict->HCCtx   = (LZ4_streamHC_t*)LZ4F_malloc(sizeof(LZ4_streamHC_t), cmem);
     if (!cdict->dictContent || !cdict->fastCtx || !cdict->HCCtx) {
         LZ4F_freeCDict(cdict);
         return NULL;
@@ -589,28 +600,25 @@ LZ4F_CDict* LZ4F_createCDict(const void* dictBuffer, size_t dictSize)
 
 void LZ4F_freeCDict(LZ4F_CDict* cdict)
 {
-    if (cdict==NULL) return;  /* support free on NULL */
+    if (cdict == NULL) return; /* support free on NULL */
     LZ4F_free(cdict->dictContent, cdict->cmem);
     LZ4F_free(cdict->fastCtx, cdict->cmem);
     LZ4F_free(cdict->HCCtx, cdict->cmem);
     LZ4F_free(cdict, cdict->cmem);
 }
 
-
 /*-*********************************
 *  Advanced compression functions
 ***********************************/
 
-LZ4F_cctx*
-LZ4F_createCompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version)
+LZ4F_cctx* LZ4F_createCompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version)
 {
-    LZ4F_cctx* const cctxPtr =
-        (LZ4F_cctx*)LZ4F_calloc(sizeof(LZ4F_cctx), customMem);
-    if (cctxPtr==NULL) return NULL;
+    LZ4F_cctx* const cctxPtr = (LZ4F_cctx*)LZ4F_calloc(sizeof(LZ4F_cctx), customMem);
+    if (cctxPtr == NULL) return NULL;
 
-    cctxPtr->cmem = customMem;
+    cctxPtr->cmem    = customMem;
     cctxPtr->version = version;
-    cctxPtr->cStage = 0;   /* Uninitialized. Next stage : init cctx */
+    cctxPtr->cStage  = 0; /* Uninitialized. Next stage : init cctx */
 
     return cctxPtr;
 }
@@ -623,28 +631,27 @@ LZ4F_createCompressionContext_advanced(LZ4F_CustomMem customMem, unsigned versio
  *  If the result LZ4F_errorCode_t is not OK_NoError, there was an error during context creation.
  *  Object can release its memory using LZ4F_freeCompressionContext();
 **/
-LZ4F_errorCode_t
-LZ4F_createCompressionContext(LZ4F_cctx** LZ4F_compressionContextPtr, unsigned version)
+LZ4F_errorCode_t LZ4F_createCompressionContext(LZ4F_cctx** LZ4F_compressionContextPtr, unsigned version)
 {
     assert(LZ4F_compressionContextPtr != NULL); /* considered a violation of narrow contract */
     /* in case it nonetheless happen in production */
     RETURN_ERROR_IF(LZ4F_compressionContextPtr == NULL, parameter_null);
 
     *LZ4F_compressionContextPtr = LZ4F_createCompressionContext_advanced(LZ4F_defaultCMem, version);
-    RETURN_ERROR_IF(*LZ4F_compressionContextPtr==NULL, allocation_failed);
+    RETURN_ERROR_IF(*LZ4F_compressionContextPtr == NULL, allocation_failed);
     return LZ4F_OK_NoError;
 }
 
 LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctxPtr)
 {
-    if (cctxPtr != NULL) {  /* support free on NULL */
-       LZ4F_free(cctxPtr->lz4CtxPtr, cctxPtr->cmem);  /* note: LZ4_streamHC_t and LZ4_stream_t are simple POD types */
-       LZ4F_free(cctxPtr->tmpBuff, cctxPtr->cmem);
-       LZ4F_free(cctxPtr, cctxPtr->cmem);
+    if (cctxPtr != NULL) { /* support free on NULL */
+        LZ4F_free(cctxPtr->lz4CtxPtr,
+                  cctxPtr->cmem); /* note: LZ4_streamHC_t and LZ4_stream_t are simple POD types */
+        LZ4F_free(cctxPtr->tmpBuff, cctxPtr->cmem);
+        LZ4F_free(cctxPtr, cctxPtr->cmem);
     }
     return LZ4F_OK_NoError;
 }
-
 
 /**
  * This function prepares the internal LZ4(HC) stream for a new compression,
@@ -654,10 +661,8 @@ LZ4F_errorCode_t LZ4F_freeCompressionContext(LZ4F_cctx* cctxPtr)
  * stream (i.e., at the beginning of a frame in blockLinked mode, or at the
  * beginning of each block in blockIndependent mode).
  */
-static void LZ4F_initStream(void* ctx,
-                            const LZ4F_CDict* cdict,
-                            int level,
-                            LZ4F_blockMode_t blockMode) {
+static void LZ4F_initStream(void* ctx, const LZ4F_CDict* cdict, int level, LZ4F_blockMode_t blockMode)
+{
     if (level < LZ4HC_CLEVEL_MIN) {
         if (cdict || blockMode == LZ4F_blockLinked) {
             /* In these cases, we will call LZ4_compress_fast_continue(),
@@ -667,8 +672,7 @@ static void LZ4F_initStream(void* ctx,
              * tableType they need the context to be in. So in that case this
              * would be misguided / wasted work. */
             LZ4_resetStream_fast((LZ4_stream_t*)ctx);
-            if (cdict)
-                LZ4_attach_dictionary((LZ4_stream_t*)ctx, cdict->fastCtx);
+            if (cdict) LZ4_attach_dictionary((LZ4_stream_t*)ctx, cdict->fastCtx);
         }
         /* In these cases, we'll call a one-shot API.
          * The non-continued APIs internally perform their own resets
@@ -677,13 +681,13 @@ static void LZ4F_initStream(void* ctx,
          * Therefore, a reset here would be wasted work. */
     } else {
         LZ4_resetStreamHC_fast((LZ4_streamHC_t*)ctx, level);
-        if (cdict)
-            LZ4_attach_HC_dictionary((LZ4_streamHC_t*)ctx, cdict->HCCtx);
+        if (cdict) LZ4_attach_HC_dictionary((LZ4_streamHC_t*)ctx, cdict->HCCtx);
     }
 }
 
-static int ctxTypeID_to_size(int ctxTypeID) {
-    switch(ctxTypeID) {
+static int ctxTypeID_to_size(int ctxTypeID)
+{
+    switch (ctxTypeID) {
     case 1:
         return LZ4_sizeofState();
     case 2:
@@ -693,7 +697,8 @@ static int ctxTypeID_to_size(int ctxTypeID) {
     }
 }
 
-size_t LZ4F_cctx_size(const LZ4F_cctx* cctx) {
+size_t LZ4F_cctx_size(const LZ4F_cctx* cctx)
+{
     if (cctx == NULL) {
         return 0;
     }
@@ -703,15 +708,17 @@ size_t LZ4F_cctx_size(const LZ4F_cctx* cctx) {
 /* LZ4F_compressBegin_internal()
  * Note: only accepts @cdict _or_ @dictBuffer as non NULL.
  */
-static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
-                          void* dstBuffer, size_t dstCapacity,
-                          const void* dictBuffer, size_t dictSize,
-                          const LZ4F_CDict* cdict,
-                          const LZ4F_preferences_t* preferencesPtr)
+static size_t LZ4F_compressBegin_internal(LZ4F_cctx*                cctx,
+                                          void*                     dstBuffer,
+                                          size_t                    dstCapacity,
+                                          const void*               dictBuffer,
+                                          size_t                    dictSize,
+                                          const LZ4F_CDict*         cdict,
+                                          const LZ4F_preferences_t* preferencesPtr)
 {
-    LZ4F_preferences_t const prefNull = LZ4F_INIT_PREFERENCES;
-    BYTE* const dstStart = (BYTE*)dstBuffer;
-    BYTE* dstPtr = dstStart;
+    const LZ4F_preferences_t prefNull = LZ4F_INIT_PREFERENCES;
+    BYTE* const              dstStart = (BYTE*)dstBuffer;
+    BYTE*                    dstPtr   = dstStart;
 
     RETURN_ERROR_IF(dstCapacity < maxFHSize, dstMaxSize_tooSmall);
     if (preferencesPtr == NULL) preferencesPtr = &prefNull;
@@ -719,9 +726,10 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
     DEBUGLOG(5, "LZ4F_compressBegin_internal: Independent_blocks=%u", cctx->prefs.frameInfo.blockMode);
 
     /* cctx Management */
-    {   U16 const ctxTypeID = (cctx->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ? 1 : 2;
-        int requiredSize = ctxTypeID_to_size(ctxTypeID);
-        int allocatedSize = ctxTypeID_to_size(cctx->lz4CtxAlloc);
+    {
+        U16 const ctxTypeID     = (cctx->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ? 1 : 2;
+        int       requiredSize  = ctxTypeID_to_size(ctxTypeID);
+        int       allocatedSize = ctxTypeID_to_size(cctx->lz4CtxAlloc);
         if (allocatedSize < requiredSize) {
             /* not enough space allocated */
             LZ4F_free(cctx->lz4CtxPtr, cctx->cmem);
@@ -729,16 +737,14 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
                 /* must take ownership of memory allocation,
                  * in order to respect custom allocator contract */
                 cctx->lz4CtxPtr = LZ4F_malloc(sizeof(LZ4_stream_t), cctx->cmem);
-                if (cctx->lz4CtxPtr)
-                    LZ4_initStream(cctx->lz4CtxPtr, sizeof(LZ4_stream_t));
+                if (cctx->lz4CtxPtr) LZ4_initStream(cctx->lz4CtxPtr, sizeof(LZ4_stream_t));
             } else {
                 cctx->lz4CtxPtr = LZ4F_malloc(sizeof(LZ4_streamHC_t), cctx->cmem);
-                if (cctx->lz4CtxPtr)
-                    LZ4_initStreamHC(cctx->lz4CtxPtr, sizeof(LZ4_streamHC_t));
+                if (cctx->lz4CtxPtr) LZ4_initStreamHC(cctx->lz4CtxPtr, sizeof(LZ4_streamHC_t));
             }
             RETURN_ERROR_IF(cctx->lz4CtxPtr == NULL, allocation_failed);
             cctx->lz4CtxAlloc = ctxTypeID;
-            cctx->lz4CtxType = ctxTypeID;
+            cctx->lz4CtxType  = ctxTypeID;
         } else if (cctx->lz4CtxType != ctxTypeID) {
             /* otherwise, a sufficient buffer is already allocated,
              * but we need to reset it to the correct context type */
@@ -749,16 +755,20 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
                 LZ4_setCompressionLevel((LZ4_streamHC_t*)cctx->lz4CtxPtr, cctx->prefs.compressionLevel);
             }
             cctx->lz4CtxType = ctxTypeID;
-    }   }
+        }
+    }
 
     /* Buffer Management */
-    if (cctx->prefs.frameInfo.blockSizeID == 0)
-        cctx->prefs.frameInfo.blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
+    if (cctx->prefs.frameInfo.blockSizeID == 0) cctx->prefs.frameInfo.blockSizeID = LZ4F_BLOCKSIZEID_DEFAULT;
     cctx->maxBlockSize = LZ4F_getBlockSize(cctx->prefs.frameInfo.blockSizeID);
 
-    {   size_t const requiredBuffSize = preferencesPtr->autoFlush ?
-                ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 64 KB : 0) :  /* only needs past data up to window size */
-                cctx->maxBlockSize + ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 128 KB : 0);
+    {
+        const size_t requiredBuffSize = preferencesPtr->autoFlush
+                                            ? ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 64 KB : 0)
+                                            : /* only needs past data up to window size */
+                                            cctx->maxBlockSize +
+                                                ((cctx->prefs.frameInfo.blockMode == LZ4F_blockLinked) ? 128 KB
+                                                                                                       : 0);
 
         if (cctx->maxBufferSize < requiredBuffSize) {
             cctx->maxBufferSize = 0;
@@ -766,8 +776,9 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
             cctx->tmpBuff = (BYTE*)LZ4F_malloc(requiredBuffSize, cctx->cmem);
             RETURN_ERROR_IF(cctx->tmpBuff == NULL, allocation_failed);
             cctx->maxBufferSize = requiredBuffSize;
-    }   }
-    cctx->tmpIn = cctx->tmpBuff;
+        }
+    }
+    cctx->tmpIn     = cctx->tmpBuff;
     cctx->tmpInSize = 0;
     (void)XXH32_reset(&(cctx->xxh), 0);
 
@@ -798,15 +809,16 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
     /* Magic Number */
     LZ4F_writeLE32(dstPtr, LZ4F_MAGICNUMBER);
     dstPtr += 4;
-    {   BYTE* const headerStart = dstPtr;
+    {
+        BYTE* const headerStart = dstPtr;
 
         /* FLG Byte */
-        *dstPtr++ = (BYTE)(((1 & _2BITS) << 6)    /* Version('01') */
-            + ((cctx->prefs.frameInfo.blockMode & _1BIT ) << 5)
-            + ((cctx->prefs.frameInfo.blockChecksumFlag & _1BIT ) << 4)
-            + ((unsigned)(cctx->prefs.frameInfo.contentSize > 0) << 3)
-            + ((cctx->prefs.frameInfo.contentChecksumFlag & _1BIT ) << 2)
-            +  (cctx->prefs.frameInfo.dictID > 0) );
+        *dstPtr++ = (BYTE)(((1 & _2BITS) << 6) /* Version('01') */
+                           + ((cctx->prefs.frameInfo.blockMode & _1BIT) << 5) +
+                           ((cctx->prefs.frameInfo.blockChecksumFlag & _1BIT) << 4) +
+                           ((unsigned)(cctx->prefs.frameInfo.contentSize > 0) << 3) +
+                           ((cctx->prefs.frameInfo.contentChecksumFlag & _1BIT) << 2) +
+                           (cctx->prefs.frameInfo.dictID > 0));
         /* BD Byte */
         *dstPtr++ = (BYTE)((cctx->prefs.frameInfo.blockSizeID & _3BITS) << 4);
         /* Optional Frame content size field */
@@ -825,56 +837,53 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
         dstPtr++;
     }
 
-    cctx->cStage = 1;   /* header written, now request input data block */
+    cctx->cStage = 1; /* header written, now request input data block */
     return (size_t)(dstPtr - dstStart);
 }
 
-size_t LZ4F_compressBegin(LZ4F_cctx* cctx,
-                          void* dstBuffer, size_t dstCapacity,
+size_t LZ4F_compressBegin(LZ4F_cctx*                cctx,
+                          void*                     dstBuffer,
+                          size_t                    dstCapacity,
                           const LZ4F_preferences_t* preferencesPtr)
 {
-    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
-                                        NULL, 0,
-                                        NULL, preferencesPtr);
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity, NULL, 0, NULL, preferencesPtr);
 }
 
 /* LZ4F_compressBegin_usingDictOnce:
  * Hidden implementation,
  * employed for multi-threaded compression
  * when frame defines linked blocks */
-static size_t LZ4F_compressBegin_usingDictOnce(LZ4F_cctx* cctx,
-                          void* dstBuffer, size_t dstCapacity,
-                          const void* dict, size_t dictSize,
-                          const LZ4F_preferences_t* preferencesPtr)
+static size_t LZ4F_compressBegin_usingDictOnce(LZ4F_cctx*                cctx,
+                                               void*                     dstBuffer,
+                                               size_t                    dstCapacity,
+                                               const void*               dict,
+                                               size_t                    dictSize,
+                                               const LZ4F_preferences_t* preferencesPtr)
 {
-    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
-                                        dict, dictSize,
-                                        NULL, preferencesPtr);
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity, dict, dictSize, NULL, preferencesPtr);
 }
 
-size_t LZ4F_compressBegin_usingDict(LZ4F_cctx* cctx,
-                          void* dstBuffer, size_t dstCapacity,
-                          const void* dict, size_t dictSize,
-                          const LZ4F_preferences_t* preferencesPtr)
+size_t LZ4F_compressBegin_usingDict(LZ4F_cctx*                cctx,
+                                    void*                     dstBuffer,
+                                    size_t                    dstCapacity,
+                                    const void*               dict,
+                                    size_t                    dictSize,
+                                    const LZ4F_preferences_t* preferencesPtr)
 {
     /* note : incorrect implementation :
      * this will only use the dictionary once,
      * instead of once *per* block when frames defines independent blocks */
-    return LZ4F_compressBegin_usingDictOnce(cctx, dstBuffer, dstCapacity,
-                                        dict, dictSize,
-                                        preferencesPtr);
+    return LZ4F_compressBegin_usingDictOnce(cctx, dstBuffer, dstCapacity, dict, dictSize, preferencesPtr);
 }
 
-size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx* cctx,
-                          void* dstBuffer, size_t dstCapacity,
-                          const LZ4F_CDict* cdict,
-                          const LZ4F_preferences_t* preferencesPtr)
+size_t LZ4F_compressBegin_usingCDict(LZ4F_cctx*                cctx,
+                                     void*                     dstBuffer,
+                                     size_t                    dstCapacity,
+                                     const LZ4F_CDict*         cdict,
+                                     const LZ4F_preferences_t* preferencesPtr)
 {
-    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity,
-                                        NULL, 0,
-                                       cdict, preferencesPtr);
+    return LZ4F_compressBegin_internal(cctx, dstBuffer, dstCapacity, NULL, 0, cdict, preferencesPtr);
 }
-
 
 /*  LZ4F_compressBound() :
  * @return minimum capacity of dstBuffer for a given srcSize to handle worst case scenario.
@@ -889,46 +898,57 @@ size_t LZ4F_compressBound(size_t srcSize, const LZ4F_preferences_t* preferencesP
     return LZ4F_compressBound_internal(srcSize, preferencesPtr, (size_t)-1);
 }
 
-
-typedef int (*compressFunc_t)(void* ctx, const char* src, char* dst, int srcSize, int dstSize, int level, const LZ4F_CDict* cdict);
-
+typedef int (*compressFunc_t)(void*             ctx,
+                              const char*       src,
+                              char*             dst,
+                              int               srcSize,
+                              int               dstSize,
+                              int               level,
+                              const LZ4F_CDict* cdict);
 
 /*! LZ4F_makeBlock():
  *  compress a single block, add header and optional checksum.
  *  assumption : dst buffer capacity is >= BHSize + srcSize + crcSize
  */
-static size_t LZ4F_makeBlock(void* dst,
-                       const void* src, size_t srcSize,
-                             compressFunc_t compress, void* lz4ctx, int level,
-                       const LZ4F_CDict* cdict,
+static size_t LZ4F_makeBlock(void*                dst,
+                             const void*          src,
+                             size_t               srcSize,
+                             compressFunc_t       compress,
+                             void*                lz4ctx,
+                             int                  level,
+                             const LZ4F_CDict*    cdict,
                              LZ4F_blockChecksum_t crcFlag)
 {
-    BYTE* const cSizePtr = (BYTE*)dst;
-    int dstCapacity = (srcSize > 1) ? (int)srcSize - 1 : 1;
-    U32 cSize;
+    BYTE* const cSizePtr    = (BYTE*)dst;
+    int         dstCapacity = (srcSize > 1) ? (int)srcSize - 1 : 1;
+    U32         cSize;
     assert(compress != NULL);
-    cSize = (U32)compress(lz4ctx, (const char*)src, (char*)(cSizePtr+BHSize),
-                          (int)srcSize, dstCapacity,
+    cSize = (U32)compress(lz4ctx, (const char*)src, (char*)(cSizePtr + BHSize), (int)srcSize, dstCapacity,
                           level, cdict);
 
     if (cSize == 0 || cSize >= srcSize) {
         cSize = (U32)srcSize;
         LZ4F_writeLE32(cSizePtr, cSize | LZ4F_BLOCKUNCOMPRESSED_FLAG);
-        memcpy(cSizePtr+BHSize, src, srcSize);
+        memcpy(cSizePtr + BHSize, src, srcSize);
     } else {
         LZ4F_writeLE32(cSizePtr, cSize);
     }
     if (crcFlag) {
-        U32 const crc32 = XXH32(cSizePtr+BHSize, cSize, 0);  /* checksum of compressed data */
-        LZ4F_writeLE32(cSizePtr+BHSize+cSize, crc32);
+        U32 const crc32 = XXH32(cSizePtr + BHSize, cSize, 0); /* checksum of compressed data */
+        LZ4F_writeLE32(cSizePtr + BHSize + cSize, crc32);
     }
-    return BHSize + cSize + ((U32)crcFlag)*BFSize;
+    return BHSize + cSize + ((U32)crcFlag) * BFSize;
 }
 
-
-static int LZ4F_compressBlock(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+static int LZ4F_compressBlock(void*             ctx,
+                              const char*       src,
+                              char*             dst,
+                              int               srcSize,
+                              int               dstCapacity,
+                              int               level,
+                              const LZ4F_CDict* cdict)
 {
-    int const acceleration = (level < 0) ? -level + 1 : 1;
+    const int acceleration = (level < 0) ? -level + 1 : 1;
     DEBUGLOG(5, "LZ4F_compressBlock (srcSize=%i)", srcSize);
     LZ4F_initStream(ctx, cdict, level, LZ4F_blockIndependent);
     if (cdict) {
@@ -938,15 +958,27 @@ static int LZ4F_compressBlock(void* ctx, const char* src, char* dst, int srcSize
     }
 }
 
-static int LZ4F_compressBlock_continue(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+static int LZ4F_compressBlock_continue(void*             ctx,
+                                       const char*       src,
+                                       char*             dst,
+                                       int               srcSize,
+                                       int               dstCapacity,
+                                       int               level,
+                                       const LZ4F_CDict* cdict)
 {
-    int const acceleration = (level < 0) ? -level + 1 : 1;
+    const int acceleration = (level < 0) ? -level + 1 : 1;
     (void)cdict; /* init once at beginning of frame */
     DEBUGLOG(5, "LZ4F_compressBlock_continue (srcSize=%i)", srcSize);
     return LZ4_compress_fast_continue((LZ4_stream_t*)ctx, src, dst, srcSize, dstCapacity, acceleration);
 }
 
-static int LZ4F_compressBlockHC(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+static int LZ4F_compressBlockHC(void*             ctx,
+                                const char*       src,
+                                char*             dst,
+                                int               srcSize,
+                                int               dstCapacity,
+                                int               level,
+                                const LZ4F_CDict* cdict)
 {
     LZ4F_initStream(ctx, cdict, level, LZ4F_blockIndependent);
     if (cdict) {
@@ -955,22 +987,41 @@ static int LZ4F_compressBlockHC(void* ctx, const char* src, char* dst, int srcSi
     return LZ4_compress_HC_extStateHC_fastReset(ctx, src, dst, srcSize, dstCapacity, level);
 }
 
-static int LZ4F_compressBlockHC_continue(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+static int LZ4F_compressBlockHC_continue(void*             ctx,
+                                         const char*       src,
+                                         char*             dst,
+                                         int               srcSize,
+                                         int               dstCapacity,
+                                         int               level,
+                                         const LZ4F_CDict* cdict)
 {
-    (void)level; (void)cdict; /* init once at beginning of frame */
+    (void)level;
+    (void)cdict; /* init once at beginning of frame */
     return LZ4_compress_HC_continue((LZ4_streamHC_t*)ctx, src, dst, srcSize, dstCapacity);
 }
 
-static int LZ4F_doNotCompressBlock(void* ctx, const char* src, char* dst, int srcSize, int dstCapacity, int level, const LZ4F_CDict* cdict)
+static int LZ4F_doNotCompressBlock(void*             ctx,
+                                   const char*       src,
+                                   char*             dst,
+                                   int               srcSize,
+                                   int               dstCapacity,
+                                   int               level,
+                                   const LZ4F_CDict* cdict)
 {
-    (void)ctx; (void)src; (void)dst; (void)srcSize; (void)dstCapacity; (void)level; (void)cdict;
+    (void)ctx;
+    (void)src;
+    (void)dst;
+    (void)srcSize;
+    (void)dstCapacity;
+    (void)level;
+    (void)cdict;
     return 0;
 }
 
-static compressFunc_t LZ4F_selectCompression(LZ4F_blockMode_t blockMode, int level, LZ4F_BlockCompressMode_e  compressMode)
+static compressFunc_t
+LZ4F_selectCompression(LZ4F_blockMode_t blockMode, int level, LZ4F_BlockCompressMode_e compressMode)
 {
-    if (compressMode == LZ4B_UNCOMPRESSED)
-        return LZ4F_doNotCompressBlock;
+    if (compressMode == LZ4B_UNCOMPRESSED) return LZ4F_doNotCompressBlock;
     if (level < LZ4HC_CLEVEL_MIN) {
         if (blockMode == LZ4F_blockIndependent) return LZ4F_compressBlock;
         return LZ4F_compressBlock_continue;
@@ -982,16 +1033,20 @@ static compressFunc_t LZ4F_selectCompression(LZ4F_blockMode_t blockMode, int lev
 /* Save or shorten history (up to 64KB) into @tmpBuff */
 static void LZ4F_localSaveDict(LZ4F_cctx_t* cctxPtr)
 {
-    int const dictSize = (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN) ?
-                    LZ4_saveDict ((LZ4_stream_t*)(cctxPtr->lz4CtxPtr), (char*)(cctxPtr->tmpBuff), 64 KB) :
-                    LZ4_saveDictHC ((LZ4_streamHC_t*)(cctxPtr->lz4CtxPtr), (char*)(cctxPtr->tmpBuff), 64 KB);
-    cctxPtr->tmpIn = cctxPtr->tmpBuff + dictSize;
+    const int dictSize = (cctxPtr->prefs.compressionLevel < LZ4HC_CLEVEL_MIN)
+                             ? LZ4_saveDict((LZ4_stream_t*)(cctxPtr->lz4CtxPtr), (char*)(cctxPtr->tmpBuff),
+                                            64 KB)
+                             : LZ4_saveDictHC((LZ4_streamHC_t*)(cctxPtr->lz4CtxPtr),
+                                              (char*)(cctxPtr->tmpBuff), 64 KB);
+    cctxPtr->tmpIn     = cctxPtr->tmpBuff + dictSize;
 }
 
 typedef enum { notDone, fromTmpBuffer, fromSrcBuffer } LZ4F_lastBlockStatus;
 
-static const LZ4F_compressOptions_t k_cOptionsNull = { 0, { 0, 0, 0 } };
-
+static const LZ4F_compressOptions_t k_cOptionsNull = {
+    0,
+    {0, 0, 0}
+};
 
 /*! LZ4F_compressUpdateImpl() :
  *  LZ4F_compressUpdate() can be called repetitively to compress as much data as necessary.
@@ -1005,28 +1060,31 @@ static const LZ4F_compressOptions_t k_cOptionsNull = { 0, { 0, 0, 0 } };
  *           or an error code if it fails (which can be tested using LZ4F_isError())
  *  After an error, the state is left in a UB state, and must be re-initialized.
  */
-static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
-                     void* dstBuffer, size_t dstCapacity,
-                     const void* srcBuffer, size_t srcSize,
-                     const LZ4F_compressOptions_t* compressOptionsPtr,
-                     LZ4F_BlockCompressMode_e blockCompression)
-  {
-    size_t const blockSize = cctxPtr->maxBlockSize;
-    const BYTE* srcPtr = (const BYTE*)srcBuffer;
-    const BYTE* const srcEnd = srcSize ? (assert(srcPtr!=NULL), srcPtr + srcSize) : srcPtr;
-    BYTE* const dstStart = (BYTE*)dstBuffer;
-    BYTE* dstPtr = dstStart;
+static size_t LZ4F_compressUpdateImpl(LZ4F_cctx*                    cctxPtr,
+                                      void*                         dstBuffer,
+                                      size_t                        dstCapacity,
+                                      const void*                   srcBuffer,
+                                      size_t                        srcSize,
+                                      const LZ4F_compressOptions_t* compressOptionsPtr,
+                                      LZ4F_BlockCompressMode_e      blockCompression)
+{
+    const size_t         blockSize           = cctxPtr->maxBlockSize;
+    const BYTE*          srcPtr              = (const BYTE*)srcBuffer;
+    const BYTE* const    srcEnd              = srcSize ? (assert(srcPtr != NULL), srcPtr + srcSize) : srcPtr;
+    BYTE* const          dstStart            = (BYTE*)dstBuffer;
+    BYTE*                dstPtr              = dstStart;
     LZ4F_lastBlockStatus lastBlockCompressed = notDone;
-    compressFunc_t const compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel, blockCompression);
-    size_t bytesWritten;
+    const compressFunc_t compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode,
+                                                           cctxPtr->prefs.compressionLevel, blockCompression);
+    size_t               bytesWritten;
     DEBUGLOG(4, "LZ4F_compressUpdate (srcSize=%zu)", srcSize);
 
-    RETURN_ERROR_IF(cctxPtr->cStage != 1, compressionState_uninitialized);   /* state must be initialized and waiting for next block */
+    RETURN_ERROR_IF(cctxPtr->cStage != 1,
+                    compressionState_uninitialized); /* state must be initialized and waiting for next block */
     if (dstCapacity < LZ4F_compressBound_internal(srcSize, &(cctxPtr->prefs), cctxPtr->tmpInSize))
         RETURN_ERROR(dstMaxSize_tooSmall);
 
-    if (blockCompression == LZ4B_UNCOMPRESSED && dstCapacity < srcSize)
-        RETURN_ERROR(dstMaxSize_tooSmall);
+    if (blockCompression == LZ4B_UNCOMPRESSED && dstCapacity < srcSize) RETURN_ERROR(dstMaxSize_tooSmall);
 
     /* flush currently written block, to continue with new block compression */
     if (cctxPtr->blockCompressMode != blockCompression) {
@@ -1038,8 +1096,8 @@ static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
     if (compressOptionsPtr == NULL) compressOptionsPtr = &k_cOptionsNull;
 
     /* complete tmp buffer */
-    if (cctxPtr->tmpInSize > 0) {   /* some data already within tmp buffer */
-        size_t const sizeToCopy = blockSize - cctxPtr->tmpInSize;
+    if (cctxPtr->tmpInSize > 0) { /* some data already within tmp buffer */
+        const size_t sizeToCopy = blockSize - cctxPtr->tmpInSize;
         assert(blockSize > cctxPtr->tmpInSize);
         if (sizeToCopy > srcSize) {
             /* add src to tmpIn buffer */
@@ -1053,22 +1111,19 @@ static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
             memcpy(cctxPtr->tmpIn + cctxPtr->tmpInSize, srcBuffer, sizeToCopy);
             srcPtr += sizeToCopy;
 
-            dstPtr += LZ4F_makeBlock(dstPtr,
-                                     cctxPtr->tmpIn, blockSize,
-                                     compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
-                                     cctxPtr->cdict,
+            dstPtr += LZ4F_makeBlock(dstPtr, cctxPtr->tmpIn, blockSize, compress, cctxPtr->lz4CtxPtr,
+                                     cctxPtr->prefs.compressionLevel, cctxPtr->cdict,
                                      cctxPtr->prefs.frameInfo.blockChecksumFlag);
-            if (cctxPtr->prefs.frameInfo.blockMode==LZ4F_blockLinked) cctxPtr->tmpIn += blockSize;
+            if (cctxPtr->prefs.frameInfo.blockMode == LZ4F_blockLinked) cctxPtr->tmpIn += blockSize;
             cctxPtr->tmpInSize = 0;
-    }   }
+        }
+    }
 
     while ((size_t)(srcEnd - srcPtr) >= blockSize) {
         /* compress full blocks */
         lastBlockCompressed = fromSrcBuffer;
-        dstPtr += LZ4F_makeBlock(dstPtr,
-                                 srcPtr, blockSize,
-                                 compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
-                                 cctxPtr->cdict,
+        dstPtr += LZ4F_makeBlock(dstPtr, srcPtr, blockSize, compress, cctxPtr->lz4CtxPtr,
+                                 cctxPtr->prefs.compressionLevel, cctxPtr->cdict,
                                  cctxPtr->prefs.frameInfo.blockChecksumFlag);
         srcPtr += blockSize;
     }
@@ -1076,28 +1131,27 @@ static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
     if ((cctxPtr->prefs.autoFlush) && (srcPtr < srcEnd)) {
         /* autoFlush : remaining input (< blockSize) is compressed */
         lastBlockCompressed = fromSrcBuffer;
-        dstPtr += LZ4F_makeBlock(dstPtr,
-                                 srcPtr, (size_t)(srcEnd - srcPtr),
-                                 compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
-                                 cctxPtr->cdict,
+        dstPtr += LZ4F_makeBlock(dstPtr, srcPtr, (size_t)(srcEnd - srcPtr), compress, cctxPtr->lz4CtxPtr,
+                                 cctxPtr->prefs.compressionLevel, cctxPtr->cdict,
                                  cctxPtr->prefs.frameInfo.blockChecksumFlag);
         srcPtr = srcEnd;
     }
 
     /* preserve dictionary within @tmpBuff whenever necessary */
-    if ((cctxPtr->prefs.frameInfo.blockMode==LZ4F_blockLinked) && (lastBlockCompressed==fromSrcBuffer)) {
+    if ((cctxPtr->prefs.frameInfo.blockMode == LZ4F_blockLinked) && (lastBlockCompressed == fromSrcBuffer)) {
         /* linked blocks are only supported in compressed mode, see LZ4F_uncompressedUpdate */
         assert(blockCompression == LZ4B_COMPRESSED);
         if (compressOptionsPtr->stableSrc) {
-            cctxPtr->tmpIn = cctxPtr->tmpBuff;  /* src is stable : dictionary remains in src across invocations */
+            cctxPtr->tmpIn = cctxPtr->tmpBuff; /* src is stable : dictionary remains in src across invocations */
         } else {
             LZ4F_localSaveDict(cctxPtr);
         }
     }
 
     /* keep tmpIn within limits */
-    if (!(cctxPtr->prefs.autoFlush)  /* no autoflush : there may be some data left within internal buffer */
-      && (cctxPtr->tmpIn + blockSize) > (cctxPtr->tmpBuff + cctxPtr->maxBufferSize) )  /* not enough room to store next block */
+    if (!(cctxPtr->prefs.autoFlush) /* no autoflush : there may be some data left within internal buffer */
+        && (cctxPtr->tmpIn + blockSize) >
+               (cctxPtr->tmpBuff + cctxPtr->maxBufferSize)) /* not enough room to store next block */
     {
         /* only preserve 64KB within internal buffer. Ensures there is enough room for next block.
          * note: this situation necessarily implies lastBlockCompressed==fromTmpBuffer */
@@ -1108,7 +1162,7 @@ static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
     /* some input data left, necessarily < blockSize */
     if (srcPtr < srcEnd) {
         /* fill tmp buffer */
-        size_t const sizeToCopy = (size_t)(srcEnd - srcPtr);
+        const size_t sizeToCopy = (size_t)(srcEnd - srcPtr);
         memcpy(cctxPtr->tmpIn, srcPtr, sizeToCopy);
         cctxPtr->tmpInSize = sizeToCopy;
     }
@@ -1132,15 +1186,15 @@ static size_t LZ4F_compressUpdateImpl(LZ4F_cctx* cctxPtr,
  *           or an error code if it fails (which can be tested using LZ4F_isError())
  *  After an error, the state is left in a UB state, and must be re-initialized.
  */
-size_t LZ4F_compressUpdate(LZ4F_cctx* cctxPtr,
-                           void* dstBuffer, size_t dstCapacity,
-                     const void* srcBuffer, size_t srcSize,
-                     const LZ4F_compressOptions_t* compressOptionsPtr)
+size_t LZ4F_compressUpdate(LZ4F_cctx*                    cctxPtr,
+                           void*                         dstBuffer,
+                           size_t                        dstCapacity,
+                           const void*                   srcBuffer,
+                           size_t                        srcSize,
+                           const LZ4F_compressOptions_t* compressOptionsPtr)
 {
-     return LZ4F_compressUpdateImpl(cctxPtr,
-                                   dstBuffer, dstCapacity,
-                                   srcBuffer, srcSize,
-                                   compressOptionsPtr, LZ4B_COMPRESSED);
+    return LZ4F_compressUpdateImpl(cctxPtr, dstBuffer, dstCapacity, srcBuffer, srcSize, compressOptionsPtr,
+                                   LZ4B_COMPRESSED);
 }
 
 /*! LZ4F_uncompressedUpdate() :
@@ -1152,17 +1206,16 @@ size_t LZ4F_compressUpdate(LZ4F_cctx* cctxPtr,
  *           or an error code if it fails (which can be tested using LZ4F_isError())
  *  After an error, the state is left in a UB state, and must be re-initialized.
  */
-size_t LZ4F_uncompressedUpdate(LZ4F_cctx* cctxPtr,
-                               void* dstBuffer, size_t dstCapacity,
-                         const void* srcBuffer, size_t srcSize,
-                         const LZ4F_compressOptions_t* compressOptionsPtr)
+size_t LZ4F_uncompressedUpdate(LZ4F_cctx*                    cctxPtr,
+                               void*                         dstBuffer,
+                               size_t                        dstCapacity,
+                               const void*                   srcBuffer,
+                               size_t                        srcSize,
+                               const LZ4F_compressOptions_t* compressOptionsPtr)
 {
-    return LZ4F_compressUpdateImpl(cctxPtr,
-                                   dstBuffer, dstCapacity,
-                                   srcBuffer, srcSize,
-                                   compressOptionsPtr, LZ4B_UNCOMPRESSED);
+    return LZ4F_compressUpdateImpl(cctxPtr, dstBuffer, dstCapacity, srcBuffer, srcSize, compressOptionsPtr,
+                                   LZ4B_UNCOMPRESSED);
 }
-
 
 /*! LZ4F_flush() :
  *  When compressed data must be sent immediately, without waiting for a block to be filled,
@@ -1172,34 +1225,33 @@ size_t LZ4F_uncompressedUpdate(LZ4F_cctx* cctxPtr,
  *  The function outputs an error code if it fails (can be tested using LZ4F_isError())
  *  LZ4F_compressOptions_t* is optional. NULL is a valid argument.
  */
-size_t LZ4F_flush(LZ4F_cctx* cctxPtr,
-                  void* dstBuffer, size_t dstCapacity,
-            const LZ4F_compressOptions_t* compressOptionsPtr)
+size_t LZ4F_flush(LZ4F_cctx*                    cctxPtr,
+                  void*                         dstBuffer,
+                  size_t                        dstCapacity,
+                  const LZ4F_compressOptions_t* compressOptionsPtr)
 {
-    BYTE* const dstStart = (BYTE*)dstBuffer;
-    BYTE* dstPtr = dstStart;
+    BYTE* const    dstStart = (BYTE*)dstBuffer;
+    BYTE*          dstPtr   = dstStart;
     compressFunc_t compress;
 
-    DEBUGLOG(5, "LZ4F_flush: %zu buffered bytes (saved dict size = %i) (dstCapacity=%u)",
-            cctxPtr->tmpInSize, (int)(cctxPtr->tmpIn - cctxPtr->tmpBuff), (unsigned)dstCapacity);
-    if (cctxPtr->tmpInSize == 0) return 0;   /* nothing to flush */
+    DEBUGLOG(5, "LZ4F_flush: %zu buffered bytes (saved dict size = %i) (dstCapacity=%u)", cctxPtr->tmpInSize,
+             (int)(cctxPtr->tmpIn - cctxPtr->tmpBuff), (unsigned)dstCapacity);
+    if (cctxPtr->tmpInSize == 0) return 0; /* nothing to flush */
     RETURN_ERROR_IF(cctxPtr->cStage != 1, compressionState_uninitialized);
     RETURN_ERROR_IF(dstCapacity < (cctxPtr->tmpInSize + BHSize + BFSize), dstMaxSize_tooSmall);
-    (void)compressOptionsPtr;   /* not useful (yet) */
+    (void)compressOptionsPtr; /* not useful (yet) */
 
     /* select compression function */
-    compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel, cctxPtr->blockCompressMode);
+    compress = LZ4F_selectCompression(cctxPtr->prefs.frameInfo.blockMode, cctxPtr->prefs.compressionLevel,
+                                      cctxPtr->blockCompressMode);
 
     /* compress tmp buffer */
-    dstPtr += LZ4F_makeBlock(dstPtr,
-                             cctxPtr->tmpIn, cctxPtr->tmpInSize,
-                             compress, cctxPtr->lz4CtxPtr, cctxPtr->prefs.compressionLevel,
-                             cctxPtr->cdict,
+    dstPtr += LZ4F_makeBlock(dstPtr, cctxPtr->tmpIn, cctxPtr->tmpInSize, compress, cctxPtr->lz4CtxPtr,
+                             cctxPtr->prefs.compressionLevel, cctxPtr->cdict,
                              cctxPtr->prefs.frameInfo.blockChecksumFlag);
     assert(((void)"flush overflows dstBuffer!", (size_t)(dstPtr - dstStart) <= dstCapacity));
 
-    if (cctxPtr->prefs.frameInfo.blockMode == LZ4F_blockLinked)
-        cctxPtr->tmpIn += cctxPtr->tmpInSize;
+    if (cctxPtr->prefs.frameInfo.blockMode == LZ4F_blockLinked) cctxPtr->tmpIn += cctxPtr->tmpInSize;
     cctxPtr->tmpInSize = 0;
 
     /* keep tmpIn within limits */
@@ -1211,7 +1263,6 @@ size_t LZ4F_flush(LZ4F_cctx* cctxPtr,
     return (size_t)(dstPtr - dstStart);
 }
 
-
 /*! LZ4F_compressEnd() :
  *  When you want to properly finish the compressed frame, just call LZ4F_compressEnd().
  *  It will flush whatever data remained within compressionContext (like LZ4_flush())
@@ -1221,15 +1272,16 @@ size_t LZ4F_flush(LZ4F_cctx* cctxPtr,
  *       or an error code if it fails (can be tested using LZ4F_isError())
  *  The context can then be used again to compress a new frame, starting with LZ4F_compressBegin().
  */
-size_t LZ4F_compressEnd(LZ4F_cctx* cctxPtr,
-                        void* dstBuffer, size_t dstCapacity,
-                  const LZ4F_compressOptions_t* compressOptionsPtr)
+size_t LZ4F_compressEnd(LZ4F_cctx*                    cctxPtr,
+                        void*                         dstBuffer,
+                        size_t                        dstCapacity,
+                        const LZ4F_compressOptions_t* compressOptionsPtr)
 {
     BYTE* const dstStart = (BYTE*)dstBuffer;
-    BYTE* dstPtr = dstStart;
+    BYTE*       dstPtr   = dstStart;
 
-    size_t const flushSize = LZ4F_flush(cctxPtr, dstBuffer, dstCapacity, compressOptionsPtr);
-    DEBUGLOG(5,"LZ4F_compressEnd: dstCapacity=%u", (unsigned)dstCapacity);
+    const size_t flushSize = LZ4F_flush(cctxPtr, dstBuffer, dstCapacity, compressOptionsPtr);
+    DEBUGLOG(5, "LZ4F_compressEnd: dstCapacity=%u", (unsigned)dstCapacity);
     FORWARD_IF_ERROR(flushSize);
     dstPtr += flushSize;
 
@@ -1238,73 +1290,76 @@ size_t LZ4F_compressEnd(LZ4F_cctx* cctxPtr,
 
     RETURN_ERROR_IF(dstCapacity < 4, dstMaxSize_tooSmall);
     LZ4F_writeLE32(dstPtr, 0);
-    dstPtr += 4;   /* endMark */
+    dstPtr += 4; /* endMark */
 
     if (cctxPtr->prefs.frameInfo.contentChecksumFlag == LZ4F_contentChecksumEnabled) {
         U32 const xxh = XXH32_digest(&(cctxPtr->xxh));
         RETURN_ERROR_IF(dstCapacity < 8, dstMaxSize_tooSmall);
-        DEBUGLOG(5,"Writing 32-bit content checksum (0x%0X)", xxh);
+        DEBUGLOG(5, "Writing 32-bit content checksum (0x%0X)", xxh);
         LZ4F_writeLE32(dstPtr, xxh);
-        dstPtr+=4;   /* content Checksum */
+        dstPtr += 4; /* content Checksum */
     }
 
-    cctxPtr->cStage = 0;   /* state is now re-usable (with identical preferences) */
+    cctxPtr->cStage = 0; /* state is now re-usable (with identical preferences) */
 
     if (cctxPtr->prefs.frameInfo.contentSize) {
-        if (cctxPtr->prefs.frameInfo.contentSize != cctxPtr->totalInSize)
-            RETURN_ERROR(frameSize_wrong);
+        if (cctxPtr->prefs.frameInfo.contentSize != cctxPtr->totalInSize) RETURN_ERROR(frameSize_wrong);
     }
 
     return (size_t)(dstPtr - dstStart);
 }
-
 
 /*-***************************************************
 *   Frame Decompression
 *****************************************************/
 
 typedef enum {
-    dstage_getFrameHeader=0, dstage_storeFrameHeader,
+    dstage_getFrameHeader = 0,
+    dstage_storeFrameHeader,
     dstage_init,
-    dstage_getBlockHeader, dstage_storeBlockHeader,
-    dstage_copyDirect, dstage_getBlockChecksum,
-    dstage_getCBlock, dstage_storeCBlock,
+    dstage_getBlockHeader,
+    dstage_storeBlockHeader,
+    dstage_copyDirect,
+    dstage_getBlockChecksum,
+    dstage_getCBlock,
+    dstage_storeCBlock,
     dstage_flushOut,
-    dstage_getSuffix, dstage_storeSuffix,
-    dstage_getSFrameSize, dstage_storeSFrameSize,
+    dstage_getSuffix,
+    dstage_storeSuffix,
+    dstage_getSFrameSize,
+    dstage_storeSFrameSize,
     dstage_skipSkippable
 } dStage_t;
 
 struct LZ4F_dctx_s {
-    LZ4F_CustomMem cmem;
+    LZ4F_CustomMem   cmem;
     LZ4F_frameInfo_t frameInfo;
-    U32    version;
-    dStage_t dStage;
-    U64    frameRemainingSize;
-    size_t maxBlockSize;
-    size_t maxBufferSize;
-    BYTE*  tmpIn;
-    size_t tmpInSize;
-    size_t tmpInTarget;
-    BYTE*  tmpOutBuffer;
-    const BYTE* dict;
-    size_t dictSize;
-    BYTE*  tmpOut;
-    size_t tmpOutSize;
-    size_t tmpOutStart;
-    XXH32_state_t xxh;
-    XXH32_state_t blockChecksum;
-    int    skipChecksum;
-    BYTE   header[LZ4F_HEADER_SIZE_MAX];
-};  /* typedef'd to LZ4F_dctx in lz4frame.h */
-
+    U32              version;
+    dStage_t         dStage;
+    U64              frameRemainingSize;
+    size_t           maxBlockSize;
+    size_t           maxBufferSize;
+    BYTE*            tmpIn;
+    size_t           tmpInSize;
+    size_t           tmpInTarget;
+    BYTE*            tmpOutBuffer;
+    const BYTE*      dict;
+    size_t           dictSize;
+    BYTE*            tmpOut;
+    size_t           tmpOutSize;
+    size_t           tmpOutStart;
+    XXH32_state_t    xxh;
+    XXH32_state_t    blockChecksum;
+    int              skipChecksum;
+    BYTE             header[LZ4F_HEADER_SIZE_MAX];
+}; /* typedef'd to LZ4F_dctx in lz4frame.h */
 
 LZ4F_dctx* LZ4F_createDecompressionContext_advanced(LZ4F_CustomMem customMem, unsigned version)
 {
     LZ4F_dctx* const dctx = (LZ4F_dctx*)LZ4F_calloc(sizeof(LZ4F_dctx), customMem);
     if (dctx == NULL) return NULL;
 
-    dctx->cmem = customMem;
+    dctx->cmem    = customMem;
     dctx->version = version;
     return dctx;
 }
@@ -1315,14 +1370,15 @@ LZ4F_dctx* LZ4F_createDecompressionContext_advanced(LZ4F_CustomMem customMem, un
  *  Object can later be released using LZ4F_freeDecompressionContext().
  * @return : if != 0, there was an error during context creation.
  */
-LZ4F_errorCode_t
-LZ4F_createDecompressionContext(LZ4F_dctx** LZ4F_decompressionContextPtr, unsigned versionNumber)
+LZ4F_errorCode_t LZ4F_createDecompressionContext(LZ4F_dctx** LZ4F_decompressionContextPtr,
+                                                 unsigned    versionNumber)
 {
-    assert(LZ4F_decompressionContextPtr != NULL);  /* violation of narrow contract */
-    RETURN_ERROR_IF(LZ4F_decompressionContextPtr == NULL, parameter_null);  /* in case it nonetheless happen in production */
+    assert(LZ4F_decompressionContextPtr != NULL); /* violation of narrow contract */
+    RETURN_ERROR_IF(LZ4F_decompressionContextPtr == NULL,
+                    parameter_null); /* in case it nonetheless happen in production */
 
     *LZ4F_decompressionContextPtr = LZ4F_createDecompressionContext_advanced(LZ4F_defaultCMem, versionNumber);
-    if (*LZ4F_decompressionContextPtr == NULL) {  /* failed allocation */
+    if (*LZ4F_decompressionContextPtr == NULL) { /* failed allocation */
         RETURN_ERROR(allocation_failed);
     }
     return LZ4F_OK_NoError;
@@ -1331,36 +1387,34 @@ LZ4F_createDecompressionContext(LZ4F_dctx** LZ4F_decompressionContextPtr, unsign
 LZ4F_errorCode_t LZ4F_freeDecompressionContext(LZ4F_dctx* dctx)
 {
     LZ4F_errorCode_t result = LZ4F_OK_NoError;
-    if (dctx != NULL) {   /* can accept NULL input, like free() */
-      result = (LZ4F_errorCode_t)dctx->dStage;
-      LZ4F_free(dctx->tmpIn, dctx->cmem);
-      LZ4F_free(dctx->tmpOutBuffer, dctx->cmem);
-      LZ4F_free(dctx, dctx->cmem);
+    if (dctx != NULL) { /* can accept NULL input, like free() */
+        result = (LZ4F_errorCode_t)dctx->dStage;
+        LZ4F_free(dctx->tmpIn, dctx->cmem);
+        LZ4F_free(dctx->tmpOutBuffer, dctx->cmem);
+        LZ4F_free(dctx, dctx->cmem);
     }
     return result;
 }
 
-size_t LZ4F_dctx_size(const LZ4F_dctx* dctx) {
+size_t LZ4F_dctx_size(const LZ4F_dctx* dctx)
+{
     if (dctx == NULL) {
         return 0;
     }
-    return sizeof(*dctx)
-         + (dctx->tmpIn != NULL ? dctx->maxBlockSize + BFSize : 0)
-         + (dctx->tmpOutBuffer != NULL ? dctx->maxBufferSize : 0);
+    return sizeof(*dctx) + (dctx->tmpIn != NULL ? dctx->maxBlockSize + BFSize : 0) +
+           (dctx->tmpOutBuffer != NULL ? dctx->maxBufferSize : 0);
 }
-
 
 /*==---   Streaming Decompression operations   ---==*/
 void LZ4F_resetDecompressionContext(LZ4F_dctx* dctx)
 {
     DEBUGLOG(5, "LZ4F_resetDecompressionContext");
-    dctx->dStage = dstage_getFrameHeader;
-    dctx->dict = NULL;
-    dctx->dictSize = 0;
-    dctx->skipChecksum = 0;
+    dctx->dStage             = dstage_getFrameHeader;
+    dctx->dict               = NULL;
+    dctx->dictSize           = 0;
+    dctx->skipChecksum       = 0;
     dctx->frameRemainingSize = 0;
 }
-
 
 /*! LZ4F_decodeHeader() :
  *  input   : `src` points at the **beginning of the frame**
@@ -1372,27 +1426,28 @@ void LZ4F_resetDecompressionContext(LZ4F_dctx* dctx)
  */
 static size_t LZ4F_decodeHeader(LZ4F_dctx* dctx, const void* src, size_t srcSize)
 {
-    unsigned blockMode, blockChecksumFlag, contentSizeFlag, contentChecksumFlag, dictIDFlag, blockSizeID;
-    size_t frameHeaderSize;
+    unsigned    blockMode, blockChecksumFlag, contentSizeFlag, contentChecksumFlag, dictIDFlag, blockSizeID;
+    size_t      frameHeaderSize;
     const BYTE* srcPtr = (const BYTE*)src;
 
     DEBUGLOG(5, "LZ4F_decodeHeader");
     /* need to decode header to get frameInfo */
-    RETURN_ERROR_IF(srcSize < minFHSize, frameHeader_incomplete);   /* minimal frame header size */
+    RETURN_ERROR_IF(srcSize < minFHSize, frameHeader_incomplete); /* minimal frame header size */
     MEM_INIT(&(dctx->frameInfo), 0, sizeof(dctx->frameInfo));
 
     /* special case : skippable frames */
     if ((LZ4F_readLE32(srcPtr) & 0xFFFFFFF0U) == LZ4F_MAGIC_SKIPPABLE_START) {
         dctx->frameInfo.frameType = LZ4F_skippableFrame;
         if (src == (void*)(dctx->header)) {
-            dctx->tmpInSize = srcSize;
+            dctx->tmpInSize   = srcSize;
             dctx->tmpInTarget = 8;
-            dctx->dStage = dstage_storeSFrameSize;
+            dctx->dStage      = dstage_storeSFrameSize;
             return srcSize;
         } else {
             dctx->dStage = dstage_getSFrameSize;
             return 4;
-    }   }
+        }
+    }
 
     /* control magic number */
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -1404,65 +1459,66 @@ static size_t LZ4F_decodeHeader(LZ4F_dctx* dctx, const void* src, size_t srcSize
     dctx->frameInfo.frameType = LZ4F_frame;
 
     /* Flags */
-    {   U32 const FLG = srcPtr[4];
-        U32 const version = (FLG>>6) & _2BITS;
-        blockChecksumFlag = (FLG>>4) & _1BIT;
-        blockMode = (FLG>>5) & _1BIT;
-        contentSizeFlag = (FLG>>3) & _1BIT;
-        contentChecksumFlag = (FLG>>2) & _1BIT;
-        dictIDFlag = FLG & _1BIT;
+    {
+        U32 const FLG       = srcPtr[4];
+        U32 const version   = (FLG >> 6) & _2BITS;
+        blockChecksumFlag   = (FLG >> 4) & _1BIT;
+        blockMode           = (FLG >> 5) & _1BIT;
+        contentSizeFlag     = (FLG >> 3) & _1BIT;
+        contentChecksumFlag = (FLG >> 2) & _1BIT;
+        dictIDFlag          = FLG & _1BIT;
         /* validate */
-        if (((FLG>>1)&_1BIT) != 0) RETURN_ERROR(reservedFlag_set); /* Reserved bit */
-        if (version != 1) RETURN_ERROR(headerVersion_wrong);       /* Version Number, only supported value */
+        if (((FLG >> 1) & _1BIT) != 0) RETURN_ERROR(reservedFlag_set); /* Reserved bit */
+        if (version != 1) RETURN_ERROR(headerVersion_wrong); /* Version Number, only supported value */
     }
     DEBUGLOG(6, "contentSizeFlag: %u", contentSizeFlag);
 
     /* Frame Header Size */
-    frameHeaderSize = minFHSize + (contentSizeFlag?8:0) + (dictIDFlag?4:0);
+    frameHeaderSize = minFHSize + (contentSizeFlag ? 8 : 0) + (dictIDFlag ? 4 : 0);
 
     if (srcSize < frameHeaderSize) {
         /* not enough input to fully decode frame header */
-        if (srcPtr != dctx->header)
-            memcpy(dctx->header, srcPtr, srcSize);
-        dctx->tmpInSize = srcSize;
+        if (srcPtr != dctx->header) memcpy(dctx->header, srcPtr, srcSize);
+        dctx->tmpInSize   = srcSize;
         dctx->tmpInTarget = frameHeaderSize;
-        dctx->dStage = dstage_storeFrameHeader;
+        dctx->dStage      = dstage_storeFrameHeader;
         return srcSize;
     }
 
-    {   U32 const BD = srcPtr[5];
-        blockSizeID = (BD>>4) & _3BITS;
+    {
+        U32 const BD = srcPtr[5];
+        blockSizeID  = (BD >> 4) & _3BITS;
         /* validate */
-        if (((BD>>7)&_1BIT) != 0) RETURN_ERROR(reservedFlag_set);   /* Reserved bit */
-        if (blockSizeID < 4) RETURN_ERROR(maxBlockSize_invalid);    /* 4-7 only supported values for the time being */
-        if (((BD>>0)&_4BITS) != 0) RETURN_ERROR(reservedFlag_set);  /* Reserved bits */
+        if (((BD >> 7) & _1BIT) != 0) RETURN_ERROR(reservedFlag_set); /* Reserved bit */
+        if (blockSizeID < 4)
+            RETURN_ERROR(maxBlockSize_invalid); /* 4-7 only supported values for the time being */
+        if (((BD >> 0) & _4BITS) != 0) RETURN_ERROR(reservedFlag_set); /* Reserved bits */
     }
 
     /* check header */
     assert(frameHeaderSize > 5);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    {   BYTE const HC = LZ4F_headerChecksum(srcPtr+4, frameHeaderSize-5);
-        RETURN_ERROR_IF(HC != srcPtr[frameHeaderSize-1], headerChecksum_invalid);
+    {
+        BYTE const HC = LZ4F_headerChecksum(srcPtr + 4, frameHeaderSize - 5);
+        RETURN_ERROR_IF(HC != srcPtr[frameHeaderSize - 1], headerChecksum_invalid);
     }
 #endif
 
     /* save */
-    dctx->frameInfo.blockMode = (LZ4F_blockMode_t)blockMode;
-    dctx->frameInfo.blockChecksumFlag = (LZ4F_blockChecksum_t)blockChecksumFlag;
+    dctx->frameInfo.blockMode           = (LZ4F_blockMode_t)blockMode;
+    dctx->frameInfo.blockChecksumFlag   = (LZ4F_blockChecksum_t)blockChecksumFlag;
     dctx->frameInfo.contentChecksumFlag = (LZ4F_contentChecksum_t)contentChecksumFlag;
-    dctx->frameInfo.blockSizeID = (LZ4F_blockSizeID_t)blockSizeID;
-    dctx->maxBlockSize = LZ4F_getBlockSize((LZ4F_blockSizeID_t)blockSizeID);
+    dctx->frameInfo.blockSizeID         = (LZ4F_blockSizeID_t)blockSizeID;
+    dctx->maxBlockSize                  = LZ4F_getBlockSize((LZ4F_blockSizeID_t)blockSizeID);
     if (contentSizeFlag) {
-        dctx->frameRemainingSize = dctx->frameInfo.contentSize = LZ4F_readLE64(srcPtr+6);
+        dctx->frameRemainingSize = dctx->frameInfo.contentSize = LZ4F_readLE64(srcPtr + 6);
     }
-    if (dictIDFlag)
-        dctx->frameInfo.dictID = LZ4F_readLE32(srcPtr + frameHeaderSize - 5);
+    if (dictIDFlag) dctx->frameInfo.dictID = LZ4F_readLE32(srcPtr + frameHeaderSize - 5);
 
     dctx->dStage = dstage_init;
 
     return frameHeaderSize;
 }
-
 
 /*! LZ4F_headerSize() :
  * @return : size of frame header
@@ -1473,24 +1529,22 @@ size_t LZ4F_headerSize(const void* src, size_t srcSize)
     RETURN_ERROR_IF(src == NULL, srcPtr_wrong);
 
     /* minimal srcSize to determine header size */
-    if (srcSize < LZ4F_MIN_SIZE_TO_KNOW_HEADER_LENGTH)
-        RETURN_ERROR(frameHeader_incomplete);
+    if (srcSize < LZ4F_MIN_SIZE_TO_KNOW_HEADER_LENGTH) RETURN_ERROR(frameHeader_incomplete);
 
     /* special case : skippable frames */
-    if ((LZ4F_readLE32(src) & 0xFFFFFFF0U) == LZ4F_MAGIC_SKIPPABLE_START)
-        return 8;
+    if ((LZ4F_readLE32(src) & 0xFFFFFFF0U) == LZ4F_MAGIC_SKIPPABLE_START) return 8;
 
     /* control magic number */
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    if (LZ4F_readLE32(src) != LZ4F_MAGICNUMBER)
-        RETURN_ERROR(frameType_unknown);
+    if (LZ4F_readLE32(src) != LZ4F_MAGICNUMBER) RETURN_ERROR(frameType_unknown);
 #endif
 
     /* Frame Header Size */
-    {   BYTE const FLG = ((const BYTE*)src)[4];
-        U32 const contentSizeFlag = (FLG>>3) & _1BIT;
-        U32 const dictIDFlag = FLG & _1BIT;
-        return minFHSize + (contentSizeFlag?8:0) + (dictIDFlag?4:0);
+    {
+        BYTE const FLG             = ((const BYTE*)src)[4];
+        U32 const  contentSizeFlag = (FLG >> 3) & _1BIT;
+        U32 const  dictIDFlag      = FLG & _1BIT;
+        return minFHSize + (contentSizeFlag ? 8 : 0) + (dictIDFlag ? 4 : 0);
     }
 }
 
@@ -1509,9 +1563,8 @@ size_t LZ4F_headerSize(const void* src, size_t srcSize)
  *  note 1 : in case of error, dctx is not modified. Decoding operations can resume from where they stopped.
  *  note 2 : frame parameters are *copied into* an already allocated LZ4F_frameInfo_t structure.
  */
-LZ4F_errorCode_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
-                                   LZ4F_frameInfo_t* frameInfoPtr,
-                             const void* srcBuffer, size_t* srcSizePtr)
+LZ4F_errorCode_t
+LZ4F_getFrameInfo(LZ4F_dctx* dctx, LZ4F_frameInfo_t* frameInfoPtr, const void* srcBuffer, size_t* srcSizePtr)
 {
     assert(dctx != NULL);
     RETURN_ERROR_IF(frameInfoPtr == NULL, parameter_null);
@@ -1520,8 +1573,8 @@ LZ4F_errorCode_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
     LZ4F_STATIC_ASSERT(dstage_getFrameHeader < dstage_storeFrameHeader);
     if (dctx->dStage > dstage_storeFrameHeader) {
         /* frameInfo already decoded */
-        size_t o=0, i=0;
-        *srcSizePtr = 0;
+        size_t o = 0, i = 0;
+        *srcSizePtr   = 0;
         *frameInfoPtr = dctx->frameInfo;
         /* returns : recommended nb of bytes for LZ4F_decompress() */
         return LZ4F_decompress(dctx, NULL, &o, NULL, &i, NULL);
@@ -1531,56 +1584,64 @@ LZ4F_errorCode_t LZ4F_getFrameInfo(LZ4F_dctx* dctx,
             *srcSizePtr = 0;
             RETURN_ERROR(frameDecoding_alreadyStarted);
         } else {
-            size_t const hSize = LZ4F_headerSize(srcBuffer, *srcSizePtr);
-            if (LZ4F_isError(hSize)) { *srcSizePtr=0; return hSize; }
+            const size_t hSize = LZ4F_headerSize(srcBuffer, *srcSizePtr);
+            if (LZ4F_isError(hSize)) {
+                *srcSizePtr = 0;
+                return hSize;
+            }
             if (*srcSizePtr < hSize) {
-                *srcSizePtr=0;
+                *srcSizePtr = 0;
                 RETURN_ERROR(frameHeader_incomplete);
             }
 
-            {   size_t decodeResult = LZ4F_decodeHeader(dctx, srcBuffer, hSize);
+            {
+                size_t decodeResult = LZ4F_decodeHeader(dctx, srcBuffer, hSize);
                 if (LZ4F_isError(decodeResult)) {
                     *srcSizePtr = 0;
                 } else {
-                    *srcSizePtr = decodeResult;
-                    decodeResult = BHSize;   /* block header size */
+                    *srcSizePtr  = decodeResult;
+                    decodeResult = BHSize; /* block header size */
                 }
                 *frameInfoPtr = dctx->frameInfo;
                 return decodeResult;
-    }   }   }
+            }
+        }
+    }
 }
-
 
 /* LZ4F_updateDict() :
  * only used for LZ4F_blockLinked mode
  * Condition : @dstPtr != NULL
  */
-static void LZ4F_updateDict(LZ4F_dctx* dctx,
-                      const BYTE* dstPtr, size_t dstSize, const BYTE* dstBufferStart,
-                      unsigned withinTmp)
+static void LZ4F_updateDict(LZ4F_dctx*  dctx,
+                            const BYTE* dstPtr,
+                            size_t      dstSize,
+                            const BYTE* dstBufferStart,
+                            unsigned    withinTmp)
 {
     assert(dstPtr != NULL);
-    if (dctx->dictSize==0) dctx->dict = (const BYTE*)dstPtr;  /* will lead to prefix mode */
+    if (dctx->dictSize == 0) dctx->dict = (const BYTE*)dstPtr; /* will lead to prefix mode */
     assert(dctx->dict != NULL);
 
-    if (dctx->dict + dctx->dictSize == dstPtr) {  /* prefix mode, everything within dstBuffer */
+    if (dctx->dict + dctx->dictSize == dstPtr) { /* prefix mode, everything within dstBuffer */
         dctx->dictSize += dstSize;
         return;
     }
 
     assert(dstPtr >= dstBufferStart);
-    if ((size_t)(dstPtr - dstBufferStart) + dstSize >= 64 KB) {  /* history in dstBuffer becomes large enough to become dictionary */
-        dctx->dict = (const BYTE*)dstBufferStart;
+    if ((size_t)(dstPtr - dstBufferStart) + dstSize >=
+        64 KB) { /* history in dstBuffer becomes large enough to become dictionary */
+        dctx->dict     = (const BYTE*)dstBufferStart;
         dctx->dictSize = (size_t)(dstPtr - dstBufferStart) + dstSize;
         return;
     }
 
-    assert(dstSize < 64 KB);   /* if dstSize >= 64 KB, dictionary would be set into dstBuffer directly */
+    assert(dstSize < 64 KB); /* if dstSize >= 64 KB, dictionary would be set into dstBuffer directly */
 
     /* dstBuffer does not contain whole useful history (64 KB), so it must be saved within tmpOutBuffer */
     assert(dctx->tmpOutBuffer != NULL);
 
-    if (withinTmp && (dctx->dict == dctx->tmpOutBuffer)) {   /* continue history within tmpOutBuffer */
+    if (withinTmp && (dctx->dict == dctx->tmpOutBuffer)) { /* continue history within tmpOutBuffer */
         /* withinTmp expectation : content of [dstPtr,dstSize] is same as [dict+dictSize,dstSize], so we just extend it */
         assert(dctx->dict + dctx->dictSize == dctx->tmpOut + dctx->tmpOutStart);
         dctx->dictSize += dstSize;
@@ -1588,22 +1649,22 @@ static void LZ4F_updateDict(LZ4F_dctx* dctx,
     }
 
     if (withinTmp) { /* copy relevant dict portion in front of tmpOut within tmpOutBuffer */
-        size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
-        size_t copySize = 64 KB - dctx->tmpOutSize;
-        const BYTE* const oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
+        const size_t      preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
+        size_t            copySize     = 64 KB - dctx->tmpOutSize;
+        const BYTE* const oldDictEnd   = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
         if (dctx->tmpOutSize > 64 KB) copySize = 0;
         if (copySize > preserveSize) copySize = preserveSize;
 
         memcpy(dctx->tmpOutBuffer + preserveSize - copySize, oldDictEnd - copySize, copySize);
 
-        dctx->dict = dctx->tmpOutBuffer;
+        dctx->dict     = dctx->tmpOutBuffer;
         dctx->dictSize = preserveSize + dctx->tmpOutStart + dstSize;
         return;
     }
 
-    if (dctx->dict == dctx->tmpOutBuffer) {    /* copy dst into tmp to complete dict */
-        if (dctx->dictSize + dstSize > dctx->maxBufferSize) {  /* tmp buffer not large enough */
-            size_t const preserveSize = 64 KB - dstSize;
+    if (dctx->dict == dctx->tmpOutBuffer) { /* copy dst into tmp to complete dict */
+        if (dctx->dictSize + dstSize > dctx->maxBufferSize) { /* tmp buffer not large enough */
+            const size_t preserveSize = 64 KB - dstSize;
             memcpy(dctx->tmpOutBuffer, dctx->dict + dctx->dictSize - preserveSize, preserveSize);
             dctx->dictSize = preserveSize;
         }
@@ -1613,15 +1674,15 @@ static void LZ4F_updateDict(LZ4F_dctx* dctx,
     }
 
     /* join dict & dest into tmp */
-    {   size_t preserveSize = 64 KB - dstSize;
+    {
+        size_t preserveSize = 64 KB - dstSize;
         if (preserveSize > dctx->dictSize) preserveSize = dctx->dictSize;
         memcpy(dctx->tmpOutBuffer, dctx->dict + dctx->dictSize - preserveSize, preserveSize);
         memcpy(dctx->tmpOutBuffer + preserveSize, dstPtr, dstSize);
-        dctx->dict = dctx->tmpOutBuffer;
+        dctx->dict     = dctx->tmpOutBuffer;
         dctx->dictSize = preserveSize + dstSize;
     }
 }
-
 
 /*! LZ4F_decompress() :
  *  Call this function repetitively to regenerate compressed data in srcBuffer.
@@ -1641,90 +1702,96 @@ static void LZ4F_updateDict(LZ4F_dctx* dctx,
  *  When a frame is fully decoded, @return will be 0.
  *  If decompression failed, @return is an error code which can be tested using LZ4F_isError().
  */
-size_t LZ4F_decompress(LZ4F_dctx* dctx,
-                       void* dstBuffer, size_t* dstSizePtr,
-                       const void* srcBuffer, size_t* srcSizePtr,
+size_t LZ4F_decompress(LZ4F_dctx*                      dctx,
+                       void*                           dstBuffer,
+                       size_t*                         dstSizePtr,
+                       const void*                     srcBuffer,
+                       size_t*                         srcSizePtr,
                        const LZ4F_decompressOptions_t* decompressOptionsPtr)
 {
     LZ4F_decompressOptions_t optionsNull;
-    const BYTE* const srcStart = (const BYTE*)srcBuffer;
-    const BYTE* const srcEnd = srcStart + *srcSizePtr;
-    const BYTE* srcPtr = srcStart;
-    BYTE* const dstStart = (BYTE*)dstBuffer;
-    BYTE* const dstEnd = dstStart ? dstStart + *dstSizePtr : NULL;
-    BYTE* dstPtr = dstStart;
-    const BYTE* selectedIn = NULL;
-    unsigned doAnotherStage = 1;
-    size_t nextSrcSizeHint = 1;
+    const BYTE* const        srcStart        = (const BYTE*)srcBuffer;
+    const BYTE* const        srcEnd          = srcStart + *srcSizePtr;
+    const BYTE*              srcPtr          = srcStart;
+    BYTE* const              dstStart        = (BYTE*)dstBuffer;
+    BYTE* const              dstEnd          = dstStart ? dstStart + *dstSizePtr : NULL;
+    BYTE*                    dstPtr          = dstStart;
+    const BYTE*              selectedIn      = NULL;
+    unsigned                 doAnotherStage  = 1;
+    size_t                   nextSrcSizeHint = 1;
 
-
-    DEBUGLOG(5, "LZ4F_decompress: src[%p](%u) => dst[%p](%u)",
-            srcBuffer, (unsigned)*srcSizePtr, dstBuffer, (unsigned)*dstSizePtr);
+    DEBUGLOG(5, "LZ4F_decompress: src[%p](%u) => dst[%p](%u)", srcBuffer, (unsigned)*srcSizePtr, dstBuffer,
+             (unsigned)*dstSizePtr);
     if (dstBuffer == NULL) assert(*dstSizePtr == 0);
     MEM_INIT(&optionsNull, 0, sizeof(optionsNull));
-    if (decompressOptionsPtr==NULL) decompressOptionsPtr = &optionsNull;
+    if (decompressOptionsPtr == NULL) decompressOptionsPtr = &optionsNull;
     *srcSizePtr = 0;
     *dstSizePtr = 0;
     assert(dctx != NULL);
-    dctx->skipChecksum |= (decompressOptionsPtr->skipChecksums != 0); /* once set, disable for the remainder of the frame */
+    dctx->skipChecksum |= (decompressOptionsPtr->skipChecksums !=
+                           0); /* once set, disable for the remainder of the frame */
 
     /* behaves as a state machine */
 
     while (doAnotherStage) {
-
-        switch(dctx->dStage)
-        {
-
+        switch (dctx->dStage) {
         case dstage_getFrameHeader:
             DEBUGLOG(6, "dstage_getFrameHeader");
-            if ((size_t)(srcEnd-srcPtr) >= maxFHSize) {  /* enough to decode - shortcut */
-                size_t const hSize = LZ4F_decodeHeader(dctx, srcPtr, (size_t)(srcEnd-srcPtr));  /* will update dStage appropriately */
+            if ((size_t)(srcEnd - srcPtr) >= maxFHSize) { /* enough to decode - shortcut */
+                const size_t hSize = LZ4F_decodeHeader(
+                    dctx, srcPtr, (size_t)(srcEnd - srcPtr)); /* will update dStage appropriately */
                 FORWARD_IF_ERROR(hSize);
                 srcPtr += hSize;
                 break;
             }
             dctx->tmpInSize = 0;
-            if (srcEnd-srcPtr == 0) return minFHSize;   /* 0-size input */
-            dctx->tmpInTarget = minFHSize;   /* minimum size to decode header */
-            dctx->dStage = dstage_storeFrameHeader;
+            if (srcEnd - srcPtr == 0) return minFHSize; /* 0-size input */
+            dctx->tmpInTarget = minFHSize; /* minimum size to decode header */
+            dctx->dStage      = dstage_storeFrameHeader;
             /* fall-through */
 
         case dstage_storeFrameHeader:
             DEBUGLOG(6, "dstage_storeFrameHeader");
-            {   size_t const sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize, (size_t)(srcEnd - srcPtr));
+            {
+                const size_t sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize, (size_t)(srcEnd - srcPtr));
                 memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
                 dctx->tmpInSize += sizeToCopy;
                 srcPtr += sizeToCopy;
             }
             if (dctx->tmpInSize < dctx->tmpInTarget) {
-                nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize) + BHSize;   /* rest of header + nextBlockHeader */
-                doAnotherStage = 0;   /* not enough src data, ask for some more */
+                nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize) +
+                                  BHSize; /* rest of header + nextBlockHeader */
+                doAnotherStage  = 0; /* not enough src data, ask for some more */
                 break;
             }
-            FORWARD_IF_ERROR( LZ4F_decodeHeader(dctx, dctx->header, dctx->tmpInTarget) ); /* will update dStage appropriately */
+            FORWARD_IF_ERROR(LZ4F_decodeHeader(dctx, dctx->header,
+                                               dctx->tmpInTarget)); /* will update dStage appropriately */
             break;
 
         case dstage_init:
             DEBUGLOG(6, "dstage_init");
             if (dctx->frameInfo.contentChecksumFlag) (void)XXH32_reset(&(dctx->xxh), 0);
             /* internal buffers allocation */
-            {   size_t const bufferNeeded = dctx->maxBlockSize
-                    + ((dctx->frameInfo.blockMode==LZ4F_blockLinked) ? 128 KB : 0);
-                if (bufferNeeded > dctx->maxBufferSize) {   /* tmp buffers too small */
-                    dctx->maxBufferSize = 0;   /* ensure allocation will be re-attempted on next entry*/
+            {
+                const size_t bufferNeeded = dctx->maxBlockSize +
+                                            ((dctx->frameInfo.blockMode == LZ4F_blockLinked) ? 128 KB : 0);
+                if (bufferNeeded > dctx->maxBufferSize) { /* tmp buffers too small */
+                    dctx->maxBufferSize = 0; /* ensure allocation will be re-attempted on next entry*/
                     LZ4F_free(dctx->tmpIn, dctx->cmem);
-                    dctx->tmpIn = (BYTE*)LZ4F_malloc(dctx->maxBlockSize + BFSize /* block checksum */, dctx->cmem);
+                    dctx->tmpIn = (BYTE*)LZ4F_malloc(dctx->maxBlockSize + BFSize /* block checksum */,
+                                                     dctx->cmem);
                     RETURN_ERROR_IF(dctx->tmpIn == NULL, allocation_failed);
                     LZ4F_free(dctx->tmpOutBuffer, dctx->cmem);
-                    dctx->tmpOutBuffer= (BYTE*)LZ4F_malloc(bufferNeeded, dctx->cmem);
-                    RETURN_ERROR_IF(dctx->tmpOutBuffer== NULL, allocation_failed);
+                    dctx->tmpOutBuffer = (BYTE*)LZ4F_malloc(bufferNeeded, dctx->cmem);
+                    RETURN_ERROR_IF(dctx->tmpOutBuffer == NULL, allocation_failed);
                     dctx->maxBufferSize = bufferNeeded;
-            }   }
-            dctx->tmpInSize = 0;
+                }
+            }
+            dctx->tmpInSize   = 0;
             dctx->tmpInTarget = 0;
-            dctx->tmpOut = dctx->tmpOutBuffer;
+            dctx->tmpOut      = dctx->tmpOutBuffer;
             dctx->tmpOutStart = 0;
-            dctx->tmpOutSize = 0;
+            dctx->tmpOutSize  = 0;
 
             dctx->dStage = dstage_getBlockHeader;
             /* fall-through */
@@ -1736,31 +1803,32 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
             } else {
                 /* not enough input to read cBlockSize field */
                 dctx->tmpInSize = 0;
-                dctx->dStage = dstage_storeBlockHeader;
+                dctx->dStage    = dstage_storeBlockHeader;
             }
 
-            if (dctx->dStage == dstage_storeBlockHeader)   /* can be skipped */
-        case dstage_storeBlockHeader:
-            {   size_t const remainingInput = (size_t)(srcEnd - srcPtr);
-                size_t const wantedData = BHSize - dctx->tmpInSize;
-                size_t const sizeToCopy = MIN(wantedData, remainingInput);
+            if (dctx->dStage == dstage_storeBlockHeader) /* can be skipped */
+            case dstage_storeBlockHeader: {
+                const size_t remainingInput = (size_t)(srcEnd - srcPtr);
+                const size_t wantedData     = BHSize - dctx->tmpInSize;
+                const size_t sizeToCopy     = MIN(wantedData, remainingInput);
                 memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
                 srcPtr += sizeToCopy;
                 dctx->tmpInSize += sizeToCopy;
 
-                if (dctx->tmpInSize < BHSize) {   /* not enough input for cBlockSize */
+                if (dctx->tmpInSize < BHSize) { /* not enough input for cBlockSize */
                     nextSrcSizeHint = BHSize - dctx->tmpInSize;
                     doAnotherStage  = 0;
                     break;
                 }
                 selectedIn = dctx->tmpIn;
-            }   /* if (dctx->dStage == dstage_storeBlockHeader) */
+            } /* if (dctx->dStage == dstage_storeBlockHeader) */
 
-        /* decode block header */
-            {   U32 const blockHeader = LZ4F_readLE32(selectedIn);
-                size_t const nextCBlockSize = blockHeader & 0x7FFFFFFFU;
-                size_t const crcSize = dctx->frameInfo.blockChecksumFlag * BFSize;
-                if (blockHeader==0) {  /* frameEnd signal, no more block */
+            /* decode block header */
+            {
+                U32 const    blockHeader    = LZ4F_readLE32(selectedIn);
+                const size_t nextCBlockSize = blockHeader & 0x7FFFFFFFU;
+                const size_t crcSize        = dctx->frameInfo.blockChecksumFlag * BFSize;
+                if (blockHeader == 0) { /* frameEnd signal, no more block */
                     DEBUGLOG(5, "end of frame");
                     dctx->dStage = dstage_getSuffix;
                     break;
@@ -1780,22 +1848,23 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 }
                 /* next block is a compressed block */
                 dctx->tmpInTarget = nextCBlockSize + crcSize;
-                dctx->dStage = dstage_getCBlock;
-                if (dstPtr==dstEnd || srcPtr==srcEnd) {
+                dctx->dStage      = dstage_getCBlock;
+                if (dstPtr == dstEnd || srcPtr == srcEnd) {
                     nextSrcSizeHint = BHSize + nextCBlockSize + crcSize;
-                    doAnotherStage = 0;
+                    doAnotherStage  = 0;
                 }
                 break;
             }
 
-        case dstage_copyDirect:   /* uncompressed block */
+        case dstage_copyDirect: /* uncompressed block */
             DEBUGLOG(6, "dstage_copyDirect");
-            {   size_t sizeToCopy;
+            {
+                size_t sizeToCopy;
                 if (dstPtr == NULL) {
                     sizeToCopy = 0;
                 } else {
-                    size_t const minBuffSize = MIN((size_t)(srcEnd-srcPtr), (size_t)(dstEnd-dstPtr));
-                    sizeToCopy = MIN(dctx->tmpInTarget, minBuffSize);
+                    const size_t minBuffSize = MIN((size_t)(srcEnd - srcPtr), (size_t)(dstEnd - dstPtr));
+                    sizeToCopy               = MIN(dctx->tmpInTarget, minBuffSize);
                     memcpy(dstPtr, srcPtr, sizeToCopy);
                     if (!dctx->skipChecksum) {
                         if (dctx->frameInfo.blockChecksumFlag) {
@@ -1804,8 +1873,7 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                         if (dctx->frameInfo.contentChecksumFlag)
                             (void)XXH32_update(&dctx->xxh, srcPtr, sizeToCopy);
                     }
-                    if (dctx->frameInfo.contentSize)
-                        dctx->frameRemainingSize -= sizeToCopy;
+                    if (dctx->frameInfo.contentSize) dctx->frameRemainingSize -= sizeToCopy;
 
                     /* history management (linked blocks only)*/
                     if (dctx->frameInfo.blockMode == LZ4F_blockLinked) {
@@ -1814,36 +1882,35 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                     srcPtr += sizeToCopy;
                     dstPtr += sizeToCopy;
                 }
-                if (sizeToCopy == dctx->tmpInTarget) {   /* all done */
+                if (sizeToCopy == dctx->tmpInTarget) { /* all done */
                     if (dctx->frameInfo.blockChecksumFlag) {
                         dctx->tmpInSize = 0;
-                        dctx->dStage = dstage_getBlockChecksum;
-                    } else
-                        dctx->dStage = dstage_getBlockHeader;  /* new block */
+                        dctx->dStage    = dstage_getBlockChecksum;
+                    } else dctx->dStage = dstage_getBlockHeader; /* new block */
                     break;
                 }
-                dctx->tmpInTarget -= sizeToCopy;  /* need to copy more */
+                dctx->tmpInTarget -= sizeToCopy; /* need to copy more */
             }
-            nextSrcSizeHint = dctx->tmpInTarget +
-                            +(dctx->frameInfo.blockChecksumFlag ? BFSize : 0)
-                            + BHSize /* next header size */;
-            doAnotherStage = 0;
+            nextSrcSizeHint = dctx->tmpInTarget + +(dctx->frameInfo.blockChecksumFlag ? BFSize : 0) +
+                              BHSize /* next header size */;
+            doAnotherStage  = 0;
             break;
 
         /* check block checksum for recently transferred uncompressed block */
         case dstage_getBlockChecksum:
             DEBUGLOG(6, "dstage_getBlockChecksum");
-            {   const void* crcSrc;
-                if ((srcEnd-srcPtr >= 4) && (dctx->tmpInSize==0)) {
+            {
+                const void* crcSrc;
+                if ((srcEnd - srcPtr >= 4) && (dctx->tmpInSize == 0)) {
                     crcSrc = srcPtr;
                     srcPtr += 4;
                 } else {
-                    size_t const stillToCopy = 4 - dctx->tmpInSize;
-                    size_t const sizeToCopy = MIN(stillToCopy, (size_t)(srcEnd-srcPtr));
+                    const size_t stillToCopy = 4 - dctx->tmpInSize;
+                    const size_t sizeToCopy  = MIN(stillToCopy, (size_t)(srcEnd - srcPtr));
                     memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
                     dctx->tmpInSize += sizeToCopy;
                     srcPtr += sizeToCopy;
-                    if (dctx->tmpInSize < 4) {  /* all input consumed */
+                    if (dctx->tmpInSize < 4) { /* all input consumed */
                         doAnotherStage = 0;
                         break;
                     }
@@ -1855,97 +1922,97 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
                     DEBUGLOG(6, "compare block checksum");
                     if (readCRC != calcCRC) {
-                        DEBUGLOG(4, "incorrect block checksum: %08X != %08X",
-                                readCRC, calcCRC);
+                        DEBUGLOG(4, "incorrect block checksum: %08X != %08X", readCRC, calcCRC);
                         RETURN_ERROR(blockChecksum_invalid);
                     }
 #else
                     (void)readCRC;
                     (void)calcCRC;
 #endif
-            }   }
-            dctx->dStage = dstage_getBlockHeader;  /* new block */
+                }
+            }
+            dctx->dStage = dstage_getBlockHeader; /* new block */
             break;
 
         case dstage_getCBlock:
             DEBUGLOG(6, "dstage_getCBlock");
-            if ((size_t)(srcEnd-srcPtr) < dctx->tmpInTarget) {
+            if ((size_t)(srcEnd - srcPtr) < dctx->tmpInTarget) {
                 dctx->tmpInSize = 0;
-                dctx->dStage = dstage_storeCBlock;
+                dctx->dStage    = dstage_storeCBlock;
                 break;
             }
             /* input large enough to read full block directly */
             selectedIn = srcPtr;
             srcPtr += dctx->tmpInTarget;
 
-            if (0)  /* always jump over next block */
-        case dstage_storeCBlock:
-            {   size_t const wantedData = dctx->tmpInTarget - dctx->tmpInSize;
-                size_t const inputLeft = (size_t)(srcEnd-srcPtr);
-                size_t const sizeToCopy = MIN(wantedData, inputLeft);
+            if (0) /* always jump over next block */
+            case dstage_storeCBlock: {
+                const size_t wantedData = dctx->tmpInTarget - dctx->tmpInSize;
+                const size_t inputLeft  = (size_t)(srcEnd - srcPtr);
+                const size_t sizeToCopy = MIN(wantedData, inputLeft);
                 memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
                 dctx->tmpInSize += sizeToCopy;
                 srcPtr += sizeToCopy;
                 if (dctx->tmpInSize < dctx->tmpInTarget) { /* need more input */
-                    nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize)
-                                    + (dctx->frameInfo.blockChecksumFlag ? BFSize : 0)
-                                    + BHSize /* next header size */;
-                    doAnotherStage = 0;
+                    nextSrcSizeHint = (dctx->tmpInTarget - dctx->tmpInSize) +
+                                      (dctx->frameInfo.blockChecksumFlag ? BFSize : 0) +
+                                      BHSize /* next header size */;
+                    doAnotherStage  = 0;
                     break;
                 }
                 selectedIn = dctx->tmpIn;
             }
 
-            /* At this stage, input is large enough to decode a block */
+                /* At this stage, input is large enough to decode a block */
 
-            /* First, decode and control block checksum if it exists */
-            if (dctx->frameInfo.blockChecksumFlag) {
-                assert(dctx->tmpInTarget >= 4);
-                dctx->tmpInTarget -= 4;
-                assert(selectedIn != NULL);  /* selectedIn is defined at this stage (either srcPtr, or dctx->tmpIn) */
-                {   U32 const readBlockCrc = LZ4F_readLE32(selectedIn + dctx->tmpInTarget);
-                    U32 const calcBlockCrc = XXH32(selectedIn, dctx->tmpInTarget, 0);
+                /* First, decode and control block checksum if it exists */
+                if (dctx->frameInfo.blockChecksumFlag) {
+                    assert(dctx->tmpInTarget >= 4);
+                    dctx->tmpInTarget -= 4;
+                    assert(selectedIn !=
+                           NULL); /* selectedIn is defined at this stage (either srcPtr, or dctx->tmpIn) */
+                    {
+                        U32 const readBlockCrc = LZ4F_readLE32(selectedIn + dctx->tmpInTarget);
+                        U32 const calcBlockCrc = XXH32(selectedIn, dctx->tmpInTarget, 0);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-                    RETURN_ERROR_IF(readBlockCrc != calcBlockCrc, blockChecksum_invalid);
+                        RETURN_ERROR_IF(readBlockCrc != calcBlockCrc, blockChecksum_invalid);
 #else
-                    (void)readBlockCrc;
-                    (void)calcBlockCrc;
+                        (void)readBlockCrc;
+                        (void)calcBlockCrc;
 #endif
-            }   }
+                    }
+                }
 
             /* decode directly into destination buffer if there is enough room */
-            if ( ((size_t)(dstEnd-dstPtr) >= dctx->maxBlockSize)
-                 /* unless the dictionary is stored in tmpOut:
+            if (((size_t)(dstEnd - dstPtr) >= dctx->maxBlockSize)
+                /* unless the dictionary is stored in tmpOut:
                   * in which case it's faster to decode within tmpOut
                   * to benefit from prefix speedup */
-              && !(dctx->dict!= NULL && (const BYTE*)dctx->dict + dctx->dictSize == dctx->tmpOut) )
-            {
-                const char* dict = (const char*)dctx->dict;
-                size_t dictSize = dctx->dictSize;
-                int decodedSize;
+                && !(dctx->dict != NULL && (const BYTE*)dctx->dict + dctx->dictSize == dctx->tmpOut)) {
+                const char* dict     = (const char*)dctx->dict;
+                size_t      dictSize = dctx->dictSize;
+                int         decodedSize;
                 assert(dstPtr != NULL);
                 if (dict && dictSize > 1 GB) {
                     /* overflow control : dctx->dictSize is an int, avoid truncation / sign issues */
                     dict += dictSize - 64 KB;
                     dictSize = 64 KB;
                 }
-                decodedSize = LZ4_decompress_safe_usingDict(
-                        (const char*)selectedIn, (char*)dstPtr,
-                        (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
-                        dict, (int)dictSize);
+                decodedSize = LZ4_decompress_safe_usingDict((const char*)selectedIn, (char*)dstPtr,
+                                                            (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
+                                                            dict, (int)dictSize);
                 RETURN_ERROR_IF(decodedSize < 0, decompressionFailed);
                 if ((dctx->frameInfo.contentChecksumFlag) && (!dctx->skipChecksum))
                     XXH32_update(&(dctx->xxh), dstPtr, (size_t)decodedSize);
-                if (dctx->frameInfo.contentSize)
-                    dctx->frameRemainingSize -= (size_t)decodedSize;
+                if (dctx->frameInfo.contentSize) dctx->frameRemainingSize -= (size_t)decodedSize;
 
                 /* dictionary management */
-                if (dctx->frameInfo.blockMode==LZ4F_blockLinked) {
+                if (dctx->frameInfo.blockMode == LZ4F_blockLinked) {
                     LZ4F_updateDict(dctx, dstPtr, (size_t)decodedSize, dstStart, 0);
                 }
 
                 dstPtr += decodedSize;
-                dctx->dStage = dstage_getBlockHeader;  /* end of block, let's get another one */
+                dctx->dStage = dstage_getBlockHeader; /* end of block, let's get another one */
                 break;
             }
 
@@ -1960,39 +2027,39 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                         dctx->dictSize = 64 KB;
                     }
                     dctx->tmpOut = dctx->tmpOutBuffer + dctx->dictSize;
-                } else {  /* dict not within tmpOut */
-                    size_t const reservedDictSpace = MIN(dctx->dictSize, 64 KB);
-                    dctx->tmpOut = dctx->tmpOutBuffer + reservedDictSpace;
-            }   }
+                } else { /* dict not within tmpOut */
+                    const size_t reservedDictSpace = MIN(dctx->dictSize, 64 KB);
+                    dctx->tmpOut                   = dctx->tmpOutBuffer + reservedDictSpace;
+                }
+            }
 
             /* Decode block into tmpOut */
-            {   const char* dict = (const char*)dctx->dict;
-                size_t dictSize = dctx->dictSize;
-                int decodedSize;
+            {
+                const char* dict     = (const char*)dctx->dict;
+                size_t      dictSize = dctx->dictSize;
+                int         decodedSize;
                 if (dict && dictSize > 1 GB) {
                     /* the dictSize param is an int, avoid truncation / sign issues */
                     dict += dictSize - 64 KB;
                     dictSize = 64 KB;
                 }
-                decodedSize = LZ4_decompress_safe_usingDict(
-                        (const char*)selectedIn, (char*)dctx->tmpOut,
-                        (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
-                        dict, (int)dictSize);
+                decodedSize = LZ4_decompress_safe_usingDict((const char*)selectedIn, (char*)dctx->tmpOut,
+                                                            (int)dctx->tmpInTarget, (int)dctx->maxBlockSize,
+                                                            dict, (int)dictSize);
                 RETURN_ERROR_IF(decodedSize < 0, decompressionFailed);
                 if (dctx->frameInfo.contentChecksumFlag && !dctx->skipChecksum)
                     XXH32_update(&(dctx->xxh), dctx->tmpOut, (size_t)decodedSize);
-                if (dctx->frameInfo.contentSize)
-                    dctx->frameRemainingSize -= (size_t)decodedSize;
-                dctx->tmpOutSize = (size_t)decodedSize;
+                if (dctx->frameInfo.contentSize) dctx->frameRemainingSize -= (size_t)decodedSize;
+                dctx->tmpOutSize  = (size_t)decodedSize;
                 dctx->tmpOutStart = 0;
-                dctx->dStage = dstage_flushOut;
+                dctx->dStage      = dstage_flushOut;
             }
             /* fall-through */
 
-        case dstage_flushOut:  /* flush decoded data from tmpOut to dstBuffer */
+        case dstage_flushOut: /* flush decoded data from tmpOut to dstBuffer */
             DEBUGLOG(6, "dstage_flushOut");
             if (dstPtr != NULL) {
-                size_t const sizeToCopy = MIN(dctx->tmpOutSize - dctx->tmpOutStart, (size_t)(dstEnd-dstPtr));
+                const size_t sizeToCopy = MIN(dctx->tmpOutSize - dctx->tmpOutStart, (size_t)(dstEnd - dstPtr));
                 memcpy(dstPtr, dctx->tmpOut + dctx->tmpOutStart, sizeToCopy);
 
                 /* dictionary management */
@@ -2003,58 +2070,58 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 dstPtr += sizeToCopy;
             }
             if (dctx->tmpOutStart == dctx->tmpOutSize) { /* all flushed */
-                dctx->dStage = dstage_getBlockHeader;  /* get next block */
+                dctx->dStage = dstage_getBlockHeader; /* get next block */
                 break;
             }
             /* could not flush everything : stop there, just request a block header */
-            doAnotherStage = 0;
+            doAnotherStage  = 0;
             nextSrcSizeHint = BHSize;
             break;
 
         case dstage_getSuffix:
-            RETURN_ERROR_IF(dctx->frameRemainingSize, frameSize_wrong);   /* incorrect frame size decoded */
-            if (!dctx->frameInfo.contentChecksumFlag) {  /* no checksum, frame is completed */
+            RETURN_ERROR_IF(dctx->frameRemainingSize, frameSize_wrong); /* incorrect frame size decoded */
+            if (!dctx->frameInfo.contentChecksumFlag) { /* no checksum, frame is completed */
                 nextSrcSizeHint = 0;
                 LZ4F_resetDecompressionContext(dctx);
                 doAnotherStage = 0;
                 break;
             }
-            if ((srcEnd - srcPtr) < 4) {  /* not enough size for entire CRC */
+            if ((srcEnd - srcPtr) < 4) { /* not enough size for entire CRC */
                 dctx->tmpInSize = 0;
-                dctx->dStage = dstage_storeSuffix;
+                dctx->dStage    = dstage_storeSuffix;
             } else {
                 selectedIn = srcPtr;
                 srcPtr += 4;
             }
 
-            if (dctx->dStage == dstage_storeSuffix)   /* can be skipped */
-        case dstage_storeSuffix:
-            {   size_t const remainingInput = (size_t)(srcEnd - srcPtr);
-                size_t const wantedData = 4 - dctx->tmpInSize;
-                size_t const sizeToCopy = MIN(wantedData, remainingInput);
+            if (dctx->dStage == dstage_storeSuffix) /* can be skipped */
+            case dstage_storeSuffix: {
+                const size_t remainingInput = (size_t)(srcEnd - srcPtr);
+                const size_t wantedData     = 4 - dctx->tmpInSize;
+                const size_t sizeToCopy     = MIN(wantedData, remainingInput);
                 memcpy(dctx->tmpIn + dctx->tmpInSize, srcPtr, sizeToCopy);
                 srcPtr += sizeToCopy;
                 dctx->tmpInSize += sizeToCopy;
                 if (dctx->tmpInSize < 4) { /* not enough input to read complete suffix */
                     nextSrcSizeHint = 4 - dctx->tmpInSize;
-                    doAnotherStage=0;
+                    doAnotherStage  = 0;
                     break;
                 }
                 selectedIn = dctx->tmpIn;
-            }   /* if (dctx->dStage == dstage_storeSuffix) */
+            } /* if (dctx->dStage == dstage_storeSuffix) */
 
-        /* case dstage_checkSuffix: */   /* no direct entry, avoid initialization risks */
-            if (!dctx->skipChecksum) {
-                U32 const readCRC = LZ4F_readLE32(selectedIn);
-                U32 const resultCRC = XXH32_digest(&(dctx->xxh));
-                DEBUGLOG(4, "frame checksum: stored 0x%0X vs 0x%0X processed", readCRC, resultCRC);
+                /* case dstage_checkSuffix: */ /* no direct entry, avoid initialization risks */
+                if (!dctx->skipChecksum) {
+                    U32 const readCRC   = LZ4F_readLE32(selectedIn);
+                    U32 const resultCRC = XXH32_digest(&(dctx->xxh));
+                    DEBUGLOG(4, "frame checksum: stored 0x%0X vs 0x%0X processed", readCRC, resultCRC);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-                RETURN_ERROR_IF(readCRC != resultCRC, contentChecksum_invalid);
+                    RETURN_ERROR_IF(readCRC != resultCRC, contentChecksum_invalid);
 #else
-                (void)readCRC;
-                (void)resultCRC;
+                    (void)readCRC;
+                    (void)resultCRC;
 #endif
-            }
+                }
             nextSrcSizeHint = 0;
             LZ4F_resetDecompressionContext(dctx);
             doAnotherStage = 0;
@@ -2066,78 +2133,77 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
                 srcPtr += 4;
             } else {
                 /* not enough input to read cBlockSize field */
-                dctx->tmpInSize = 4;
+                dctx->tmpInSize   = 4;
                 dctx->tmpInTarget = 8;
-                dctx->dStage = dstage_storeSFrameSize;
+                dctx->dStage      = dstage_storeSFrameSize;
             }
 
-            if (dctx->dStage == dstage_storeSFrameSize)
-        case dstage_storeSFrameSize:
-            {   size_t const sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize,
-                                             (size_t)(srcEnd - srcPtr) );
+            if (dctx->dStage == dstage_storeSFrameSize) case dstage_storeSFrameSize: {
+                const size_t sizeToCopy = MIN(dctx->tmpInTarget - dctx->tmpInSize, (size_t)(srcEnd - srcPtr));
                 memcpy(dctx->header + dctx->tmpInSize, srcPtr, sizeToCopy);
                 srcPtr += sizeToCopy;
                 dctx->tmpInSize += sizeToCopy;
                 if (dctx->tmpInSize < dctx->tmpInTarget) {
                     /* not enough input to get full sBlockSize; wait for more */
                     nextSrcSizeHint = dctx->tmpInTarget - dctx->tmpInSize;
-                    doAnotherStage = 0;
+                    doAnotherStage  = 0;
                     break;
                 }
                 selectedIn = dctx->header + 4;
-            }   /* if (dctx->dStage == dstage_storeSFrameSize) */
+            } /* if (dctx->dStage == dstage_storeSFrameSize) */
 
-        /* case dstage_decodeSFrameSize: */   /* no direct entry */
-            {   size_t const SFrameSize = LZ4F_readLE32(selectedIn);
+            /* case dstage_decodeSFrameSize: */ /* no direct entry */
+            {
+                const size_t SFrameSize     = LZ4F_readLE32(selectedIn);
                 dctx->frameInfo.contentSize = SFrameSize;
-                dctx->tmpInTarget = SFrameSize;
-                dctx->dStage = dstage_skipSkippable;
+                dctx->tmpInTarget           = SFrameSize;
+                dctx->dStage                = dstage_skipSkippable;
                 break;
             }
 
-        case dstage_skipSkippable:
-            {   size_t const skipSize = MIN(dctx->tmpInTarget, (size_t)(srcEnd-srcPtr));
-                srcPtr += skipSize;
-                dctx->tmpInTarget -= skipSize;
-                doAnotherStage = 0;
-                nextSrcSizeHint = dctx->tmpInTarget;
-                if (nextSrcSizeHint) break;  /* still more to skip */
-                /* frame fully skipped : prepare context for a new frame */
-                LZ4F_resetDecompressionContext(dctx);
-                break;
-            }
-        }   /* switch (dctx->dStage) */
-    }   /* while (doAnotherStage) */
+        case dstage_skipSkippable: {
+            const size_t skipSize = MIN(dctx->tmpInTarget, (size_t)(srcEnd - srcPtr));
+            srcPtr += skipSize;
+            dctx->tmpInTarget -= skipSize;
+            doAnotherStage  = 0;
+            nextSrcSizeHint = dctx->tmpInTarget;
+            if (nextSrcSizeHint) break; /* still more to skip */
+            /* frame fully skipped : prepare context for a new frame */
+            LZ4F_resetDecompressionContext(dctx);
+            break;
+        }
+        } /* switch (dctx->dStage) */
+    } /* while (doAnotherStage) */
 
     /* preserve history within tmpOut whenever necessary */
     LZ4F_STATIC_ASSERT((unsigned)dstage_init == 2);
-    if ( (dctx->frameInfo.blockMode==LZ4F_blockLinked)  /* next block will use up to 64KB from previous ones */
-      && (dctx->dict != dctx->tmpOutBuffer)             /* dictionary is not already within tmp */
-      && (dctx->dict != NULL)                           /* dictionary exists */
-      && (!decompressOptionsPtr->stableDst)             /* cannot rely on dst data to remain there for next call */
-      && ((unsigned)(dctx->dStage)-2 < (unsigned)(dstage_getSuffix)-2) )  /* valid stages : [init ... getSuffix[ */
+    if ((dctx->frameInfo.blockMode == LZ4F_blockLinked) /* next block will use up to 64KB from previous ones */
+        && (dctx->dict != dctx->tmpOutBuffer) /* dictionary is not already within tmp */
+        && (dctx->dict != NULL) /* dictionary exists */
+        && (!decompressOptionsPtr->stableDst) /* cannot rely on dst data to remain there for next call */
+        && ((unsigned)(dctx->dStage) - 2 < (unsigned)(dstage_getSuffix)-2)) /* valid stages : [init ... getSuffix[ */
     {
         if (dctx->dStage == dstage_flushOut) {
-            size_t const preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
-            size_t copySize = 64 KB - dctx->tmpOutSize;
-            const BYTE* oldDictEnd = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
+            const size_t preserveSize = (size_t)(dctx->tmpOut - dctx->tmpOutBuffer);
+            size_t       copySize     = 64 KB - dctx->tmpOutSize;
+            const BYTE*  oldDictEnd   = dctx->dict + dctx->dictSize - dctx->tmpOutStart;
             if (dctx->tmpOutSize > 64 KB) copySize = 0;
             if (copySize > preserveSize) copySize = preserveSize;
             assert(dctx->tmpOutBuffer != NULL);
 
             memcpy(dctx->tmpOutBuffer + preserveSize - copySize, oldDictEnd - copySize, copySize);
 
-            dctx->dict = dctx->tmpOutBuffer;
+            dctx->dict     = dctx->tmpOutBuffer;
             dctx->dictSize = preserveSize + dctx->tmpOutStart;
         } else {
-            const BYTE* const oldDictEnd = dctx->dict + dctx->dictSize;
-            size_t const newDictSize = MIN(dctx->dictSize, 64 KB);
+            const BYTE* const oldDictEnd  = dctx->dict + dctx->dictSize;
+            const size_t      newDictSize = MIN(dctx->dictSize, 64 KB);
 
             memcpy(dctx->tmpOutBuffer, oldDictEnd - newDictSize, newDictSize);
 
-            dctx->dict = dctx->tmpOutBuffer;
+            dctx->dict     = dctx->tmpOutBuffer;
             dctx->dictSize = newDictSize;
-            dctx->tmpOut = dctx->tmpOutBuffer + newDictSize;
+            dctx->tmpOut   = dctx->tmpOutBuffer + newDictSize;
         }
     }
 
@@ -2151,17 +2217,18 @@ size_t LZ4F_decompress(LZ4F_dctx* dctx,
  *  Dictionary is used "in place", without any preprocessing.
  *  It must remain accessible throughout the entire frame decoding.
  */
-size_t LZ4F_decompress_usingDict(LZ4F_dctx* dctx,
-                       void* dstBuffer, size_t* dstSizePtr,
-                       const void* srcBuffer, size_t* srcSizePtr,
-                       const void* dict, size_t dictSize,
-                       const LZ4F_decompressOptions_t* decompressOptionsPtr)
+size_t LZ4F_decompress_usingDict(LZ4F_dctx*                      dctx,
+                                 void*                           dstBuffer,
+                                 size_t*                         dstSizePtr,
+                                 const void*                     srcBuffer,
+                                 size_t*                         srcSizePtr,
+                                 const void*                     dict,
+                                 size_t                          dictSize,
+                                 const LZ4F_decompressOptions_t* decompressOptionsPtr)
 {
     if (dctx->dStage <= dstage_init) {
-        dctx->dict = (const BYTE*)dict;
+        dctx->dict     = (const BYTE*)dict;
         dctx->dictSize = dictSize;
     }
-    return LZ4F_decompress(dctx, dstBuffer, dstSizePtr,
-                           srcBuffer, srcSizePtr,
-                           decompressOptionsPtr);
+    return LZ4F_decompress(dctx, dstBuffer, dstSizePtr, srcBuffer, srcSizePtr, decompressOptionsPtr);
 }

--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -33,7 +33,6 @@
 */
 /* note : lz4hc is not an independent module, it requires lz4.h/lz4.c for proper compilation */
 
-
 /* *************************************
 *  Tuning Parameter
 ***************************************/
@@ -48,107 +47,131 @@
 #  define LZ4HC_HEAPMODE 1
 #endif
 
-
 /*===    Dependency    ===*/
 #define LZ4_HC_STATIC_LINKING_ONLY
 #include "lz4hc.h"
 #include <limits.h>
 
-
 /*===   Shared lz4.c code   ===*/
 #ifndef LZ4_SRC_INCLUDED
-# if defined(__GNUC__)
-#  pragma GCC diagnostic ignored "-Wunused-function"
-# endif
-# if defined (__clang__)
-#  pragma clang diagnostic ignored "-Wunused-function"
-# endif
-# define LZ4_COMMONDEFS_ONLY
-# include "lz4.c"   /* LZ4_count, constants, mem */
+#  if defined(__GNUC__)
+#    pragma GCC diagnostic ignored "-Wunused-function"
+#  endif
+#  if defined(__clang__)
+#    pragma clang diagnostic ignored "-Wunused-function"
+#  endif
+#  define LZ4_COMMONDEFS_ONLY
+#  include "lz4.c"   /* LZ4_count, constants, mem */
 #endif
-
 
 /*===   Enums   ===*/
 typedef enum { noDictCtx, usingDictCtxHc } dictCtx_directive;
 
-
 /*===   Constants   ===*/
-#define OPTIMAL_ML (int)((ML_MASK-1)+MINMATCH)
-#define LZ4_OPT_NUM   (1<<12)
-
+#define OPTIMAL_ML  (int)((ML_MASK - 1) + MINMATCH)
+#define LZ4_OPT_NUM (1 << 12)
 
 /*===   Macros   ===*/
-#define MIN(a,b)   ( (a) < (b) ? (a) : (b) )
-#define MAX(a,b)   ( (a) > (b) ? (a) : (b) )
-
+#undef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 /*===   Levels definition   ===*/
 typedef enum { lz4mid, lz4hc, lz4opt } lz4hc_strat_e;
+
 typedef struct {
     lz4hc_strat_e strat;
-    int nbSearches;
-    U32 targetLength;
+    int           nbSearches;
+    U32           targetLength;
 } cParams_t;
-static const cParams_t k_clTable[LZ4HC_CLEVEL_MAX+1] = {
-    { lz4mid,    2, 16 },  /* 0, unused */
-    { lz4mid,    2, 16 },  /* 1, unused */
-    { lz4mid,    2, 16 },  /* 2 */
-    { lz4hc,     4, 16 },  /* 3 */
-    { lz4hc,     8, 16 },  /* 4 */
-    { lz4hc,    16, 16 },  /* 5 */
-    { lz4hc,    32, 16 },  /* 6 */
-    { lz4hc,    64, 16 },  /* 7 */
-    { lz4hc,   128, 16 },  /* 8 */
-    { lz4hc,   256, 16 },  /* 9 */
-    { lz4opt,   96, 64 },  /*10==LZ4HC_CLEVEL_OPT_MIN*/
-    { lz4opt,  512,128 },  /*11 */
-    { lz4opt,16384,LZ4_OPT_NUM },  /* 12==LZ4HC_CLEVEL_MAX */
+
+static const cParams_t k_clTable[LZ4HC_CLEVEL_MAX + 1] = {
+    {lz4mid,     2,          16}, /* 0, unused */
+    {lz4mid,     2,          16}, /* 1, unused */
+    {lz4mid,     2,          16}, /* 2 */
+    { lz4hc,     4,          16}, /* 3 */
+    { lz4hc,     8,          16}, /* 4 */
+    { lz4hc,    16,          16}, /* 5 */
+    { lz4hc,    32,          16}, /* 6 */
+    { lz4hc,    64,          16}, /* 7 */
+    { lz4hc,   128,          16}, /* 8 */
+    { lz4hc,   256,          16}, /* 9 */
+    {lz4opt,    96,          64}, /*10==LZ4HC_CLEVEL_OPT_MIN*/
+    {lz4opt,   512,         128}, /*11 */
+    {lz4opt, 16384, LZ4_OPT_NUM}, /* 12==LZ4HC_CLEVEL_MAX */
 };
 
 static cParams_t LZ4HC_getCLevelParams(int cLevel)
 {
     /* note : clevel convention is a bit different from lz4frame,
      * possibly something worth revisiting for consistency */
-    if (cLevel < 1)
-        cLevel = LZ4HC_CLEVEL_DEFAULT;
+    if (cLevel < 1) cLevel = LZ4HC_CLEVEL_DEFAULT;
     cLevel = MIN(LZ4HC_CLEVEL_MAX, cLevel);
     return k_clTable[cLevel];
 }
 
-
 /*===   Hashing   ===*/
-#define LZ4HC_HASHSIZE 4
-#define HASH_FUNCTION(i)      (((i) * 2654435761U) >> ((MINMATCH*8)-LZ4HC_HASH_LOG))
-static U32 LZ4HC_hashPtr(const void* ptr) { return HASH_FUNCTION(LZ4_read32(ptr)); }
+#define LZ4HC_HASHSIZE   4
+#define HASH_FUNCTION(i) (((i) * 2654435761U) >> ((MINMATCH * 8) - LZ4HC_HASH_LOG))
 
-#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==2)
+static U32 LZ4HC_hashPtr(const void* ptr)
+{
+    return HASH_FUNCTION(LZ4_read32(ptr));
+}
+
+#if defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 2)
 /* lie to the compiler about data alignment; use with caution */
-static U64 LZ4_read64(const void* memPtr) { return *(const U64*) memPtr; }
+static U64 LZ4_read64(const void* memPtr)
+{
+    return *(const U64*)memPtr;
+}
 
-#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS==1)
+#elif defined(LZ4_FORCE_MEMORY_ACCESS) && (LZ4_FORCE_MEMORY_ACCESS == 1)
 /* __pack instructions are safer, but compiler specific */
 LZ4_PACK(typedef struct { U64 u64; }) LZ4_unalign64;
-static U64 LZ4_read64(const void* ptr) { return ((const LZ4_unalign64*)ptr)->u64; }
+
+static U64 LZ4_read64(const void* ptr)
+{
+    return ((const LZ4_unalign64*)ptr)->u64;
+}
 
 #else  /* safe and portable access using memcpy() */
 static U64 LZ4_read64(const void* memPtr)
 {
-    U64 val; LZ4_memcpy(&val, memPtr, sizeof(val)); return val;
+    U64 val;
+    LZ4_memcpy(&val, memPtr, sizeof(val));
+    return val;
 }
 
 #endif /* LZ4_FORCE_MEMORY_ACCESS */
 
-#define LZ4MID_HASHSIZE 8
-#define LZ4MID_HASHLOG (LZ4HC_HASH_LOG-1)
+#define LZ4MID_HASHSIZE      8
+#define LZ4MID_HASHLOG       (LZ4HC_HASH_LOG - 1)
 #define LZ4MID_HASHTABLESIZE (1 << LZ4MID_HASHLOG)
 
-static U32 LZ4MID_hash4(U32 v) { return (v * 2654435761U) >> (32-LZ4MID_HASHLOG); }
-static U32 LZ4MID_hash4Ptr(const void* ptr) { return LZ4MID_hash4(LZ4_read32(ptr)); }
+static U32 LZ4MID_hash4(U32 v)
+{
+    return (v * 2654435761U) >> (32 - LZ4MID_HASHLOG);
+}
+
+static U32 LZ4MID_hash4Ptr(const void* ptr)
+{
+    return LZ4MID_hash4(LZ4_read32(ptr));
+}
+
 /* note: hash7 hashes the lower 56-bits.
  * It presumes input was read using little endian.*/
-static U32 LZ4MID_hash7(U64 v) { return (U32)(((v  << (64-56)) * 58295818150454627ULL) >> (64-LZ4MID_HASHLOG)) ; }
+static U32 LZ4MID_hash7(U64 v)
+{
+    return (U32)(((v << (64 - 56)) * 58295818150454627ULL) >> (64 - LZ4MID_HASHLOG));
+}
+
 static U64 LZ4_readLE64(const void* memPtr);
-static U32 LZ4MID_hash8Ptr(const void* ptr) { return LZ4MID_hash7(LZ4_readLE64(ptr)); }
+
+static U32 LZ4MID_hash8Ptr(const void* ptr)
+{
+    return LZ4MID_hash7(LZ4_readLE64(ptr));
+}
 
 static U64 LZ4_readLE64(const void* memPtr)
 {
@@ -157,11 +180,10 @@ static U64 LZ4_readLE64(const void* memPtr)
     } else {
         const BYTE* p = (const BYTE*)memPtr;
         /* note: relies on the compiler to simplify this expression */
-        return (U64)p[0] | ((U64)p[1]<<8) | ((U64)p[2]<<16) | ((U64)p[3]<<24)
-            | ((U64)p[4]<<32) | ((U64)p[5]<<40) | ((U64)p[6]<<48) | ((U64)p[7]<<56);
+        return (U64)p[0] | ((U64)p[1] << 8) | ((U64)p[2] << 16) | ((U64)p[3] << 24) | ((U64)p[4] << 32) |
+               ((U64)p[5] << 40) | ((U64)p[6] << 48) | ((U64)p[7] << 56);
     }
 }
-
 
 /*===   Count match length   ===*/
 LZ4_FORCE_INLINE
@@ -169,58 +191,57 @@ unsigned LZ4HC_NbCommonBytes32(U32 val)
 {
     assert(val != 0);
     if (LZ4_isLittleEndian()) {
-#     if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
         unsigned long r;
         _BitScanReverse(&r, val);
         return (unsigned)((31 - r) >> 3);
-#     elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
         return (unsigned)__builtin_clz(val) >> 3;
-#     else
+#else
         val >>= 8;
-        val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) |
-              (val + 0x00FF0000)) >> 24;
+        val = ((((val + 0x00FFFF00) | 0x00FFFFFF) + val) | (val + 0x00FF0000)) >> 24;
         return (unsigned)val ^ 3;
-#     endif
+#endif
     } else {
-#     if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
+#if defined(_MSC_VER) && (_MSC_VER >= 1400) && !defined(LZ4_FORCE_SW_BITCOUNT)
         unsigned long r;
         _BitScanForward(&r, val);
         return (unsigned)(r >> 3);
-#     elif (defined(__clang__) || (defined(__GNUC__) && ((__GNUC__ > 3) || \
-                            ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
-                                        !defined(LZ4_FORCE_SW_BITCOUNT)
+#elif (defined(__clang__) ||                                                                     \
+       (defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))))) && \
+    !defined(LZ4_FORCE_SW_BITCOUNT)
         return (unsigned)__builtin_ctz(val) >> 3;
-#     else
+#else
         const U32 m = 0x01010101;
         return (unsigned)((((val - 1) ^ val) & (m - 1)) * m) >> 24;
-#     endif
+#endif
     }
 }
 
 /** LZ4HC_countBack() :
  * @return : negative value, nb of common bytes before ip/match */
 LZ4_FORCE_INLINE
-int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
-                    const BYTE* const iMin, const BYTE* const mMin)
+int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match, const BYTE* const iMin, const BYTE* const mMin)
 {
-    int back = 0;
-    int const min = (int)MAX(iMin - ip, mMin - match);
+    int       back = 0;
+    const int min  = (int)MAX(iMin - ip, mMin - match);
     assert(min <= 0);
-    assert(ip >= iMin); assert((size_t)(ip-iMin) < (1U<<31));
-    assert(match >= mMin); assert((size_t)(match - mMin) < (1U<<31));
+    assert(ip >= iMin);
+    assert((size_t)(ip - iMin) < (1U << 31));
+    assert(match >= mMin);
+    assert((size_t)(match - mMin) < (1U << 31));
 
     while ((back - min) > 3) {
         U32 const v = LZ4_read32(ip + back - 4) ^ LZ4_read32(match + back - 4);
         if (v) {
-            return (back - (int)LZ4HC_NbCommonBytes32(v));
+            return back - (int)LZ4HC_NbCommonBytes32(v);
         } else back -= 4; /* 4-byte step */
     }
     /* check remainder if any */
-    while ( (back > min)
-         && (ip[back-1] == match[back-1]) )
-            back--;
+    while ((back > min) && (ip[back - 1] == match[back - 1]))
+        back--;
     return back;
 }
 
@@ -229,20 +250,19 @@ int LZ4HC_countBack(const BYTE* const ip, const BYTE* const match,
 /* Make fields passed to, and updated by LZ4HC_encodeSequence explicit */
 #define UPDATABLE(ip, op, anchor) &ip, &op, &anchor
 
-
 /**************************************
 *  Init
 **************************************/
-static void LZ4HC_clearTables (LZ4HC_CCtx_internal* hc4)
+static void LZ4HC_clearTables(LZ4HC_CCtx_internal* hc4)
 {
     MEM_INIT(hc4->hashTable, 0, sizeof(hc4->hashTable));
     MEM_INIT(hc4->chainTable, 0xFF, sizeof(hc4->chainTable));
 }
 
-static void LZ4HC_init_internal (LZ4HC_CCtx_internal* hc4, const BYTE* start)
+static void LZ4HC_init_internal(LZ4HC_CCtx_internal* hc4, const BYTE* start)
 {
-    size_t const bufferSize = (size_t)(hc4->end - hc4->prefixStart);
-    size_t newStartingOffset = bufferSize + hc4->dictLimit;
+    const size_t bufferSize        = (size_t)(hc4->end - hc4->prefixStart);
+    size_t       newStartingOffset = bufferSize + hc4->dictLimit;
     DEBUGLOG(5, "LZ4HC_init_internal");
     assert(newStartingOffset >= bufferSize);  /* check overflow */
     if (newStartingOffset > 1 GB) {
@@ -251,91 +271,90 @@ static void LZ4HC_init_internal (LZ4HC_CCtx_internal* hc4, const BYTE* start)
     }
     newStartingOffset += 64 KB;
     hc4->nextToUpdate = (U32)newStartingOffset;
-    hc4->prefixStart = start;
-    hc4->end = start;
-    hc4->dictStart = start;
-    hc4->dictLimit = (U32)newStartingOffset;
-    hc4->lowLimit = (U32)newStartingOffset;
+    hc4->prefixStart  = start;
+    hc4->end          = start;
+    hc4->dictStart    = start;
+    hc4->dictLimit    = (U32)newStartingOffset;
+    hc4->lowLimit     = (U32)newStartingOffset;
 }
-
 
 /**************************************
 *  Encode
 **************************************/
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 2)
-# define RAWLOG(...) fprintf(stderr, __VA_ARGS__)
+#  define RAWLOG(...) fprintf(stderr, __VA_ARGS__)
+
 void LZ4HC_hexOut(const void* src, size_t len)
 {
     const BYTE* p = (const BYTE*)src;
-    size_t n;
-    for (n=0; n<len; n++) {
+    size_t      n;
+    for (n = 0; n < len; n++) {
         RAWLOG("%02X ", p[n]);
     }
     RAWLOG(" \n");
 }
 
-# define HEX_CMP(_lev, _ptr, _ref, _len) \
-    if (LZ4_DEBUG >= _lev) {            \
-        RAWLOG("match bytes: ");        \
-        LZ4HC_hexOut(_ptr, _len);       \
-        RAWLOG("ref bytes: ");          \
-        LZ4HC_hexOut(_ref, _len);       \
-    }
+#  define HEX_CMP(_lev, _ptr, _ref, _len) \
+      if (LZ4_DEBUG >= _lev) {            \
+          RAWLOG("match bytes: ");        \
+          LZ4HC_hexOut(_ptr, _len);       \
+          RAWLOG("ref bytes: ");          \
+          LZ4HC_hexOut(_ref, _len);       \
+      }
 
 #else
-# define HEX_CMP(l,p,r,_l)
+#  define HEX_CMP(l, p, r, _l)
 #endif
 
 /* LZ4HC_encodeSequence() :
  * @return : 0 if ok,
  *           1 if buffer issue detected */
-LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
-    const BYTE** _ip,
-    BYTE** _op,
-    const BYTE** _anchor,
-    int matchLength,
-    int offset,
-    limitedOutput_directive limit,
-    BYTE* oend)
+LZ4_FORCE_INLINE int LZ4HC_encodeSequence(const BYTE**            _ip,
+                                          BYTE**                  _op,
+                                          const BYTE**            _anchor,
+                                          int                     matchLength,
+                                          int                     offset,
+                                          limitedOutput_directive limit,
+                                          BYTE*                   oend)
 {
-#define ip      (*_ip)
-#define op      (*_op)
-#define anchor  (*_anchor)
+#define ip     (*_ip)
+#define op     (*_op)
+#define anchor (*_anchor)
 
     BYTE* const token = op++;
 
 #if defined(LZ4_DEBUG) && (LZ4_DEBUG >= 6)
-    static const BYTE* start = NULL;
-    static U32 totalCost = 0;
-    U32 const pos = (start==NULL) ? 0 : (U32)(anchor - start); /* only works for single segment */
-    U32 const ll = (U32)(ip - anchor);
-    U32 const llAdd = (ll>=15) ? ((ll-15) / 255) + 1 : 0;
-    U32 const mlAdd = (matchLength>=19) ? ((matchLength-19) / 255) + 1 : 0;
-    U32 const cost = 1 + llAdd + ll + 2 + mlAdd;
-    if (start==NULL) start = anchor;  /* only works for single segment */
-    DEBUGLOG(6, "pos:%7u -- literals:%4u, match:%4i, offset:%5i, cost:%4u + %5u",
-                pos,
-                (U32)(ip - anchor), matchLength, offset,
-                cost, totalCost);
-# if 1 /* only works on single segment data */
-    HEX_CMP(7, ip, ip-offset, matchLength);
-# endif
+    static const BYTE* start     = NULL;
+    static U32         totalCost = 0;
+    U32 const          pos = (start == NULL) ? 0 : (U32)(anchor - start); /* only works for single segment */
+    U32 const          ll  = (U32)(ip - anchor);
+    U32 const          llAdd = (ll >= 15) ? ((ll - 15) / 255) + 1 : 0;
+    U32 const          mlAdd = (matchLength >= 19) ? ((matchLength - 19) / 255) + 1 : 0;
+    U32 const          cost  = 1 + llAdd + ll + 2 + mlAdd;
+    if (start == NULL) start = anchor; /* only works for single segment */
+    DEBUGLOG(6, "pos:%7u -- literals:%4u, match:%4i, offset:%5i, cost:%4u + %5u", pos, (U32)(ip - anchor),
+             matchLength, offset, cost, totalCost);
+#  if 1 /* only works on single segment data */
+    HEX_CMP(7, ip, ip - offset, matchLength);
+#  endif
     totalCost += cost;
 #endif
 
     /* Encode Literal length */
-    {   size_t litLen = (size_t)(ip - anchor);
+    {
+        size_t litLen = (size_t)(ip - anchor);
         LZ4_STATIC_ASSERT(notLimited == 0);
         /* Check output limit */
         if (limit && ((op + (litLen / 255) + litLen + (2 + 1 + LASTLITERALS)) > oend)) {
-            DEBUGLOG(6, "Not enough room to write %i literals (%i bytes remaining)",
-                    (int)litLen, (int)(oend - op));
+            DEBUGLOG(6, "Not enough room to write %i literals (%i bytes remaining)", (int)litLen,
+                     (int)(oend - op));
             return 1;
         }
         if (litLen >= RUN_MASK) {
             size_t len = litLen - RUN_MASK;
-            *token = (RUN_MASK << ML_BITS);
-            for(; len >= 255 ; len -= 255) *op++ = 255;
+            *token     = (RUN_MASK << ML_BITS);
+            for (; len >= 255; len -= 255)
+                *op++ = 255;
             *op++ = (BYTE)len;
         } else {
             *token = (BYTE)(litLen << ML_BITS);
@@ -347,26 +366,35 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
     }
 
     /* Encode Offset */
-    assert(offset <= LZ4_DISTANCE_MAX );
+    assert(offset <= LZ4_DISTANCE_MAX);
     assert(offset > 0);
-    LZ4_writeLE16(op, (U16)(offset)); op += 2;
+    LZ4_writeLE16(op, (U16)(offset));
+    op += 2;
 
     /* Encode MatchLength */
     assert(matchLength >= MINMATCH);
-    {   size_t mlCode = (size_t)matchLength - MINMATCH;
+    {
+        size_t mlCode = (size_t)matchLength - MINMATCH;
         if (limit && (op + (mlCode / 255) + (1 + LASTLITERALS) > oend)) {
             DEBUGLOG(6, "Not enough room to write match length");
-            return 1;   /* Check output limit */
+            return 1; /* Check output limit */
         }
         if (mlCode >= ML_MASK) {
             *token += ML_MASK;
             mlCode -= ML_MASK;
-            for(; mlCode >= 510 ; mlCode -= 510) { *op++ = 255; *op++ = 255; }
-            if (mlCode >= 255) { mlCode -= 255; *op++ = 255; }
+            for (; mlCode >= 510; mlCode -= 510) {
+                *op++ = 255;
+                *op++ = 255;
+            }
+            if (mlCode >= 255) {
+                mlCode -= 255;
+                *op++ = 255;
+            }
             *op++ = (BYTE)mlCode;
         } else {
             *token += (BYTE)(mlCode);
-    }   }
+        }
+    }
 
     /* Prepare next loop */
     ip += matchLength;
@@ -379,92 +407,103 @@ LZ4_FORCE_INLINE int LZ4HC_encodeSequence (
 #undef anchor
 }
 
-
 typedef struct {
     int off;
     int len;
-    int back;  /* negative value */
+    int back; /* negative value */
 } LZ4HC_match_t;
 
-static LZ4HC_match_t LZ4HC_searchExtDict(const BYTE* ip, U32 ipIndex,
-        const BYTE* const iLowLimit, const BYTE* const iHighLimit,
-        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex,
-        int currentBestML, int nbAttempts)
+static LZ4HC_match_t LZ4HC_searchExtDict(const BYTE*                ip,
+                                         U32                        ipIndex,
+                                         const BYTE* const          iLowLimit,
+                                         const BYTE* const          iHighLimit,
+                                         const LZ4HC_CCtx_internal* dictCtx,
+                                         U32                        gDictEndIndex,
+                                         int                        currentBestML,
+                                         int                        nbAttempts)
 {
-    size_t const lDictEndIndex = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
-    U32 lDictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
-    U32 matchIndex = lDictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
-    int offset = 0, sBack = 0;
+    const size_t lDictEndIndex   = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+    U32          lDictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
+    U32          matchIndex      = lDictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+    int          offset = 0, sBack = 0;
     assert(lDictEndIndex <= 1 GB);
-    if (lDictMatchIndex>0)
+    if (lDictMatchIndex > 0)
         DEBUGLOG(7, "lDictEndIndex = %zu, lDictMatchIndex = %u", lDictEndIndex, lDictMatchIndex);
     while (ipIndex - matchIndex <= LZ4_DISTANCE_MAX && nbAttempts--) {
         const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + lDictMatchIndex;
 
         if (LZ4_read32(matchPtr) == LZ4_read32(ip)) {
-            int mlt;
-            int back = 0;
+            int         mlt;
+            int         back   = 0;
             const BYTE* vLimit = ip + (lDictEndIndex - lDictMatchIndex);
             if (vLimit > iHighLimit) vLimit = iHighLimit;
-            mlt = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
+            mlt  = (int)LZ4_count(ip + MINMATCH, matchPtr + MINMATCH, vLimit) + MINMATCH;
             back = (ip > iLowLimit) ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictCtx->prefixStart) : 0;
             mlt -= back;
             if (mlt > currentBestML) {
                 currentBestML = mlt;
-                offset = (int)(ipIndex - matchIndex);
-                sBack = back;
+                offset        = (int)(ipIndex - matchIndex);
+                sBack         = back;
                 DEBUGLOG(7, "found match of length %i within extDictCtx", currentBestML);
-        }   }
+            }
+        }
 
-        {   U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, lDictMatchIndex);
+        {
+            U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, lDictMatchIndex);
             lDictMatchIndex -= nextOffset;
             matchIndex -= nextOffset;
-    }   }
+        }
+    }
 
-    {   LZ4HC_match_t md;
-        md.len = currentBestML;
-        md.off = offset;
+    {
+        LZ4HC_match_t md;
+        md.len  = currentBestML;
+        md.off  = offset;
         md.back = sBack;
         return md;
     }
 }
 
-typedef LZ4HC_match_t (*LZ4MID_searchIntoDict_f)(const BYTE* ip, U32 ipIndex,
-        const BYTE* const iHighLimit,
-        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex);
+typedef LZ4HC_match_t (*LZ4MID_searchIntoDict_f)(const BYTE*                ip,
+                                                 U32                        ipIndex,
+                                                 const BYTE* const          iHighLimit,
+                                                 const LZ4HC_CCtx_internal* dictCtx,
+                                                 U32                        gDictEndIndex);
 
-static LZ4HC_match_t LZ4MID_searchHCDict(const BYTE* ip, U32 ipIndex,
-        const BYTE* const iHighLimit,
-        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex)
+static LZ4HC_match_t LZ4MID_searchHCDict(const BYTE*                ip,
+                                         U32                        ipIndex,
+                                         const BYTE* const          iHighLimit,
+                                         const LZ4HC_CCtx_internal* dictCtx,
+                                         U32                        gDictEndIndex)
 {
-    return LZ4HC_searchExtDict(ip,ipIndex,
-                            ip, iHighLimit,
-                            dictCtx, gDictEndIndex,
-                            MINMATCH-1, 2);
+    return LZ4HC_searchExtDict(ip, ipIndex, ip, iHighLimit, dictCtx, gDictEndIndex, MINMATCH - 1, 2);
 }
 
-static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE* ip, U32 ipIndex,
-        const BYTE* const iHighLimit,
-        const LZ4HC_CCtx_internal* dictCtx, U32 gDictEndIndex)
+static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE*                ip,
+                                          U32                        ipIndex,
+                                          const BYTE* const          iHighLimit,
+                                          const LZ4HC_CCtx_internal* dictCtx,
+                                          U32                        gDictEndIndex)
 {
-    size_t const lDictEndIndex = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
-    const U32* const hash4Table = dictCtx->hashTable;
-    const U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    const size_t     lDictEndIndex = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+    const U32* const hash4Table    = dictCtx->hashTable;
+    const U32* const hash8Table    = hash4Table + LZ4MID_HASHTABLESIZE;
     DEBUGLOG(7, "LZ4MID_searchExtDict (ipIdx=%u)", ipIndex);
 
     /* search long match first */
-    {   U32 l8DictMatchIndex = hash8Table[LZ4MID_hash8Ptr(ip)];
-        U32 m8Index = l8DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+    {
+        U32 l8DictMatchIndex = hash8Table[LZ4MID_hash8Ptr(ip)];
+        U32 m8Index          = l8DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
         assert(lDictEndIndex <= 1 GB);
         if (ipIndex - m8Index <= LZ4_DISTANCE_MAX) {
             const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + l8DictMatchIndex;
-            const size_t safeLen = MIN(lDictEndIndex - l8DictMatchIndex, (size_t)(iHighLimit - ip));
-            int mlt = (int)LZ4_count(ip, matchPtr, ip + safeLen);
+            const size_t      safeLen  = MIN(lDictEndIndex - l8DictMatchIndex, (size_t)(iHighLimit - ip));
+            int               mlt      = (int)LZ4_count(ip, matchPtr, ip + safeLen);
             if (mlt >= MINMATCH) {
                 LZ4HC_match_t md;
                 DEBUGLOG(7, "Found long ExtDict match of len=%u", mlt);
-                md.len = mlt;
-                md.off = (int)(ipIndex - m8Index);
+                md.len  = mlt;
+                md.off  = (int)(ipIndex - m8Index);
                 md.back = 0;
                 return md;
             }
@@ -472,17 +511,18 @@ static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE* ip, U32 ipIndex,
     }
 
     /* search for short match second */
-    {   U32 l4DictMatchIndex = hash4Table[LZ4MID_hash4Ptr(ip)];
-        U32 m4Index = l4DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
+    {
+        U32 l4DictMatchIndex = hash4Table[LZ4MID_hash4Ptr(ip)];
+        U32 m4Index          = l4DictMatchIndex + gDictEndIndex - (U32)lDictEndIndex;
         if (ipIndex - m4Index <= LZ4_DISTANCE_MAX) {
             const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + l4DictMatchIndex;
-            const size_t safeLen = MIN(lDictEndIndex - l4DictMatchIndex, (size_t)(iHighLimit - ip));
-            int mlt = (int)LZ4_count(ip, matchPtr, ip + safeLen);
+            const size_t      safeLen  = MIN(lDictEndIndex - l4DictMatchIndex, (size_t)(iHighLimit - ip));
+            int               mlt      = (int)LZ4_count(ip, matchPtr, ip + safeLen);
             if (mlt >= MINMATCH) {
                 LZ4HC_match_t md;
                 DEBUGLOG(7, "Found short ExtDict match of len=%u", mlt);
-                md.len = mlt;
-                md.off = (int)(ipIndex - m4Index);
+                md.len  = mlt;
+                md.off  = (int)(ipIndex - m4Index);
                 md.back = 0;
                 return md;
             }
@@ -490,7 +530,8 @@ static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE* ip, U32 ipIndex,
     }
 
     /* nothing found */
-    {   LZ4HC_match_t const md = {0, 0, 0 };
+    {
+        const LZ4HC_match_t md = {0, 0, 0};
         return md;
     }
 }
@@ -499,8 +540,7 @@ static LZ4HC_match_t LZ4MID_searchExtDict(const BYTE* ip, U32 ipIndex,
 *  Mid Compression (level 2)
 **************************************/
 
-LZ4_FORCE_INLINE void
-LZ4MID_addPosition(U32* hTable, U32 hValue, U32 index)
+LZ4_FORCE_INLINE void LZ4MID_addPosition(U32* hTable, U32 hValue, U32 index)
 {
     hTable[hValue] = index;
 }
@@ -510,28 +550,26 @@ LZ4MID_addPosition(U32* hTable, U32 hValue, U32 index)
 
 /* Fill hash tables with references into dictionary.
  * The resulting table is only exploitable by LZ4MID (level 2) */
-static void
-LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
+static void LZ4MID_fillHTable(LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
 {
-    U32* const hash4Table = cctx->hashTable;
-    U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
-    const BYTE* const prefixPtr = (const BYTE*)dict;
-    U32 const prefixIdx = cctx->dictLimit;
-    U32 const target = prefixIdx + (U32)size - LZ4MID_HASHSIZE;
-    U32 idx = cctx->nextToUpdate;
+    U32* const        hash4Table = cctx->hashTable;
+    U32* const        hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    const BYTE* const prefixPtr  = (const BYTE*)dict;
+    U32 const         prefixIdx  = cctx->dictLimit;
+    U32 const         target     = prefixIdx + (U32)size - LZ4MID_HASHSIZE;
+    U32               idx        = cctx->nextToUpdate;
     assert(dict == cctx->prefixStart);
     DEBUGLOG(4, "LZ4MID_fillHTable (size:%zu)", size);
-    if (size <= LZ4MID_HASHSIZE)
-        return;
+    if (size <= LZ4MID_HASHSIZE) return;
 
     for (; idx < target; idx += 3) {
-        ADDPOS4(prefixPtr+idx-prefixIdx, idx);
-        ADDPOS8(prefixPtr+idx+1-prefixIdx, idx+1);
+        ADDPOS4(prefixPtr + idx - prefixIdx, idx);
+        ADDPOS8(prefixPtr + idx + 1 - prefixIdx, idx + 1);
     }
 
     idx = (size > 32 KB + LZ4MID_HASHSIZE) ? target - 32 KB : cctx->nextToUpdate;
     for (; idx < target; idx += 1) {
-        ADDPOS8(prefixPtr+idx-prefixIdx, idx);
+        ADDPOS8(prefixPtr + idx - prefixIdx, idx);
     }
 
     cctx->nextToUpdate = target;
@@ -540,8 +578,7 @@ LZ4MID_fillHTable (LZ4HC_CCtx_internal* cctx, const void* dict, size_t size)
 static LZ4MID_searchIntoDict_f select_searchDict_function(const LZ4HC_CCtx_internal* dictCtx)
 {
     if (dictCtx == NULL) return NULL;
-    if (LZ4HC_getCLevelParams(dictCtx->compressionLevel).strat == lz4mid)
-        return LZ4MID_searchExtDict;
+    if (LZ4HC_getCLevelParams(dictCtx->compressionLevel).strat == lz4mid) return LZ4MID_searchExtDict;
     return LZ4MID_searchHCDict;
 }
 
@@ -551,36 +588,36 @@ static LZ4MID_searchIntoDict_f select_searchDict_function(const LZ4HC_CCtx_inter
  * - maxOutputSize >= 1
  * - dst is valid
  */
-static int LZ4MID_compress (
-    LZ4HC_CCtx_internal* const ctx,
-    const char* const src,
-    char* const dst,
-    int* srcSizePtr,
-    int const maxOutputSize,
-    const limitedOutput_directive limit,
-    const dictCtx_directive dict
-    )
+static int LZ4MID_compress(LZ4HC_CCtx_internal* const    ctx,
+                           const char* const             src,
+                           char* const                   dst,
+                           int*                          srcSizePtr,
+                           const int                     maxOutputSize,
+                           const limitedOutput_directive limit,
+                           const dictCtx_directive       dict)
 {
-    U32* const hash4Table = ctx->hashTable;
-    U32* const hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
-    const BYTE* ip = (const BYTE*)src;
-    const BYTE* anchor = ip;
-    const BYTE* const iend = ip + *srcSizePtr;
-    const BYTE* const mflimit = iend - MFLIMIT;
+    U32* const        hash4Table = ctx->hashTable;
+    U32* const        hash8Table = hash4Table + LZ4MID_HASHTABLESIZE;
+    const BYTE*       ip         = (const BYTE*)src;
+    const BYTE*       anchor     = ip;
+    const BYTE* const iend       = ip + *srcSizePtr;
+    const BYTE* const mflimit    = iend - MFLIMIT;
     const BYTE* const matchlimit = (iend - LASTLITERALS);
-    const BYTE* const ilimit = (iend - LZ4MID_HASHSIZE);
-    BYTE* op = (BYTE*)dst;
-    BYTE* oend = op + maxOutputSize;
+    const BYTE* const ilimit     = (iend - LZ4MID_HASHSIZE);
+    BYTE*             op         = (BYTE*)dst;
+    BYTE*             oend       = op + maxOutputSize;
 
-    const BYTE* const prefixPtr = ctx->prefixStart;
-    const U32 prefixIdx = ctx->dictLimit;
-    const U32 ilimitIdx = (U32)(ilimit - prefixPtr) + prefixIdx;
-    const BYTE* const dictStart = ctx->dictStart;
-    const U32 dictIdx = ctx->lowLimit;
-    const U32 gDictEndIndex = ctx->lowLimit;
-    const LZ4MID_searchIntoDict_f searchIntoDict = (dict == usingDictCtxHc) ? select_searchDict_function(ctx->dictCtx) : NULL;
-    unsigned matchLength;
-    unsigned matchDistance;
+    const BYTE* const             prefixPtr      = ctx->prefixStart;
+    const U32                     prefixIdx      = ctx->dictLimit;
+    const U32                     ilimitIdx      = (U32)(ilimit - prefixPtr) + prefixIdx;
+    const BYTE* const             dictStart      = ctx->dictStart;
+    const U32                     dictIdx        = ctx->lowLimit;
+    const U32                     gDictEndIndex  = ctx->lowLimit;
+    const LZ4MID_searchIntoDict_f searchIntoDict = (dict == usingDictCtxHc)
+                                                       ? select_searchDict_function(ctx->dictCtx)
+                                                       : NULL;
+    unsigned                      matchLength;
+    unsigned                      matchDistance;
 
     DEBUGLOG(5, "LZ4MID_compress (%i bytes)", *srcSizePtr);
 
@@ -592,15 +629,16 @@ static int LZ4MID_compress (
     assert(maxOutputSize >= 1);
     assert(dst != NULL);
 
-    if (limit == fillOutput) oend -= LASTLITERALS;  /* Hack for support LZ4 format restriction */
+    if (limit == fillOutput) oend -= LASTLITERALS; /* Hack for support LZ4 format restriction */
     if (*srcSizePtr < LZ4_minLength)
-        goto _lz4mid_last_literals;  /* Input too small, no compression (all literals) */
+        goto _lz4mid_last_literals; /* Input too small, no compression (all literals) */
 
     /* main loop */
     while (ip <= mflimit) {
         const U32 ipIndex = (U32)(ip - prefixPtr) + prefixIdx;
         /* search long match */
-        {   U32 const h8 = LZ4MID_hash8Ptr(ip);
+        {
+            U32 const h8   = LZ4MID_hash8Ptr(ip);
             U32 const pos8 = hash8Table[h8];
             assert(h8 < LZ4MID_HASHTABLESIZE);
             assert(pos8 < ipIndex);
@@ -620,8 +658,8 @@ static int LZ4MID_compress (
                     if (pos8 >= dictIdx) {
                         /* extDict match candidate */
                         const BYTE* const matchPtr = dictStart + (pos8 - dictIdx);
-                        const size_t safeLen = MIN(prefixIdx - pos8, (size_t)(matchlimit - ip));
-                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        const size_t      safeLen  = MIN(prefixIdx - pos8, (size_t)(matchlimit - ip));
+                        matchLength                = LZ4_count(ip, matchPtr, ip + safeLen);
                         if (matchLength >= MINMATCH) {
                             DEBUGLOG(7, "found long match at ExtDict pos %u (len=%u)", pos8, matchLength);
                             matchDistance = ipIndex - pos8;
@@ -629,9 +667,11 @@ static int LZ4MID_compress (
                         }
                     }
                 }
-        }   }
+            }
+        }
         /* search short match */
-        {   U32 const h4 = LZ4MID_hash4Ptr(ip);
+        {
+            U32 const h4   = LZ4MID_hash4Ptr(ip);
             U32 const pos4 = hash4Table[h4];
             assert(h4 < LZ4MID_HASHTABLESIZE);
             assert(pos4 < ipIndex);
@@ -639,37 +679,36 @@ static int LZ4MID_compress (
             if (ipIndex - pos4 <= LZ4_DISTANCE_MAX) {
                 /* match candidate found */
                 if (pos4 >= prefixIdx) {
-                /* only search within prefix */
+                    /* only search within prefix */
                     const BYTE* const matchPtr = prefixPtr + (pos4 - prefixIdx);
                     assert(matchPtr < ip);
                     assert(matchPtr >= prefixPtr);
                     matchLength = LZ4_count(ip, matchPtr, matchlimit);
                     if (matchLength >= MINMATCH) {
                         /* short match found, let's just check ip+1 for longer */
-                        U32 const h8 = LZ4MID_hash8Ptr(ip+1);
-                        U32 const pos8 = hash8Table[h8];
+                        U32 const h8         = LZ4MID_hash8Ptr(ip + 1);
+                        U32 const pos8       = hash8Table[h8];
                         U32 const m2Distance = ipIndex + 1 - pos8;
-                        matchDistance = ipIndex - pos4;
-                        if ( m2Distance <= LZ4_DISTANCE_MAX
-                        && pos8 >= prefixIdx /* only search within prefix */
-                        && likely(ip < mflimit)
-                        ) {
+                        matchDistance        = ipIndex - pos4;
+                        if (m2Distance <= LZ4_DISTANCE_MAX && pos8 >= prefixIdx /* only search within prefix */
+                            && likely(ip < mflimit)) {
                             const BYTE* const m2Ptr = prefixPtr + (pos8 - prefixIdx);
-                            unsigned ml2 = LZ4_count(ip+1, m2Ptr, matchlimit);
+                            unsigned          ml2   = LZ4_count(ip + 1, m2Ptr, matchlimit);
                             if (ml2 > matchLength) {
-                                LZ4MID_addPosition(hash8Table, h8, ipIndex+1);
+                                LZ4MID_addPosition(hash8Table, h8, ipIndex + 1);
                                 ip++;
-                                matchLength = ml2;
+                                matchLength   = ml2;
                                 matchDistance = m2Distance;
-                        }   }
+                            }
+                        }
                         goto _lz4mid_encode_sequence;
                     }
                 } else {
                     if (pos4 >= dictIdx) {
                         /* extDict match candidate */
                         const BYTE* const matchPtr = dictStart + (pos4 - dictIdx);
-                        const size_t safeLen = MIN(prefixIdx - pos4, (size_t)(matchlimit - ip));
-                        matchLength = LZ4_count(ip, matchPtr, ip + safeLen);
+                        const size_t      safeLen  = MIN(prefixIdx - pos4, (size_t)(matchlimit - ip));
+                        matchLength                = LZ4_count(ip, matchPtr, ip + safeLen);
                         if (matchLength >= MINMATCH) {
                             DEBUGLOG(7, "found match at ExtDict pos %u (len=%u)", pos4, matchLength);
                             matchDistance = ipIndex - pos4;
@@ -677,85 +716,87 @@ static int LZ4MID_compress (
                         }
                     }
                 }
-        }   }
+            }
+        }
         /* no match found in prefix */
-        if ( (dict == usingDictCtxHc)
-          && (ipIndex - gDictEndIndex < LZ4_DISTANCE_MAX - 8) ) {
+        if ((dict == usingDictCtxHc) && (ipIndex - gDictEndIndex < LZ4_DISTANCE_MAX - 8)) {
             /* search a match into external dictionary */
-            LZ4HC_match_t dMatch = searchIntoDict(ip, ipIndex,
-                    matchlimit,
-                    ctx->dictCtx, gDictEndIndex);
+            LZ4HC_match_t dMatch = searchIntoDict(ip, ipIndex, matchlimit, ctx->dictCtx, gDictEndIndex);
             if (dMatch.len >= MINMATCH) {
                 DEBUGLOG(7, "found Dictionary match (offset=%i)", dMatch.off);
                 assert(dMatch.back == 0);
-                matchLength = (unsigned)dMatch.len;
+                matchLength   = (unsigned)dMatch.len;
                 matchDistance = (unsigned)dMatch.off;
                 goto _lz4mid_encode_sequence;
             }
         }
         /* no match found */
-        ip += 1 + ((ip-anchor) >> 9);  /* skip faster over incompressible data */
+        ip += 1 + ((ip - anchor) >> 9); /* skip faster over incompressible data */
         continue;
 
 _lz4mid_encode_sequence:
         /* catch back */
-        while (((ip > anchor) & ((U32)(ip-prefixPtr) > matchDistance)) && (unlikely(ip[-1] == ip[-(int)matchDistance-1]))) {
-            ip--;  matchLength++;
+        while (((ip > anchor) & ((U32)(ip - prefixPtr) > matchDistance)) &&
+               (unlikely(ip[-1] == ip[-(int)matchDistance - 1]))) {
+            ip--;
+            matchLength++;
         };
 
         /* fill table with beginning of match */
-        ADDPOS8(ip+1, ipIndex+1);
-        ADDPOS8(ip+2, ipIndex+2);
-        ADDPOS4(ip+1, ipIndex+1);
+        ADDPOS8(ip + 1, ipIndex + 1);
+        ADDPOS8(ip + 2, ipIndex + 2);
+        ADDPOS4(ip + 1, ipIndex + 1);
 
         /* encode */
-        {   BYTE* const saved_op = op;
+        {
+            BYTE* const saved_op = op;
             /* LZ4HC_encodeSequence always updates @op; on success, it updates @ip and @anchor */
-            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                    (int)matchLength, (int)matchDistance,
-                    limit, oend) ) {
-                op = saved_op;  /* restore @op value before failed LZ4HC_encodeSequence */
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), (int)matchLength, (int)matchDistance, limit,
+                                     oend)) {
+                op = saved_op; /* restore @op value before failed LZ4HC_encodeSequence */
                 goto _lz4mid_dest_overflow;
             }
         }
 
         /* fill table with end of match */
-        {   U32 endMatchIdx = (U32)(ip-prefixPtr) + prefixIdx;
-            U32 pos_m2 = endMatchIdx - 2;
+        {
+            U32 endMatchIdx = (U32)(ip - prefixPtr) + prefixIdx;
+            U32 pos_m2      = endMatchIdx - 2;
             if (pos_m2 < ilimitIdx) {
                 if (likely(ip - prefixPtr > 5)) {
-                    ADDPOS8(ip-5, endMatchIdx - 5);
+                    ADDPOS8(ip - 5, endMatchIdx - 5);
                 }
-                ADDPOS8(ip-3, endMatchIdx - 3);
-                ADDPOS8(ip-2, endMatchIdx - 2);
-                ADDPOS4(ip-2, endMatchIdx - 2);
-                ADDPOS4(ip-1, endMatchIdx - 1);
+                ADDPOS8(ip - 3, endMatchIdx - 3);
+                ADDPOS8(ip - 2, endMatchIdx - 2);
+                ADDPOS4(ip - 2, endMatchIdx - 2);
+                ADDPOS4(ip - 1, endMatchIdx - 1);
             }
         }
     }
 
 _lz4mid_last_literals:
     /* Encode Last Literals */
-    {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
-        size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
-        size_t const totalSize = 1 + llAdd + lastRunSize;
-        if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
+    {
+        size_t       lastRunSize = (size_t)(iend - anchor); /* literals */
+        size_t       llAdd       = (lastRunSize + 255 - RUN_MASK) / 255;
+        const size_t totalSize   = 1 + llAdd + lastRunSize;
+        if (limit == fillOutput) oend += LASTLITERALS; /* restore correct value */
         if (limit && (op + totalSize > oend)) {
-            if (limit == limitedOutput) return 0;  /* not enough space in @dst */
+            if (limit == limitedOutput) return 0; /* not enough space in @dst */
             /* adapt lastRunSize to fill 'dest' */
-            lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
-            llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
+            lastRunSize = (size_t)(oend - op) - 1 /*token*/;
+            llAdd       = (lastRunSize + 256 - RUN_MASK) / 256;
             lastRunSize -= llAdd;
         }
         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
-        ip = anchor + lastRunSize;  /* can be != iend if limit==fillOutput */
+        ip = anchor + lastRunSize; /* can be != iend if limit==fillOutput */
 
         if (lastRunSize >= RUN_MASK) {
             size_t accumulator = lastRunSize - RUN_MASK;
-            *op++ = (RUN_MASK << ML_BITS);
-            for(; accumulator >= 255 ; accumulator -= 255)
+            *op++              = (RUN_MASK << ML_BITS);
+            for (; accumulator >= 255; accumulator -= 255)
                 *op++ = 255;
-            *op++ = (BYTE) accumulator;
+            *op++ = (BYTE)accumulator;
         } else {
             *op++ = (BYTE)(lastRunSize << ML_BITS);
         }
@@ -777,54 +818,53 @@ _lz4mid_last_literals:
 _lz4mid_dest_overflow:
     if (limit == fillOutput) {
         /* Assumption : @ip, @anchor, @optr and @matchLength must be set correctly */
-        size_t const ll = (size_t)(ip - anchor);
-        size_t const ll_addbytes = (ll + 240) / 255;
-        size_t const ll_totalCost = 1 + ll_addbytes + ll;
-        BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
-        DEBUGLOG(6, "Last sequence is overflowing : %u literals, %u remaining space",
-                (unsigned)ll, (unsigned)(oend-op));
+        const size_t ll           = (size_t)(ip - anchor);
+        const size_t ll_addbytes  = (ll + 240) / 255;
+        const size_t ll_totalCost = 1 + ll_addbytes + ll;
+        BYTE* const  maxLitPos    = oend - 3; /* 2 for offset, 1 for token */
+        DEBUGLOG(6, "Last sequence is overflowing : %u literals, %u remaining space", (unsigned)ll,
+                 (unsigned)(oend - op));
         if (op + ll_totalCost <= maxLitPos) {
             /* ll validated; now adjust match length */
-            size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
-            size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
+            const size_t bytesLeftForMl = (size_t)(maxLitPos - (op + ll_totalCost));
+            const size_t maxMlSize      = MINMATCH + (ML_MASK - 1) + (bytesLeftForMl * 255);
             assert(maxMlSize < INT_MAX);
-            if ((size_t)matchLength > maxMlSize) matchLength= (unsigned)maxMlSize;
+            if ((size_t)matchLength > maxMlSize) matchLength = (unsigned)maxMlSize;
             if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + matchLength >= MFLIMIT) {
-            DEBUGLOG(6, "Let's encode a last sequence (ll=%u, ml=%u)", (unsigned)ll, matchLength);
-                LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                        (int)matchLength, (int)matchDistance,
-                        notLimited, oend);
-        }   }
-        DEBUGLOG(6, "Let's finish with a run of literals (%u bytes left)", (unsigned)(oend-op));
+                DEBUGLOG(6, "Let's encode a last sequence (ll=%u, ml=%u)", (unsigned)ll, matchLength);
+                LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), (int)matchLength, (int)matchDistance,
+                                     notLimited, oend);
+            }
+        }
+        DEBUGLOG(6, "Let's finish with a run of literals (%u bytes left)", (unsigned)(oend - op));
         goto _lz4mid_last_literals;
     }
     /* compression failed */
     return 0;
 }
 
-
 /**************************************
 *  HC Compression - Search
 **************************************/
 
 /* Update chains up to ip (excluded) */
-LZ4_FORCE_INLINE void LZ4HC_Insert (LZ4HC_CCtx_internal* hc4, const BYTE* ip)
+LZ4_FORCE_INLINE void LZ4HC_Insert(LZ4HC_CCtx_internal* hc4, const BYTE* ip)
 {
-    U16* const chainTable = hc4->chainTable;
-    U32* const hashTable  = hc4->hashTable;
-    const BYTE* const prefixPtr = hc4->prefixStart;
-    U32 const prefixIdx = hc4->dictLimit;
-    U32 const target = (U32)(ip - prefixPtr) + prefixIdx;
-    U32 idx = hc4->nextToUpdate;
+    U16* const        chainTable = hc4->chainTable;
+    U32* const        hashTable  = hc4->hashTable;
+    const BYTE* const prefixPtr  = hc4->prefixStart;
+    U32 const         prefixIdx  = hc4->dictLimit;
+    U32 const         target     = (U32)(ip - prefixPtr) + prefixIdx;
+    U32               idx        = hc4->nextToUpdate;
     assert(ip >= prefixPtr);
     assert(target >= prefixIdx);
 
     while (idx < target) {
-        U32 const h = LZ4HC_hashPtr(prefixPtr+idx-prefixIdx);
-        size_t delta = idx - hashTable[h];
-        if (delta>LZ4_DISTANCE_MAX) delta = LZ4_DISTANCE_MAX;
+        U32 const h     = LZ4HC_hashPtr(prefixPtr + idx - prefixIdx);
+        size_t    delta = idx - hashTable[h];
+        if (delta > LZ4_DISTANCE_MAX) delta = LZ4_DISTANCE_MAX;
         DELTANEXTU16(chainTable, idx) = (U16)delta;
-        hashTable[h] = idx;
+        hashTable[h]                  = idx;
         idx++;
     }
 
@@ -832,47 +872,52 @@ LZ4_FORCE_INLINE void LZ4HC_Insert (LZ4HC_CCtx_internal* hc4, const BYTE* ip)
 }
 
 #if defined(_MSC_VER)
-#  define LZ4HC_rotl32(x,r) _rotl(x,r)
+#  define LZ4HC_rotl32(x, r) _rotl(x, r)
 #else
-#  define LZ4HC_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#  define LZ4HC_rotl32(x, r) ((x << r) | (x >> (32 - r)))
 #endif
 
-
-static U32 LZ4HC_rotatePattern(size_t const rotate, U32 const pattern)
+static U32 LZ4HC_rotatePattern(const size_t rotate, U32 const pattern)
 {
-    size_t const bitsToRotate = (rotate & (sizeof(pattern) - 1)) << 3;
+    const size_t bitsToRotate = (rotate & (sizeof(pattern) - 1)) << 3;
     if (bitsToRotate == 0) return pattern;
     return LZ4HC_rotl32(pattern, (int)bitsToRotate);
 }
 
 /* LZ4HC_countPattern() :
  * pattern32 must be a sample of repetitive pattern of length 1, 2 or 4 (but not 3!) */
-static unsigned
-LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 const pattern32)
+static unsigned LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 const pattern32)
 {
-    const BYTE* const iStart = ip;
-    reg_t const pattern = (sizeof(pattern)==8) ?
-        (reg_t)pattern32 + (((reg_t)pattern32) << (sizeof(pattern)*4)) : pattern32;
+    const BYTE* const iStart  = ip;
+    const reg_t       pattern = (sizeof(pattern) == 8)
+                                    ? (reg_t)pattern32 + (((reg_t)pattern32) << (sizeof(pattern) * 4))
+                                    : pattern32;
 
-    while (likely(ip < iEnd-(sizeof(pattern)-1))) {
-        reg_t const diff = LZ4_read_ARCH(ip) ^ pattern;
-        if (!diff) { ip+=sizeof(pattern); continue; }
+    while (likely(ip < iEnd - (sizeof(pattern) - 1))) {
+        const reg_t diff = LZ4_read_ARCH(ip) ^ pattern;
+        if (!diff) {
+            ip += sizeof(pattern);
+            continue;
+        }
         ip += LZ4_NbCommonBytes(diff);
         return (unsigned)(ip - iStart);
     }
 
     if (LZ4_isLittleEndian()) {
         reg_t patternByte = pattern;
-        while ((ip<iEnd) && (*ip == (BYTE)patternByte)) {
-            ip++; patternByte >>= 8;
+        while ((ip < iEnd) && (*ip == (BYTE)patternByte)) {
+            ip++;
+            patternByte >>= 8;
         }
-    } else {  /* big endian */
-        U32 bitOffset = (sizeof(pattern)*8) - 8;
+    } else { /* big endian */
+        U32 bitOffset = (sizeof(pattern) * 8) - 8;
         while (ip < iEnd) {
             BYTE const byte = (BYTE)(pattern >> bitOffset);
             if (*ip != byte) break;
-            ip ++; bitOffset -= 8;
-    }   }
+            ip++;
+            bitOffset -= 8;
+        }
+    }
 
     return (unsigned)(ip - iStart);
 }
@@ -880,20 +925,22 @@ LZ4HC_countPattern(const BYTE* ip, const BYTE* const iEnd, U32 const pattern32)
 /* LZ4HC_reverseCountPattern() :
  * pattern must be a sample of repetitive pattern of length 1, 2 or 4 (but not 3!)
  * read using natural platform endianness */
-static unsigned
-LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
+static unsigned LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
 {
     const BYTE* const iStart = ip;
 
-    while (likely(ip >= iLow+4)) {
-        if (LZ4_read32(ip-4) != pattern) break;
+    while (likely(ip >= iLow + 4)) {
+        if (LZ4_read32(ip - 4) != pattern) break;
         ip -= 4;
     }
-    {   const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianness */
-        while (likely(ip>iLow)) {
+    {
+        const BYTE* bytePtr = (const BYTE*)(&pattern) + 3; /* works for any endianness */
+        while (likely(ip > iLow)) {
             if (ip[-1] != *bytePtr) break;
-            ip--; bytePtr--;
-    }   }
+            ip--;
+            bytePtr--;
+        }
+    }
     return (unsigned)(iStart - ip);
 }
 
@@ -904,251 +951,287 @@ LZ4HC_reverseCountPattern(const BYTE* ip, const BYTE* const iLow, U32 pattern)
  */
 static int LZ4HC_protectDictEnd(U32 const dictLimit, U32 const matchIndex)
 {
-    return ((U32)((dictLimit - 1) - matchIndex) >= 3);
+    return (U32)((dictLimit - 1) - matchIndex) >= 3;
 }
 
 typedef enum { rep_untested, rep_not, rep_confirmed } repeat_state_e;
-typedef enum { favorCompressionRatio=0, favorDecompressionSpeed } HCfavor_e;
 
+typedef enum { favorCompressionRatio = 0, favorDecompressionSpeed } HCfavor_e;
 
-LZ4_FORCE_INLINE LZ4HC_match_t
-LZ4HC_InsertAndGetWiderMatch (
-        LZ4HC_CCtx_internal* const hc4,
-        const BYTE* const ip,
-        const BYTE* const iLowLimit, const BYTE* const iHighLimit,
-        int longest,
-        const int maxNbAttempts,
-        const int patternAnalysis, const int chainSwap,
-        const dictCtx_directive dict,
-        const HCfavor_e favorDecSpeed)
+LZ4_FORCE_INLINE LZ4HC_match_t LZ4HC_InsertAndGetWiderMatch(LZ4HC_CCtx_internal* const hc4,
+                                                            const BYTE* const          ip,
+                                                            const BYTE* const          iLowLimit,
+                                                            const BYTE* const          iHighLimit,
+                                                            int                        longest,
+                                                            const int                  maxNbAttempts,
+                                                            const int                  patternAnalysis,
+                                                            const int                  chainSwap,
+                                                            const dictCtx_directive    dict,
+                                                            const HCfavor_e            favorDecSpeed)
 {
-    U16* const chainTable = hc4->chainTable;
-    U32* const hashTable = hc4->hashTable;
-    const LZ4HC_CCtx_internal* const dictCtx = hc4->dictCtx;
-    const BYTE* const prefixPtr = hc4->prefixStart;
-    const U32 prefixIdx = hc4->dictLimit;
-    const U32 ipIndex = (U32)(ip - prefixPtr) + prefixIdx;
-    const int withinStartDistance = (hc4->lowLimit + (LZ4_DISTANCE_MAX + 1) > ipIndex);
-    const U32 lowestMatchIndex = (withinStartDistance) ? hc4->lowLimit : ipIndex - LZ4_DISTANCE_MAX;
-    const BYTE* const dictStart = hc4->dictStart;
-    const U32 dictIdx = hc4->lowLimit;
-    const BYTE* const dictEnd = dictStart + prefixIdx - dictIdx;
-    int const lookBackLength = (int)(ip-iLowLimit);
-    int nbAttempts = maxNbAttempts;
-    U32 matchChainPos = 0;
-    U32 const pattern = LZ4_read32(ip);
-    U32 matchIndex;
-    repeat_state_e repeat = rep_untested;
-    size_t srcPatternLength = 0;
-    int offset = 0, sBack = 0;
+    U16* const                       chainTable          = hc4->chainTable;
+    U32* const                       hashTable           = hc4->hashTable;
+    const LZ4HC_CCtx_internal* const dictCtx             = hc4->dictCtx;
+    const BYTE* const                prefixPtr           = hc4->prefixStart;
+    const U32                        prefixIdx           = hc4->dictLimit;
+    const U32                        ipIndex             = (U32)(ip - prefixPtr) + prefixIdx;
+    const int                        withinStartDistance = (hc4->lowLimit + (LZ4_DISTANCE_MAX + 1) > ipIndex);
+    const U32         lowestMatchIndex = (withinStartDistance) ? hc4->lowLimit : ipIndex - LZ4_DISTANCE_MAX;
+    const BYTE* const dictStart        = hc4->dictStart;
+    const U32         dictIdx          = hc4->lowLimit;
+    const BYTE* const dictEnd          = dictStart + prefixIdx - dictIdx;
+    const int         lookBackLength   = (int)(ip - iLowLimit);
+    int               nbAttempts       = maxNbAttempts;
+    U32               matchChainPos    = 0;
+    U32 const         pattern          = LZ4_read32(ip);
+    U32               matchIndex;
+    repeat_state_e    repeat           = rep_untested;
+    size_t            srcPatternLength = 0;
+    int               offset = 0, sBack = 0;
 
     DEBUGLOG(7, "LZ4HC_InsertAndGetWiderMatch");
     /* First Match */
-    LZ4HC_Insert(hc4, ip);  /* insert all prior positions up to ip (excluded) */
+    LZ4HC_Insert(hc4, ip); /* insert all prior positions up to ip (excluded) */
     matchIndex = hashTable[LZ4HC_hashPtr(ip)];
-    DEBUGLOG(7, "First candidate match for pos %u found at index %u / %u (lowestMatchIndex)",
-                ipIndex, matchIndex, lowestMatchIndex);
+    DEBUGLOG(7, "First candidate match for pos %u found at index %u / %u (lowestMatchIndex)", ipIndex,
+             matchIndex, lowestMatchIndex);
 
-    while ((matchIndex>=lowestMatchIndex) && (nbAttempts>0)) {
-        int matchLength=0;
+    while ((matchIndex >= lowestMatchIndex) && (nbAttempts > 0)) {
+        int matchLength = 0;
         nbAttempts--;
         assert(matchIndex < ipIndex);
         if (favorDecSpeed && (ipIndex - matchIndex < 8)) {
             /* do nothing:
              * favorDecSpeed intentionally skips matches with offset < 8 */
-        } else if (matchIndex >= prefixIdx) {   /* within current Prefix */
+        } else if (matchIndex >= prefixIdx) { /* within current Prefix */
             const BYTE* const matchPtr = prefixPtr + (matchIndex - prefixIdx);
             assert(matchPtr < ip);
             assert(longest >= 1);
             if (LZ4_read16(iLowLimit + longest - 1) == LZ4_read16(matchPtr - lookBackLength + longest - 1)) {
                 if (LZ4_read32(matchPtr) == pattern) {
-                    int const back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, prefixPtr) : 0;
-                    matchLength = MINMATCH + (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, iHighLimit);
+                    const int back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, prefixPtr) : 0;
+                    matchLength = MINMATCH + (int)LZ4_count(ip + MINMATCH, matchPtr + MINMATCH, iHighLimit);
                     matchLength -= back;
                     if (matchLength > longest) {
                         longest = matchLength;
-                        offset = (int)(ipIndex - matchIndex);
-                        sBack = back;
-                        DEBUGLOG(7, "Found match of len=%i within prefix, offset=%i, back=%i", longest, offset, -back);
+                        offset  = (int)(ipIndex - matchIndex);
+                        sBack   = back;
+                        DEBUGLOG(7, "Found match of len=%i within prefix, offset=%i, back=%i", longest,
+                                 offset, -back);
                         HEX_CMP(7, ip + back, ip + back - offset, (size_t)matchLength);
-            }   }   }
-        } else {   /* lowestMatchIndex <= matchIndex < dictLimit : within Ext Dict */
+                    }
+                }
+            }
+        } else { /* lowestMatchIndex <= matchIndex < dictLimit : within Ext Dict */
             const BYTE* const matchPtr = dictStart + (matchIndex - dictIdx);
             assert(matchIndex >= dictIdx);
-            if ( likely(matchIndex <= prefixIdx - 4)
-              && (LZ4_read32(matchPtr) == pattern) ) {
-                int back = 0;
+            if (likely(matchIndex <= prefixIdx - 4) && (LZ4_read32(matchPtr) == pattern)) {
+                int         back   = 0;
                 const BYTE* vLimit = ip + (prefixIdx - matchIndex);
                 if (vLimit > iHighLimit) vLimit = iHighLimit;
-                matchLength = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
-                if ((ip+matchLength == vLimit) && (vLimit < iHighLimit))
-                    matchLength += LZ4_count(ip+matchLength, prefixPtr, iHighLimit);
+                matchLength = (int)LZ4_count(ip + MINMATCH, matchPtr + MINMATCH, vLimit) + MINMATCH;
+                if ((ip + matchLength == vLimit) && (vLimit < iHighLimit))
+                    matchLength += LZ4_count(ip + matchLength, prefixPtr, iHighLimit);
                 back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictStart) : 0;
                 matchLength -= back;
                 if (matchLength > longest) {
                     longest = matchLength;
-                    offset = (int)(ipIndex - matchIndex);
-                    sBack = back;
-                    DEBUGLOG(7, "Found match of len=%i within dict, offset=%i, back=%i", longest, offset, -back);
+                    offset  = (int)(ipIndex - matchIndex);
+                    sBack   = back;
+                    DEBUGLOG(7, "Found match of len=%i within dict, offset=%i, back=%i", longest, offset,
+                             -back);
                     HEX_CMP(7, ip + back, matchPtr + back, (size_t)matchLength);
-        }   }   }
+                }
+            }
+        }
 
-        if (chainSwap && matchLength==longest) {   /* better match => select a better chain */
-            assert(lookBackLength==0);   /* search forward only */
+        if (chainSwap && matchLength == longest) { /* better match => select a better chain */
+            assert(lookBackLength == 0); /* search forward only */
             if (matchIndex + (U32)longest <= ipIndex) {
-                int const kTrigger = 4;
-                U32 distanceToNextMatch = 1;
-                int const end = longest - MINMATCH + 1;
-                int step = 1;
-                int accel = 1 << kTrigger;
-                int pos;
+                const int kTrigger            = 4;
+                U32       distanceToNextMatch = 1;
+                const int end                 = longest - MINMATCH + 1;
+                int       step                = 1;
+                int       accel               = 1 << kTrigger;
+                int       pos;
                 for (pos = 0; pos < end; pos += step) {
                     U32 const candidateDist = DELTANEXTU16(chainTable, matchIndex + (U32)pos);
-                    step = (accel++ >> kTrigger);
+                    step                    = (accel++ >> kTrigger);
                     if (candidateDist > distanceToNextMatch) {
                         distanceToNextMatch = candidateDist;
-                        matchChainPos = (U32)pos;
-                        accel = 1 << kTrigger;
-                }   }
+                        matchChainPos       = (U32)pos;
+                        accel               = 1 << kTrigger;
+                    }
+                }
                 if (distanceToNextMatch > 1) {
-                    if (distanceToNextMatch > matchIndex) break;   /* avoid overflow */
+                    if (distanceToNextMatch > matchIndex) break; /* avoid overflow */
                     matchIndex -= distanceToNextMatch;
                     continue;
-        }   }   }
+                }
+            }
+        }
 
-        {   U32 const distNextMatch = DELTANEXTU16(chainTable, matchIndex);
-            if (patternAnalysis && distNextMatch==1 && matchChainPos==0) {
-                U32 const matchCandidateIdx = matchIndex-1;
+        {
+            U32 const distNextMatch = DELTANEXTU16(chainTable, matchIndex);
+            if (patternAnalysis && distNextMatch == 1 && matchChainPos == 0) {
+                U32 const matchCandidateIdx = matchIndex - 1;
                 /* may be a repeated pattern */
                 if (repeat == rep_untested) {
-                    if ( ((pattern & 0xFFFF) == (pattern >> 16))
-                      &  ((pattern & 0xFF)   == (pattern >> 24)) ) {
+                    if (((pattern & 0xFFFF) == (pattern >> 16)) & ((pattern & 0xFF) == (pattern >> 24))) {
                         DEBUGLOG(7, "Repeat pattern detected, char %02X", pattern >> 24);
-                        repeat = rep_confirmed;
-                        srcPatternLength = LZ4HC_countPattern(ip+sizeof(pattern), iHighLimit, pattern) + sizeof(pattern);
+                        repeat           = rep_confirmed;
+                        srcPatternLength = LZ4HC_countPattern(ip + sizeof(pattern), iHighLimit, pattern) +
+                                           sizeof(pattern);
                     } else {
                         repeat = rep_not;
-                }   }
-                if ( (repeat == rep_confirmed) && (matchCandidateIdx >= lowestMatchIndex)
-                  && LZ4HC_protectDictEnd(prefixIdx, matchCandidateIdx) ) {
-                    const int extDict = matchCandidateIdx < prefixIdx;
-                    const BYTE* const matchPtr = extDict ? dictStart + (matchCandidateIdx - dictIdx) : prefixPtr + (matchCandidateIdx - prefixIdx);
-                    if (LZ4_read32(matchPtr) == pattern) {  /* good candidate */
-                        const BYTE* const iLimit = extDict ? dictEnd : iHighLimit;
-                        size_t forwardPatternLength = LZ4HC_countPattern(matchPtr+sizeof(pattern), iLimit, pattern) + sizeof(pattern);
+                    }
+                }
+                if ((repeat == rep_confirmed) && (matchCandidateIdx >= lowestMatchIndex) &&
+                    LZ4HC_protectDictEnd(prefixIdx, matchCandidateIdx)) {
+                    const int         extDict  = matchCandidateIdx < prefixIdx;
+                    const BYTE* const matchPtr = extDict ? dictStart + (matchCandidateIdx - dictIdx)
+                                                         : prefixPtr + (matchCandidateIdx - prefixIdx);
+                    if (LZ4_read32(matchPtr) == pattern) { /* good candidate */
+                        const BYTE* const iLimit    = extDict ? dictEnd : iHighLimit;
+                        size_t forwardPatternLength = LZ4HC_countPattern(matchPtr + sizeof(pattern), iLimit,
+                                                                         pattern) +
+                                                      sizeof(pattern);
                         if (extDict && matchPtr + forwardPatternLength == iLimit) {
                             U32 const rotatedPattern = LZ4HC_rotatePattern(forwardPatternLength, pattern);
                             forwardPatternLength += LZ4HC_countPattern(prefixPtr, iHighLimit, rotatedPattern);
                         }
-                        {   const BYTE* const lowestMatchPtr = extDict ? dictStart : prefixPtr;
+                        {
+                            const BYTE* const lowestMatchPtr = extDict ? dictStart : prefixPtr;
                             size_t backLength = LZ4HC_reverseCountPattern(matchPtr, lowestMatchPtr, pattern);
                             size_t currentSegmentLength;
-                            if (!extDict
-                              && matchPtr - backLength == prefixPtr
-                              && dictIdx < prefixIdx) {
-                                U32 const rotatedPattern = LZ4HC_rotatePattern((U32)(-(int)backLength), pattern);
+                            if (!extDict && matchPtr - backLength == prefixPtr && dictIdx < prefixIdx) {
+                                U32 const rotatedPattern = LZ4HC_rotatePattern((U32)(-(int)backLength),
+                                                                               pattern);
                                 backLength += LZ4HC_reverseCountPattern(dictEnd, dictStart, rotatedPattern);
                             }
                             /* Limit backLength not go further than lowestMatchIndex */
-                            backLength = matchCandidateIdx - MAX(matchCandidateIdx - (U32)backLength, lowestMatchIndex);
+                            backLength = matchCandidateIdx -
+                                         MAX(matchCandidateIdx - (U32)backLength, lowestMatchIndex);
                             assert(matchCandidateIdx - backLength >= lowestMatchIndex);
                             currentSegmentLength = backLength + forwardPatternLength;
                             /* Adjust to end of pattern if the source pattern fits, otherwise the beginning of the pattern */
-                            if ( (currentSegmentLength >= srcPatternLength)   /* current pattern segment large enough to contain full srcPatternLength */
-                              && (forwardPatternLength <= srcPatternLength) ) { /* haven't reached this position yet */
-                                U32 const newMatchIndex = matchCandidateIdx + (U32)forwardPatternLength - (U32)srcPatternLength;  /* best position, full pattern, might be followed by more match */
+                            if ((currentSegmentLength >=
+                                 srcPatternLength) /* current pattern segment large enough to contain full srcPatternLength */
+                                && (forwardPatternLength <=
+                                    srcPatternLength)) { /* haven't reached this position yet */
+                                U32 const newMatchIndex = matchCandidateIdx + (U32)forwardPatternLength -
+                                                          (U32)srcPatternLength; /* best position, full pattern, might be followed by more match */
                                 if (LZ4HC_protectDictEnd(prefixIdx, newMatchIndex))
                                     matchIndex = newMatchIndex;
                                 else {
                                     /* Can only happen if started in the prefix */
-                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx && !extDict);
+                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx &&
+                                           !extDict);
                                     matchIndex = prefixIdx;
                                 }
                             } else {
-                                U32 const newMatchIndex = matchCandidateIdx - (U32)backLength;   /* farthest position in current segment, will find a match of length currentSegmentLength + maybe some back */
+                                U32 const newMatchIndex = matchCandidateIdx -
+                                                          (U32)backLength; /* farthest position in current segment, will find a match of length currentSegmentLength + maybe some back */
                                 if (!LZ4HC_protectDictEnd(prefixIdx, newMatchIndex)) {
-                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx && !extDict);
+                                    assert(newMatchIndex >= prefixIdx - 3 && newMatchIndex < prefixIdx &&
+                                           !extDict);
                                     matchIndex = prefixIdx;
                                 } else {
                                     matchIndex = newMatchIndex;
-                                    if (lookBackLength==0) {  /* no back possible */
-                                        size_t const maxML = MIN(currentSegmentLength, srcPatternLength);
+                                    if (lookBackLength == 0) { /* no back possible */
+                                        const size_t maxML = MIN(currentSegmentLength, srcPatternLength);
                                         if ((size_t)longest < maxML) {
                                             assert(prefixPtr - prefixIdx + matchIndex != ip);
-                                            if ((size_t)(ip - prefixPtr) + prefixIdx - matchIndex > LZ4_DISTANCE_MAX) break;
+                                            if ((size_t)(ip - prefixPtr) + prefixIdx - matchIndex >
+                                                LZ4_DISTANCE_MAX)
+                                                break;
                                             assert(maxML < 2 GB);
                                             longest = (int)maxML;
-                                            offset = (int)(ipIndex - matchIndex);
+                                            offset  = (int)(ipIndex - matchIndex);
                                             assert(sBack == 0);
-                                            DEBUGLOG(7, "Found repeat pattern match of len=%i, offset=%i", longest, offset);
+                                            DEBUGLOG(7, "Found repeat pattern match of len=%i, offset=%i",
+                                                     longest, offset);
                                         }
-                                        {   U32 const distToNextPattern = DELTANEXTU16(chainTable, matchIndex);
-                                            if (distToNextPattern > matchIndex) break;  /* avoid overflow */
+                                        {
+                                            U32 const distToNextPattern = DELTANEXTU16(chainTable, matchIndex);
+                                            if (distToNextPattern > matchIndex) break; /* avoid overflow */
                                             matchIndex -= distToNextPattern;
-                        }   }   }   }   }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         continue;
-                }   }
-        }   }   /* PA optimization */
+                    }
+                }
+            }
+        } /* PA optimization */
 
         /* follow current chain */
         matchIndex -= DELTANEXTU16(chainTable, matchIndex + matchChainPos);
 
-    }  /* while ((matchIndex>=lowestMatchIndex) && (nbAttempts)) */
+    } /* while ((matchIndex>=lowestMatchIndex) && (nbAttempts)) */
 
-    if ( dict == usingDictCtxHc
-      && nbAttempts > 0
-      && withinStartDistance) {
-        size_t const dictEndOffset = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
-        U32 dictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
+    if (dict == usingDictCtxHc && nbAttempts > 0 && withinStartDistance) {
+        const size_t dictEndOffset  = (size_t)(dictCtx->end - dictCtx->prefixStart) + dictCtx->dictLimit;
+        U32          dictMatchIndex = dictCtx->hashTable[LZ4HC_hashPtr(ip)];
         assert(dictEndOffset <= 1 GB);
         matchIndex = dictMatchIndex + lowestMatchIndex - (U32)dictEndOffset;
-        if (dictMatchIndex>0) DEBUGLOG(7, "dictEndOffset = %zu, dictMatchIndex = %u => relative matchIndex = %i", dictEndOffset, dictMatchIndex, (int)dictMatchIndex - (int)dictEndOffset);
+        if (dictMatchIndex > 0)
+            DEBUGLOG(7, "dictEndOffset = %zu, dictMatchIndex = %u => relative matchIndex = %i", dictEndOffset,
+                     dictMatchIndex, (int)dictMatchIndex - (int)dictEndOffset);
         while (ipIndex - matchIndex <= LZ4_DISTANCE_MAX && nbAttempts--) {
             const BYTE* const matchPtr = dictCtx->prefixStart - dictCtx->dictLimit + dictMatchIndex;
 
             if (LZ4_read32(matchPtr) == pattern) {
-                int mlt;
-                int back = 0;
+                int         mlt;
+                int         back   = 0;
                 const BYTE* vLimit = ip + (dictEndOffset - dictMatchIndex);
                 if (vLimit > iHighLimit) vLimit = iHighLimit;
-                mlt = (int)LZ4_count(ip+MINMATCH, matchPtr+MINMATCH, vLimit) + MINMATCH;
+                mlt  = (int)LZ4_count(ip + MINMATCH, matchPtr + MINMATCH, vLimit) + MINMATCH;
                 back = lookBackLength ? LZ4HC_countBack(ip, matchPtr, iLowLimit, dictCtx->prefixStart) : 0;
                 mlt -= back;
                 if (mlt > longest) {
                     longest = mlt;
-                    offset = (int)(ipIndex - matchIndex);
-                    sBack = back;
+                    offset  = (int)(ipIndex - matchIndex);
+                    sBack   = back;
                     DEBUGLOG(7, "found match of length %i within extDictCtx", longest);
-            }   }
+                }
+            }
 
-            {   U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, dictMatchIndex);
+            {
+                U32 const nextOffset = DELTANEXTU16(dictCtx->chainTable, dictMatchIndex);
                 dictMatchIndex -= nextOffset;
                 matchIndex -= nextOffset;
-    }   }   }
+            }
+        }
+    }
 
-    {   LZ4HC_match_t md;
+    {
+        LZ4HC_match_t md;
         assert(longest >= 0);
-        md.len = longest;
-        md.off = offset;
+        md.len  = longest;
+        md.off  = offset;
         md.back = sBack;
         return md;
     }
 }
 
 LZ4_FORCE_INLINE LZ4HC_match_t
-LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index table will be updated */
-                       const BYTE* const ip, const BYTE* const iLimit,
-                       const int maxNbAttempts,
-                       const int patternAnalysis,
-                       const dictCtx_directive dict)
+LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4, /* Index table will be updated */
+                             const BYTE* const          ip,
+                             const BYTE* const          iLimit,
+                             const int                  maxNbAttempts,
+                             const int                  patternAnalysis,
+                             const dictCtx_directive    dict)
 {
     DEBUGLOG(7, "LZ4HC_InsertAndFindBestMatch");
     /* note : LZ4HC_InsertAndGetWiderMatch() is able to modify the starting position of a match (*startpos),
      * but this won't be the case here, as we define iLowLimit==ip,
      * so LZ4HC_InsertAndGetWiderMatch() won't be allowed to search past ip */
-    return LZ4HC_InsertAndGetWiderMatch(hc4, ip, ip, iLimit, MINMATCH-1, maxNbAttempts, patternAnalysis, 0 /*chainSwap*/, dict, favorCompressionRatio);
+    return LZ4HC_InsertAndGetWiderMatch(hc4, ip, ip, iLimit, MINMATCH - 1, maxNbAttempts, patternAnalysis,
+                                        0 /*chainSwap*/, dict, favorCompressionRatio);
 }
-
 
 /* preconditions:
  * - *srcSizePtr within [1, LZ4_MAX_INPUT_SIZE]
@@ -1156,34 +1239,32 @@ LZ4HC_InsertAndFindBestMatch(LZ4HC_CCtx_internal* const hc4,   /* Index table wi
  * - maxOutputSize >= 1
  * - dst is valid
  */
-LZ4_FORCE_INLINE int LZ4HC_compress_hashChain (
-    LZ4HC_CCtx_internal* const ctx,
-    const char* const src,
-    char* const dst,
-    int* srcSizePtr,
-    int const maxOutputSize,
-    int maxNbAttempts,
-    const limitedOutput_directive limit,
-    const dictCtx_directive dict
-    )
+LZ4_FORCE_INLINE int LZ4HC_compress_hashChain(LZ4HC_CCtx_internal* const    ctx,
+                                              const char* const             src,
+                                              char* const                   dst,
+                                              int*                          srcSizePtr,
+                                              const int                     maxOutputSize,
+                                              int                           maxNbAttempts,
+                                              const limitedOutput_directive limit,
+                                              const dictCtx_directive       dict)
 {
-    const int inputSize = *srcSizePtr;
-    const int patternAnalysis = (maxNbAttempts > 128);   /* levels 9+ */
+    const int inputSize       = *srcSizePtr;
+    const int patternAnalysis = (maxNbAttempts > 128); /* levels 9+ */
 
-    const BYTE* ip = (const BYTE*)src;
-    const BYTE* anchor = ip;
-    const BYTE* const iend = ip + inputSize;
-    const BYTE* const mflimit = iend - MFLIMIT;
+    const BYTE*       ip         = (const BYTE*)src;
+    const BYTE*       anchor     = ip;
+    const BYTE* const iend       = ip + inputSize;
+    const BYTE* const mflimit    = iend - MFLIMIT;
     const BYTE* const matchlimit = (iend - LASTLITERALS);
 
-    BYTE* optr = (BYTE*) dst;
-    BYTE* op = (BYTE*) dst;
+    BYTE* optr = (BYTE*)dst;
+    BYTE* op   = (BYTE*)dst;
     BYTE* oend = op + maxOutputSize;
 
-    const BYTE* start0;
-    const BYTE* start2 = NULL;
-    const BYTE* start3 = NULL;
-    LZ4HC_match_t m0, m1, m2, m3;
+    const BYTE*         start0;
+    const BYTE*         start2 = NULL;
+    const BYTE*         start3 = NULL;
+    LZ4HC_match_t       m0, m1, m2, m3;
     const LZ4HC_match_t nomatch = {0, 0, 0};
 
     /* init */
@@ -1196,45 +1277,48 @@ LZ4_FORCE_INLINE int LZ4HC_compress_hashChain (
     assert(dst != NULL);
 
     *srcSizePtr = 0;
-    if (limit == fillOutput) oend -= LASTLITERALS;                  /* Hack for support LZ4 format restriction */
-    if (inputSize < LZ4_minLength) goto _last_literals;             /* Input too small, no compression (all literals) */
+    if (limit == fillOutput) oend -= LASTLITERALS; /* Hack for support LZ4 format restriction */
+    if (inputSize < LZ4_minLength) goto _last_literals; /* Input too small, no compression (all literals) */
 
     /* Main Loop */
     while (ip <= mflimit) {
         m1 = LZ4HC_InsertAndFindBestMatch(ctx, ip, matchlimit, maxNbAttempts, patternAnalysis, dict);
-        if (m1.len<MINMATCH) { ip++; continue; }
+        if (m1.len < MINMATCH) {
+            ip++;
+            continue;
+        }
 
         /* saved, in case we would skip too much */
-        start0 = ip; m0 = m1;
+        start0 = ip;
+        m0     = m1;
 
 _Search2:
         DEBUGLOG(7, "_Search2 (currently found match of size %i)", m1.len);
-        if (ip+m1.len <= mflimit) {
+        if (ip + m1.len <= mflimit) {
             start2 = ip + m1.len - 2;
-            m2 = LZ4HC_InsertAndGetWiderMatch(ctx,
-                            start2, ip + 0, matchlimit, m1.len,
-                            maxNbAttempts, patternAnalysis, 0, dict, favorCompressionRatio);
+            m2     = LZ4HC_InsertAndGetWiderMatch(ctx, start2, ip + 0, matchlimit, m1.len, maxNbAttempts,
+                                                  patternAnalysis, 0, dict, favorCompressionRatio);
             start2 += m2.back;
         } else {
-            m2 = nomatch;  /* do not search further */
+            m2 = nomatch; /* do not search further */
         }
 
         if (m2.len <= m1.len) { /* No better match => encode ML1 immediately */
             optr = op;
-            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                    m1.len, m1.off,
-                    limit, oend) )
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, limit, oend))
                 goto _dest_overflow;
             continue;
         }
 
-        if (start0 < ip) {   /* first match was skipped at least once */
-            if (start2 < ip + m0.len) {  /* squeezing ML1 between ML0(original ML1) and ML2 */
-                ip = start0; m1 = m0;  /* restore initial Match1 */
-        }   }
+        if (start0 < ip) { /* first match was skipped at least once */
+            if (start2 < ip + m0.len) { /* squeezing ML1 between ML0(original ML1) and ML2 */
+                ip = start0;
+                m1 = m0; /* restore initial Match1 */
+            }
+        }
 
         /* Here, start0==ip */
-        if ((start2 - ip) < 3) {  /* First Match too small : removed */
+        if ((start2 - ip) < 3) { /* First Match too small : removed */
             ip = start2;
             m1 = m2;
             goto _Search2;
@@ -1245,8 +1329,7 @@ _Search3:
             int correction;
             int new_ml = m1.len;
             if (new_ml > OPTIMAL_ML) new_ml = OPTIMAL_ML;
-            if (ip+new_ml > start2 + m2.len - MINMATCH)
-                new_ml = (int)(start2 - ip) + m2.len - MINMATCH;
+            if (ip + new_ml > start2 + m2.len - MINMATCH) new_ml = (int)(start2 - ip) + m2.len - MINMATCH;
             correction = new_ml - (int)(start2 - ip);
             if (correction > 0) {
                 start2 += correction;
@@ -1256,61 +1339,55 @@ _Search3:
 
         if (start2 + m2.len <= mflimit) {
             start3 = start2 + m2.len - 3;
-            m3 = LZ4HC_InsertAndGetWiderMatch(ctx,
-                            start3, start2, matchlimit, m2.len,
-                            maxNbAttempts, patternAnalysis, 0, dict, favorCompressionRatio);
+            m3     = LZ4HC_InsertAndGetWiderMatch(ctx, start3, start2, matchlimit, m2.len, maxNbAttempts,
+                                                  patternAnalysis, 0, dict, favorCompressionRatio);
             start3 += m3.back;
         } else {
-            m3 = nomatch;  /* do not search further */
+            m3 = nomatch; /* do not search further */
         }
 
-        if (m3.len <= m2.len) {  /* No better match => encode ML1 and ML2 */
+        if (m3.len <= m2.len) { /* No better match => encode ML1 and ML2 */
             /* ip & ref are known; Now for ml */
-            if (start2 < ip+m1.len) m1.len = (int)(start2 - ip);
+            if (start2 < ip + m1.len) m1.len = (int)(start2 - ip);
             /* Now, encode 2 sequences */
             optr = op;
-            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                    m1.len, m1.off,
-                    limit, oend) )
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, limit, oend))
                 goto _dest_overflow;
-            ip = start2;
+            ip   = start2;
             optr = op;
-            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                    m2.len, m2.off,
-                    limit, oend) ) {
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m2.len, m2.off, limit, oend)) {
                 m1 = m2;
                 goto _dest_overflow;
             }
             continue;
         }
 
-        if (start3 < ip+m1.len+3) {  /* Not enough space for match 2 : remove it */
-            if (start3 >= (ip+m1.len)) {  /* can write Seq1 immediately ==> Seq2 is removed, so Seq3 becomes Seq1 */
-                if (start2 < ip+m1.len) {
-                    int correction = (int)(ip+m1.len - start2);
+        if (start3 < ip + m1.len + 3) { /* Not enough space for match 2 : remove it */
+            if (start3 >=
+                (ip + m1.len)) { /* can write Seq1 immediately ==> Seq2 is removed, so Seq3 becomes Seq1 */
+                if (start2 < ip + m1.len) {
+                    int correction = (int)(ip + m1.len - start2);
                     start2 += correction;
                     m2.len -= correction;
                     if (m2.len < MINMATCH) {
                         start2 = start3;
-                        m2 = m3;
+                        m2     = m3;
                     }
                 }
 
                 optr = op;
-                if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                        m1.len, m1.off,
-                        limit, oend) )
+                if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, limit, oend))
                     goto _dest_overflow;
-                ip  = start3;
+                ip = start3;
                 m1 = m3;
 
                 start0 = start2;
-                m0 = m2;
+                m0     = m2;
                 goto _Search2;
             }
 
             start2 = start3;
-            m2 = m3;
+            m2     = m3;
             goto _Search3;
         }
 
@@ -1319,12 +1396,11 @@ _Search3:
         * let's write the first one ML1.
         * ip & ref are known; Now decide ml.
         */
-        if (start2 < ip+m1.len) {
+        if (start2 < ip + m1.len) {
             if ((start2 - ip) < OPTIMAL_ML) {
                 int correction;
                 if (m1.len > OPTIMAL_ML) m1.len = OPTIMAL_ML;
-                if (ip + m1.len > start2 + m2.len - MINMATCH)
-                    m1.len = (int)(start2 - ip) + m2.len - MINMATCH;
+                if (ip + m1.len > start2 + m2.len - MINMATCH) m1.len = (int)(start2 - ip) + m2.len - MINMATCH;
                 correction = m1.len - (int)(start2 - ip);
                 if (correction > 0) {
                     start2 += correction;
@@ -1335,16 +1411,15 @@ _Search3:
             }
         }
         optr = op;
-        if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor),
-                m1.len, m1.off,
-                limit, oend) )
-            goto _dest_overflow;
+        if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, limit, oend)) goto _dest_overflow;
 
         /* ML2 becomes ML1 */
-        ip = start2; m1 = m2;
+        ip = start2;
+        m1 = m2;
 
         /* ML3 becomes ML2 */
-        start2 = start3; m2 = m3;
+        start2 = start3;
+        m2     = m3;
 
         /* let's find a new ML3 */
         goto _Search3;
@@ -1352,25 +1427,27 @@ _Search3:
 
 _last_literals:
     /* Encode Last Literals */
-    {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
-        size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
-        size_t const totalSize = 1 + llAdd + lastRunSize;
-        if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
+    {
+        size_t       lastRunSize = (size_t)(iend - anchor); /* literals */
+        size_t       llAdd       = (lastRunSize + 255 - RUN_MASK) / 255;
+        const size_t totalSize   = 1 + llAdd + lastRunSize;
+        if (limit == fillOutput) oend += LASTLITERALS; /* restore correct value */
         if (limit && (op + totalSize > oend)) {
             if (limit == limitedOutput) return 0;
             /* adapt lastRunSize to fill 'dest' */
-            lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
-            llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
+            lastRunSize = (size_t)(oend - op) - 1 /*token*/;
+            llAdd       = (lastRunSize + 256 - RUN_MASK) / 256;
             lastRunSize -= llAdd;
         }
         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
-        ip = anchor + lastRunSize;  /* can be != iend if limit==fillOutput */
+        ip = anchor + lastRunSize; /* can be != iend if limit==fillOutput */
 
         if (lastRunSize >= RUN_MASK) {
             size_t accumulator = lastRunSize - RUN_MASK;
-            *op++ = (RUN_MASK << ML_BITS);
-            for(; accumulator >= 255 ; accumulator -= 255) *op++ = 255;
-            *op++ = (BYTE) accumulator;
+            *op++              = (RUN_MASK << ML_BITS);
+            for (; accumulator >= 255; accumulator -= 255)
+                *op++ = 255;
+            *op++ = (BYTE)accumulator;
         } else {
             *op++ = (BYTE)(lastRunSize << ML_BITS);
         }
@@ -1379,84 +1456,87 @@ _last_literals:
     }
 
     /* End */
-    *srcSizePtr = (int) (((const char*)ip) - src);
-    return (int) (((char*)op)-dst);
+    *srcSizePtr = (int)(((const char*)ip) - src);
+    return (int)(((char*)op) - dst);
 
 _dest_overflow:
     if (limit == fillOutput) {
         /* Assumption : @ip, @anchor, @optr and @m1 must be set correctly */
-        size_t const ll = (size_t)(ip - anchor);
-        size_t const ll_addbytes = (ll + 240) / 255;
-        size_t const ll_totalCost = 1 + ll_addbytes + ll;
-        BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
+        const size_t ll           = (size_t)(ip - anchor);
+        const size_t ll_addbytes  = (ll + 240) / 255;
+        const size_t ll_totalCost = 1 + ll_addbytes + ll;
+        BYTE* const  maxLitPos    = oend - 3; /* 2 for offset, 1 for token */
         DEBUGLOG(6, "Last sequence overflowing");
-        op = optr;  /* restore correct out pointer */
+        op = optr; /* restore correct out pointer */
         if (op + ll_totalCost <= maxLitPos) {
             /* ll validated; now adjust match length */
-            size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
-            size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
-            assert(maxMlSize < INT_MAX); assert(m1.len >= 0);
+            const size_t bytesLeftForMl = (size_t)(maxLitPos - (op + ll_totalCost));
+            const size_t maxMlSize      = MINMATCH + (ML_MASK - 1) + (bytesLeftForMl * 255);
+            assert(maxMlSize < INT_MAX);
+            assert(m1.len >= 0);
             if ((size_t)m1.len > maxMlSize) m1.len = (int)maxMlSize;
             if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + m1.len >= MFLIMIT) {
                 LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), m1.len, m1.off, notLimited, oend);
-        }   }
+            }
+        }
         goto _last_literals;
     }
     /* compression failed */
     return 0;
 }
 
+static int LZ4HC_compress_optimal(LZ4HC_CCtx_internal*          ctx,
+                                  const char* const             source,
+                                  char*                         dst,
+                                  int*                          srcSizePtr,
+                                  int                           dstCapacity,
+                                  const int                     nbSearches,
+                                  size_t                        sufficient_len,
+                                  const limitedOutput_directive limit,
+                                  const int                     fullUpdate,
+                                  const dictCtx_directive       dict,
+                                  const HCfavor_e               favorDecSpeed);
 
-static int LZ4HC_compress_optimal( LZ4HC_CCtx_internal* ctx,
-    const char* const source, char* dst,
-    int* srcSizePtr, int dstCapacity,
-    int const nbSearches, size_t sufficient_len,
-    const limitedOutput_directive limit, int const fullUpdate,
-    const dictCtx_directive dict,
-    const HCfavor_e favorDecSpeed);
-
-static int
-LZ4HC_compress_generic_internal (
-            LZ4HC_CCtx_internal* const ctx,
-            const char* const src,
-            char* const dst,
-            int* const srcSizePtr,
-            int const dstCapacity,
-            int cLevel,
-            const limitedOutput_directive limit,
-            const dictCtx_directive dict
-            )
+static int LZ4HC_compress_generic_internal(LZ4HC_CCtx_internal* const    ctx,
+                                           const char* const             src,
+                                           char* const                   dst,
+                                           int* const                    srcSizePtr,
+                                           const int                     dstCapacity,
+                                           int                           cLevel,
+                                           const limitedOutput_directive limit,
+                                           const dictCtx_directive       dict)
 {
-    DEBUGLOG(5, "LZ4HC_compress_generic_internal(src=%p, srcSize=%d, dstCapacity=%d)",
-                src, *srcSizePtr, dstCapacity);
+    DEBUGLOG(5, "LZ4HC_compress_generic_internal(src=%p, srcSize=%d, dstCapacity=%d)", src, *srcSizePtr,
+             dstCapacity);
 
     /* input sanitization */
-    if ((U32)*srcSizePtr > (U32)LZ4_MAX_INPUT_SIZE) return 0;  /* Unsupported input size (too large or negative) */
-    if (dstCapacity < 1) return 0;   /* Invalid: impossible to store anything */
+    if ((U32)*srcSizePtr > (U32)LZ4_MAX_INPUT_SIZE)
+        return 0; /* Unsupported input size (too large or negative) */
+    if (dstCapacity < 1) return 0; /* Invalid: impossible to store anything */
     assert(dst); /* since dstCapacity >= 1, dst must be valid */
-    if (*srcSizePtr == 0) { *dst = 0; return 1; }
+    if (*srcSizePtr == 0) {
+        *dst = 0;
+        return 1;
+    }
     assert(src != NULL); /* since *srcSizePtr >= 1, src must be valid */
 
     ctx->end += *srcSizePtr;
-    {   cParams_t const cParam = LZ4HC_getCLevelParams(cLevel);
-        HCfavor_e const favor = ctx->favorDecSpeed ? favorDecompressionSpeed : favorCompressionRatio;
-        int result;
+    {
+        const cParams_t cParam = LZ4HC_getCLevelParams(cLevel);
+        const HCfavor_e favor  = ctx->favorDecSpeed ? favorDecompressionSpeed : favorCompressionRatio;
+        int             result;
 
         if (cParam.strat == lz4mid) {
-            result = LZ4MID_compress(ctx,
-                                src, dst, srcSizePtr, dstCapacity,
-                                limit, dict);
+            result = LZ4MID_compress(ctx, src, dst, srcSizePtr, dstCapacity, limit, dict);
         } else if (cParam.strat == lz4hc) {
-            result = LZ4HC_compress_hashChain(ctx,
-                                src, dst, srcSizePtr, dstCapacity,
-                                cParam.nbSearches, limit, dict);
+            result = LZ4HC_compress_hashChain(ctx, src, dst, srcSizePtr, dstCapacity, cParam.nbSearches,
+                                              limit, dict);
         } else {
             assert(cParam.strat == lz4opt);
-            result = LZ4HC_compress_optimal(ctx,
-                                src, dst, srcSizePtr, dstCapacity,
-                                cParam.nbSearches, cParam.targetLength, limit,
-                                cLevel >= LZ4HC_CLEVEL_MAX,   /* ultra mode */
-                                dict, favor);
+            result = LZ4HC_compress_optimal(ctx, src, dst, srcSizePtr, dstCapacity, cParam.nbSearches,
+                                            cParam.targetLength, limit,
+                                            cLevel >= LZ4HC_CLEVEL_MAX, /* ultra mode */
+                                            dict, favor);
         }
         if (result <= 0) ctx->dirty = 1;
         return result;
@@ -1465,16 +1545,13 @@ LZ4HC_compress_generic_internal (
 
 static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBlock);
 
-static int
-LZ4HC_compress_generic_noDictCtx (
-        LZ4HC_CCtx_internal* const ctx,
-        const char* const src,
-        char* const dst,
-        int* const srcSizePtr,
-        int const dstCapacity,
-        int cLevel,
-        limitedOutput_directive limit
-        )
+static int LZ4HC_compress_generic_noDictCtx(LZ4HC_CCtx_internal* const ctx,
+                                            const char* const          src,
+                                            char* const                dst,
+                                            int* const                 srcSizePtr,
+                                            const int                  dstCapacity,
+                                            int                        cLevel,
+                                            limitedOutput_directive    limit)
 {
     assert(ctx->dictCtx == NULL);
     return LZ4HC_compress_generic_internal(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit, noDictCtx);
@@ -1482,21 +1559,18 @@ LZ4HC_compress_generic_noDictCtx (
 
 static int isStateCompatible(const LZ4HC_CCtx_internal* ctx1, const LZ4HC_CCtx_internal* ctx2)
 {
-    int const isMid1 = LZ4HC_getCLevelParams(ctx1->compressionLevel).strat == lz4mid;
-    int const isMid2 = LZ4HC_getCLevelParams(ctx2->compressionLevel).strat == lz4mid;
+    const int isMid1 = LZ4HC_getCLevelParams(ctx1->compressionLevel).strat == lz4mid;
+    const int isMid2 = LZ4HC_getCLevelParams(ctx2->compressionLevel).strat == lz4mid;
     return !(isMid1 ^ isMid2);
 }
 
-static int
-LZ4HC_compress_generic_dictCtx (
-        LZ4HC_CCtx_internal* const ctx,
-        const char* const src,
-        char* const dst,
-        int* const srcSizePtr,
-        int const dstCapacity,
-        int cLevel,
-        limitedOutput_directive limit
-        )
+static int LZ4HC_compress_generic_dictCtx(LZ4HC_CCtx_internal* const ctx,
+                                          const char* const          src,
+                                          char* const                dst,
+                                          int* const                 srcSizePtr,
+                                          const int                  dstCapacity,
+                                          int                        cLevel,
+                                          limitedOutput_directive    limit)
 {
     const size_t position = (size_t)(ctx->end - ctx->prefixStart) + (ctx->dictLimit - ctx->lowLimit);
     assert(ctx->dictCtx != NULL);
@@ -1505,24 +1579,22 @@ LZ4HC_compress_generic_dictCtx (
         return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
     } else if (position == 0 && *srcSizePtr > 4 KB && isStateCompatible(ctx, ctx->dictCtx)) {
         LZ4_memcpy(ctx, ctx->dictCtx, sizeof(LZ4HC_CCtx_internal));
-        LZ4HC_setExternalDict(ctx, (const BYTE *)src);
+        LZ4HC_setExternalDict(ctx, (const BYTE*)src);
         ctx->compressionLevel = (short)cLevel;
         return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
     } else {
-        return LZ4HC_compress_generic_internal(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit, usingDictCtxHc);
+        return LZ4HC_compress_generic_internal(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit,
+                                               usingDictCtxHc);
     }
 }
 
-static int
-LZ4HC_compress_generic (
-        LZ4HC_CCtx_internal* const ctx,
-        const char* const src,
-        char* const dst,
-        int* const srcSizePtr,
-        int const dstCapacity,
-        int cLevel,
-        limitedOutput_directive limit
-        )
+static int LZ4HC_compress_generic(LZ4HC_CCtx_internal* const ctx,
+                                  const char* const          src,
+                                  char* const                dst,
+                                  int* const                 srcSizePtr,
+                                  const int                  dstCapacity,
+                                  int                        cLevel,
+                                  limitedOutput_directive    limit)
 {
     if (ctx->dictCtx == NULL) {
         return LZ4HC_compress_generic_noDictCtx(ctx, src, dst, srcSizePtr, dstCapacity, cLevel, limit);
@@ -1531,13 +1603,19 @@ LZ4HC_compress_generic (
     }
 }
 
-
-int LZ4_sizeofStateHC(void) { return (int)sizeof(LZ4_streamHC_t); }
+int LZ4_sizeofStateHC(void)
+{
+    return (int)sizeof(LZ4_streamHC_t);
+}
 
 static size_t LZ4_streamHC_t_alignment(void)
 {
 #if LZ4_ALIGN_TEST
-    typedef struct { char c; LZ4_streamHC_t t; } t_a;
+    typedef struct {
+        char           c;
+        LZ4_streamHC_t t;
+    } t_a;
+
     return sizeof(t_a) - sizeof(LZ4_streamHC_t);
 #else
     return 1;  /* effectively disabled */
@@ -1546,54 +1624,67 @@ static size_t LZ4_streamHC_t_alignment(void)
 
 /* state is presumed correctly initialized,
  * in which case its size and alignment have already been validate */
-int LZ4_compress_HC_extStateHC_fastReset (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
+int LZ4_compress_HC_extStateHC_fastReset(void*       state,
+                                         const char* src,
+                                         char*       dst,
+                                         int         srcSize,
+                                         int         dstCapacity,
+                                         int         compressionLevel)
 {
     LZ4HC_CCtx_internal* const ctx = &((LZ4_streamHC_t*)state)->internal_donotuse;
     if (!LZ4_isAligned(state, LZ4_streamHC_t_alignment())) return 0;
     LZ4_resetStreamHC_fast((LZ4_streamHC_t*)state, compressionLevel);
-    LZ4HC_init_internal (ctx, (const BYTE*)src);
+    LZ4HC_init_internal(ctx, (const BYTE*)src);
     if (dstCapacity < LZ4_compressBound(srcSize))
-        return LZ4HC_compress_generic (ctx, src, dst, &srcSize, dstCapacity, compressionLevel, limitedOutput);
-    else
-        return LZ4HC_compress_generic (ctx, src, dst, &srcSize, dstCapacity, compressionLevel, notLimited);
+        return LZ4HC_compress_generic(ctx, src, dst, &srcSize, dstCapacity, compressionLevel, limitedOutput);
+    else return LZ4HC_compress_generic(ctx, src, dst, &srcSize, dstCapacity, compressionLevel, notLimited);
 }
 
-int LZ4_compress_HC_extStateHC (void* state, const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
+int LZ4_compress_HC_extStateHC(void*       state,
+                               const char* src,
+                               char*       dst,
+                               int         srcSize,
+                               int         dstCapacity,
+                               int         compressionLevel)
 {
     LZ4_streamHC_t* const ctx = LZ4_initStreamHC(state, sizeof(*ctx));
-    if (ctx==NULL) return 0;   /* init failure */
+    if (ctx == NULL) return 0; /* init failure */
     return LZ4_compress_HC_extStateHC_fastReset(state, src, dst, srcSize, dstCapacity, compressionLevel);
 }
 
 int LZ4_compress_HC(const char* src, char* dst, int srcSize, int dstCapacity, int compressionLevel)
 {
     int cSize;
-#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE == 1
     LZ4_streamHC_t* const statePtr = (LZ4_streamHC_t*)ALLOC(sizeof(LZ4_streamHC_t));
-    if (statePtr==NULL) return 0;
+    if (statePtr == NULL) return 0;
 #else
-    LZ4_streamHC_t state;
+    LZ4_streamHC_t        state;
     LZ4_streamHC_t* const statePtr = &state;
 #endif
     DEBUGLOG(5, "LZ4_compress_HC")
     cSize = LZ4_compress_HC_extStateHC(statePtr, src, dst, srcSize, dstCapacity, compressionLevel);
-#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE == 1
     FREEMEM(statePtr);
 #endif
     return cSize;
 }
 
 /* state is presumed sized correctly (>= sizeof(LZ4_streamHC_t)) */
-int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* sourceSizePtr, int targetDestSize, int cLevel)
+int LZ4_compress_HC_destSize(void*       state,
+                             const char* source,
+                             char*       dest,
+                             int*        sourceSizePtr,
+                             int         targetDestSize,
+                             int         cLevel)
 {
     LZ4_streamHC_t* const ctx = LZ4_initStreamHC(state, sizeof(*ctx));
-    if (ctx==NULL) return 0;   /* init failure */
-    LZ4HC_init_internal(&ctx->internal_donotuse, (const BYTE*) source);
+    if (ctx == NULL) return 0; /* init failure */
+    LZ4HC_init_internal(&ctx->internal_donotuse, (const BYTE*)source);
     LZ4_setCompressionLevel(ctx, cLevel);
-    return LZ4HC_compress_generic(&ctx->internal_donotuse, source, dest, sourceSizePtr, targetDestSize, cLevel, fillOutput);
+    return LZ4HC_compress_generic(&ctx->internal_donotuse, source, dest, sourceSizePtr, targetDestSize,
+                                  cLevel, fillOutput);
 }
-
-
 
 /**************************************
 *  Streaming Functions
@@ -1602,24 +1693,22 @@ int LZ4_compress_HC_destSize(void* state, const char* source, char* dest, int* s
 #if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
 LZ4_streamHC_t* LZ4_createStreamHC(void)
 {
-    LZ4_streamHC_t* const state =
-        (LZ4_streamHC_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamHC_t));
+    LZ4_streamHC_t* const state = (LZ4_streamHC_t*)ALLOC_AND_ZERO(sizeof(LZ4_streamHC_t));
     if (state == NULL) return NULL;
     LZ4_setCompressionLevel(state, LZ4HC_CLEVEL_DEFAULT);
     return state;
 }
 
-int LZ4_freeStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr)
+int LZ4_freeStreamHC(LZ4_streamHC_t* LZ4_streamHCPtr)
 {
     DEBUGLOG(4, "LZ4_freeStreamHC(%p)", LZ4_streamHCPtr);
-    if (!LZ4_streamHCPtr) return 0;  /* support free on NULL */
+    if (!LZ4_streamHCPtr) return 0; /* support free on NULL */
     FREEMEM(LZ4_streamHCPtr);
     return 0;
 }
 #endif
 
-
-LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)
+LZ4_streamHC_t* LZ4_initStreamHC(void* buffer, size_t size)
 {
     LZ4_streamHC_t* const LZ4_streamHCPtr = (LZ4_streamHC_t*)buffer;
     DEBUGLOG(4, "LZ4_initStreamHC(%p, %u)", buffer, (unsigned)size);
@@ -1628,20 +1717,22 @@ LZ4_streamHC_t* LZ4_initStreamHC (void* buffer, size_t size)
     if (size < sizeof(LZ4_streamHC_t)) return NULL;
     if (!LZ4_isAligned(buffer, LZ4_streamHC_t_alignment())) return NULL;
     /* init */
-    { LZ4HC_CCtx_internal* const hcstate = &(LZ4_streamHCPtr->internal_donotuse);
-      MEM_INIT(hcstate, 0, sizeof(*hcstate)); }
+    {
+        LZ4HC_CCtx_internal* const hcstate = &(LZ4_streamHCPtr->internal_donotuse);
+        MEM_INIT(hcstate, 0, sizeof(*hcstate));
+    }
     LZ4_setCompressionLevel(LZ4_streamHCPtr, LZ4HC_CLEVEL_DEFAULT);
     return LZ4_streamHCPtr;
 }
 
 /* just a stub */
-void LZ4_resetStreamHC (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
+void LZ4_resetStreamHC(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
     LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
     LZ4_setCompressionLevel(LZ4_streamHCPtr, compressionLevel);
 }
 
-void LZ4_resetStreamHC_fast (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
+void LZ4_resetStreamHC_fast(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLevel)
 {
     LZ4HC_CCtx_internal* const s = &LZ4_streamHCPtr->internal_donotuse;
     DEBUGLOG(5, "LZ4_resetStreamHC_fast(%p, %d)", LZ4_streamHCPtr, compressionLevel);
@@ -1651,8 +1742,8 @@ void LZ4_resetStreamHC_fast (LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLev
         assert(s->end >= s->prefixStart);
         s->dictLimit += (U32)(s->end - s->prefixStart);
         s->prefixStart = NULL;
-        s->end = NULL;
-        s->dictCtx = NULL;
+        s->end         = NULL;
+        s->dictCtx     = NULL;
     }
     LZ4_setCompressionLevel(LZ4_streamHCPtr, compressionLevel);
 }
@@ -1667,17 +1758,17 @@ void LZ4_setCompressionLevel(LZ4_streamHC_t* LZ4_streamHCPtr, int compressionLev
 
 void LZ4_favorDecompressionSpeed(LZ4_streamHC_t* LZ4_streamHCPtr, int favor)
 {
-    LZ4_streamHCPtr->internal_donotuse.favorDecSpeed = (favor!=0);
+    LZ4_streamHCPtr->internal_donotuse.favorDecSpeed = (favor != 0);
 }
 
 /* LZ4_loadDictHC() :
  * LZ4_streamHCPtr is presumed properly initialized */
-int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr,
-              const char* dictionary, int dictSize)
+int LZ4_loadDictHC(LZ4_streamHC_t* LZ4_streamHCPtr, const char* dictionary, int dictSize)
 {
     LZ4HC_CCtx_internal* const ctxPtr = &LZ4_streamHCPtr->internal_donotuse;
-    cParams_t cp;
-    DEBUGLOG(4, "LZ4_loadDictHC(ctx:%p, dict:%p, dictSize:%d, clevel=%d)", LZ4_streamHCPtr, dictionary, dictSize, ctxPtr->compressionLevel);
+    cParams_t                  cp;
+    DEBUGLOG(4, "LZ4_loadDictHC(ctx:%p, dict:%p, dictSize:%d, clevel=%d)", LZ4_streamHCPtr, dictionary,
+             dictSize, ctxPtr->compressionLevel);
     assert(dictSize >= 0);
     assert(LZ4_streamHCPtr != NULL);
     if (dictSize > 64 KB) {
@@ -1685,23 +1776,27 @@ int LZ4_loadDictHC (LZ4_streamHC_t* LZ4_streamHCPtr,
         dictSize = 64 KB;
     }
     /* need a full initialization, there are bad side-effects when using resetFast() */
-    {   int const cLevel = ctxPtr->compressionLevel;
+    {
+        const int cLevel = ctxPtr->compressionLevel;
         LZ4_initStreamHC(LZ4_streamHCPtr, sizeof(*LZ4_streamHCPtr));
         LZ4_setCompressionLevel(LZ4_streamHCPtr, cLevel);
         cp = LZ4HC_getCLevelParams(cLevel);
     }
-    LZ4HC_init_internal (ctxPtr, (const BYTE*)dictionary);
+    LZ4HC_init_internal(ctxPtr, (const BYTE*)dictionary);
     ctxPtr->end = (const BYTE*)dictionary + dictSize;
     if (cp.strat == lz4mid) {
-        LZ4MID_fillHTable (ctxPtr, dictionary, (size_t)dictSize);
+        LZ4MID_fillHTable(ctxPtr, dictionary, (size_t)dictSize);
     } else {
-        if (dictSize >= LZ4HC_HASHSIZE) LZ4HC_Insert (ctxPtr, ctxPtr->end-3);
+        if (dictSize >= LZ4HC_HASHSIZE) LZ4HC_Insert(ctxPtr, ctxPtr->end - 3);
     }
     return dictSize;
 }
 
-void LZ4_attach_HC_dictionary(LZ4_streamHC_t *working_stream, const LZ4_streamHC_t *dictionary_stream) {
-    working_stream->internal_donotuse.dictCtx = dictionary_stream != NULL ? &(dictionary_stream->internal_donotuse) : NULL;
+void LZ4_attach_HC_dictionary(LZ4_streamHC_t* working_stream, const LZ4_streamHC_t* dictionary_stream)
+{
+    working_stream->internal_donotuse.dictCtx = dictionary_stream != NULL
+                                                    ? &(dictionary_stream->internal_donotuse)
+                                                    : NULL;
 }
 
 /* compression */
@@ -1709,36 +1804,36 @@ void LZ4_attach_HC_dictionary(LZ4_streamHC_t *working_stream, const LZ4_streamHC
 static void LZ4HC_setExternalDict(LZ4HC_CCtx_internal* ctxPtr, const BYTE* newBlock)
 {
     DEBUGLOG(4, "LZ4HC_setExternalDict(%p, %p)", ctxPtr, newBlock);
-    if ( (ctxPtr->end >= ctxPtr->prefixStart + 4)
-      && (LZ4HC_getCLevelParams(ctxPtr->compressionLevel).strat != lz4mid) ) {
-        LZ4HC_Insert (ctxPtr, ctxPtr->end-3);  /* Referencing remaining dictionary content */
+    if ((ctxPtr->end >= ctxPtr->prefixStart + 4) &&
+        (LZ4HC_getCLevelParams(ctxPtr->compressionLevel).strat != lz4mid)) {
+        LZ4HC_Insert(ctxPtr, ctxPtr->end - 3); /* Referencing remaining dictionary content */
     }
 
     /* Only one memory segment for extDict, so any previous extDict is lost at this stage */
     ctxPtr->lowLimit  = ctxPtr->dictLimit;
-    ctxPtr->dictStart  = ctxPtr->prefixStart;
+    ctxPtr->dictStart = ctxPtr->prefixStart;
     ctxPtr->dictLimit += (U32)(ctxPtr->end - ctxPtr->prefixStart);
-    ctxPtr->prefixStart = newBlock;
-    ctxPtr->end  = newBlock;
-    ctxPtr->nextToUpdate = ctxPtr->dictLimit;   /* match referencing will resume from there */
+    ctxPtr->prefixStart  = newBlock;
+    ctxPtr->end          = newBlock;
+    ctxPtr->nextToUpdate = ctxPtr->dictLimit; /* match referencing will resume from there */
 
     /* cannot reference an extDict and a dictCtx at the same time */
     ctxPtr->dictCtx = NULL;
 }
 
-static int
-LZ4_compressHC_continue_generic (LZ4_streamHC_t* LZ4_streamHCPtr,
-                                 const char* src, char* dst,
-                                 int* srcSizePtr, int dstCapacity,
-                                 limitedOutput_directive limit)
+static int LZ4_compressHC_continue_generic(LZ4_streamHC_t*         LZ4_streamHCPtr,
+                                           const char*             src,
+                                           char*                   dst,
+                                           int*                    srcSizePtr,
+                                           int                     dstCapacity,
+                                           limitedOutput_directive limit)
 {
     LZ4HC_CCtx_internal* const ctxPtr = &LZ4_streamHCPtr->internal_donotuse;
-    DEBUGLOG(5, "LZ4_compressHC_continue_generic(ctx=%p, src=%p, srcSize=%d, limit=%d)",
-                LZ4_streamHCPtr, src, *srcSizePtr, limit);
+    DEBUGLOG(5, "LZ4_compressHC_continue_generic(ctx=%p, src=%p, srcSize=%d, limit=%d)", LZ4_streamHCPtr, src,
+             *srcSizePtr, limit);
     assert(ctxPtr != NULL);
     /* auto-init if forgotten */
-    if (ctxPtr->prefixStart == NULL)
-        LZ4HC_init_internal (ctxPtr, (const BYTE*) src);
+    if (ctxPtr->prefixStart == NULL) LZ4HC_init_internal(ctxPtr, (const BYTE*)src);
 
     /* Check overflow */
     if ((size_t)(ctxPtr->end - ctxPtr->prefixStart) + ctxPtr->dictLimit > 2 GB) {
@@ -1748,11 +1843,11 @@ LZ4_compressHC_continue_generic (LZ4_streamHC_t* LZ4_streamHCPtr,
     }
 
     /* Check if blocks follow each other */
-    if ((const BYTE*)src != ctxPtr->end)
-        LZ4HC_setExternalDict(ctxPtr, (const BYTE*)src);
+    if ((const BYTE*)src != ctxPtr->end) LZ4HC_setExternalDict(ctxPtr, (const BYTE*)src);
 
     /* Check overlapping input/dictionary space */
-    {   const BYTE* sourceEnd = (const BYTE*) src + *srcSizePtr;
+    {
+        const BYTE*       sourceEnd = (const BYTE*)src + *srcSizePtr;
         const BYTE* const dictBegin = ctxPtr->dictStart;
         const BYTE* const dictEnd   = ctxPtr->dictStart + (ctxPtr->dictLimit - ctxPtr->lowLimit);
         if ((sourceEnd > dictBegin) && ((const BYTE*)src < dictEnd)) {
@@ -1761,57 +1856,59 @@ LZ4_compressHC_continue_generic (LZ4_streamHC_t* LZ4_streamHCPtr,
             ctxPtr->dictStart += (U32)(sourceEnd - ctxPtr->dictStart);
             /* invalidate dictionary is it's too small */
             if (ctxPtr->dictLimit - ctxPtr->lowLimit < LZ4HC_HASHSIZE) {
-                ctxPtr->lowLimit = ctxPtr->dictLimit;
+                ctxPtr->lowLimit  = ctxPtr->dictLimit;
                 ctxPtr->dictStart = ctxPtr->prefixStart;
-    }   }   }
+            }
+        }
+    }
 
-    return LZ4HC_compress_generic (ctxPtr, src, dst, srcSizePtr, dstCapacity, ctxPtr->compressionLevel, limit);
+    return LZ4HC_compress_generic(ctxPtr, src, dst, srcSizePtr, dstCapacity, ctxPtr->compressionLevel, limit);
 }
 
-int LZ4_compress_HC_continue (LZ4_streamHC_t* LZ4_streamHCPtr, const char* src, char* dst, int srcSize, int dstCapacity)
+int LZ4_compress_HC_continue(LZ4_streamHC_t* LZ4_streamHCPtr, const char* src, char* dst, int srcSize, int dstCapacity)
 {
     DEBUGLOG(5, "LZ4_compress_HC_continue");
     if (dstCapacity < LZ4_compressBound(srcSize))
-        return LZ4_compressHC_continue_generic (LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, limitedOutput);
-    else
-        return LZ4_compressHC_continue_generic (LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, notLimited);
+        return LZ4_compressHC_continue_generic(LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, limitedOutput);
+    else return LZ4_compressHC_continue_generic(LZ4_streamHCPtr, src, dst, &srcSize, dstCapacity, notLimited);
 }
 
-int LZ4_compress_HC_continue_destSize (LZ4_streamHC_t* LZ4_streamHCPtr, const char* src, char* dst, int* srcSizePtr, int targetDestSize)
+int LZ4_compress_HC_continue_destSize(LZ4_streamHC_t* LZ4_streamHCPtr,
+                                      const char*     src,
+                                      char*           dst,
+                                      int*            srcSizePtr,
+                                      int             targetDestSize)
 {
     return LZ4_compressHC_continue_generic(LZ4_streamHCPtr, src, dst, srcSizePtr, targetDestSize, fillOutput);
 }
-
 
 /* LZ4_saveDictHC :
  * save history content
  * into a user-provided buffer
  * which is then used to continue compression
  */
-int LZ4_saveDictHC (LZ4_streamHC_t* LZ4_streamHCPtr, char* safeBuffer, int dictSize)
+int LZ4_saveDictHC(LZ4_streamHC_t* LZ4_streamHCPtr, char* safeBuffer, int dictSize)
 {
-    LZ4HC_CCtx_internal* const streamPtr = &LZ4_streamHCPtr->internal_donotuse;
-    int const prefixSize = (int)(streamPtr->end - streamPtr->prefixStart);
+    LZ4HC_CCtx_internal* const streamPtr  = &LZ4_streamHCPtr->internal_donotuse;
+    const int                  prefixSize = (int)(streamPtr->end - streamPtr->prefixStart);
     DEBUGLOG(5, "LZ4_saveDictHC(%p, %p, %d)", LZ4_streamHCPtr, safeBuffer, dictSize);
     assert(prefixSize >= 0);
     if (dictSize > 64 KB) dictSize = 64 KB;
     if (dictSize < 4) dictSize = 0;
     if (dictSize > prefixSize) dictSize = prefixSize;
     if (safeBuffer == NULL) assert(dictSize == 0); /* a NULL buffer with !0 size is invalid */
-    if (dictSize > 0)
-        LZ4_memmove(safeBuffer, streamPtr->end - dictSize, (size_t)dictSize);
-    {   U32 const endIndex = (U32)(streamPtr->end - streamPtr->prefixStart) + streamPtr->dictLimit;
-        streamPtr->end = (safeBuffer == NULL) ? NULL : (const BYTE*)safeBuffer + dictSize;
+    if (dictSize > 0) LZ4_memmove(safeBuffer, streamPtr->end - dictSize, (size_t)dictSize);
+    {
+        U32 const endIndex     = (U32)(streamPtr->end - streamPtr->prefixStart) + streamPtr->dictLimit;
+        streamPtr->end         = (safeBuffer == NULL) ? NULL : (const BYTE*)safeBuffer + dictSize;
         streamPtr->prefixStart = (const BYTE*)safeBuffer;
-        streamPtr->dictLimit = endIndex - (U32)dictSize;
-        streamPtr->lowLimit = endIndex - (U32)dictSize;
-        streamPtr->dictStart = streamPtr->prefixStart;
-        if (streamPtr->nextToUpdate < streamPtr->dictLimit)
-            streamPtr->nextToUpdate = streamPtr->dictLimit;
+        streamPtr->dictLimit   = endIndex - (U32)dictSize;
+        streamPtr->lowLimit    = endIndex - (U32)dictSize;
+        streamPtr->dictStart   = streamPtr->prefixStart;
+        if (streamPtr->nextToUpdate < streamPtr->dictLimit) streamPtr->nextToUpdate = streamPtr->dictLimit;
     }
     return dictSize;
 }
-
 
 /* ================================================
  *  LZ4 Optimal parser (levels [LZ4HC_CLEVEL_OPT_MIN - LZ4HC_CLEVEL_MAX])
@@ -1824,51 +1921,50 @@ typedef struct {
 } LZ4HC_optimal_t;
 
 /* price in bytes */
-LZ4_FORCE_INLINE int LZ4HC_literalsPrice(int const litlen)
+LZ4_FORCE_INLINE int LZ4HC_literalsPrice(const int litlen)
 {
     int price = litlen;
     assert(litlen >= 0);
-    if (litlen >= (int)RUN_MASK)
-        price += 1 + ((litlen-(int)RUN_MASK) / 255);
+    if (litlen >= (int)RUN_MASK) price += 1 + ((litlen - (int)RUN_MASK) / 255);
     return price;
 }
 
 /* requires mlen >= MINMATCH */
 LZ4_FORCE_INLINE int LZ4HC_sequencePrice(int litlen, int mlen)
 {
-    int price = 1 + 2 ; /* token + 16-bit offset */
+    int price = 1 + 2; /* token + 16-bit offset */
     assert(litlen >= 0);
     assert(mlen >= MINMATCH);
 
     price += LZ4HC_literalsPrice(litlen);
 
-    if (mlen >= (int)(ML_MASK+MINMATCH))
-        price += 1 + ((mlen-(int)(ML_MASK+MINMATCH)) / 255);
+    if (mlen >= (int)(ML_MASK + MINMATCH)) price += 1 + ((mlen - (int)(ML_MASK + MINMATCH)) / 255);
 
     return price;
 }
 
-LZ4_FORCE_INLINE LZ4HC_match_t
-LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,
-                      const BYTE* ip, const BYTE* const iHighLimit,
-                      int minLen, int nbSearches,
-                      const dictCtx_directive dict,
-                      const HCfavor_e favorDecSpeed)
+LZ4_FORCE_INLINE LZ4HC_match_t LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,
+                                                     const BYTE*                ip,
+                                                     const BYTE* const          iHighLimit,
+                                                     int                        minLen,
+                                                     int                        nbSearches,
+                                                     const dictCtx_directive    dict,
+                                                     const HCfavor_e            favorDecSpeed)
 {
-    LZ4HC_match_t const match0 = { 0 , 0, 0 };
+    const LZ4HC_match_t match0 = {0, 0, 0};
     /* note : LZ4HC_InsertAndGetWiderMatch() is able to modify the starting position of a match (*startpos),
      * but this won't be the case here, as we define iLowLimit==ip,
     ** so LZ4HC_InsertAndGetWiderMatch() won't be allowed to search past ip */
-    LZ4HC_match_t md = LZ4HC_InsertAndGetWiderMatch(ctx, ip, ip, iHighLimit, minLen, nbSearches, 1 /*patternAnalysis*/, 1 /*chainSwap*/, dict, favorDecSpeed);
+    LZ4HC_match_t md = LZ4HC_InsertAndGetWiderMatch(ctx, ip, ip, iHighLimit, minLen, nbSearches,
+                                                    1 /*patternAnalysis*/, 1 /*chainSwap*/, dict,
+                                                    favorDecSpeed);
     assert(md.back == 0);
     if (md.len <= minLen) return match0;
     if (favorDecSpeed) {
-        if ((md.len>18) & (md.len<=36)) md.len=18;   /* favor dec.speed (shortcut) */
+        if ((md.len > 18) & (md.len <= 36)) md.len = 18; /* favor dec.speed (shortcut) */
     }
     return md;
 }
-
-
 
 /* preconditions:
  * - *srcSizePtr within [1, LZ4_MAX_INPUT_SIZE]
@@ -1876,40 +1972,41 @@ LZ4HC_FindLongerMatch(LZ4HC_CCtx_internal* const ctx,
  * - maxOutputSize >= 1
  * - dst is valid
  */
-static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
-                                    const char* const source,
-                                    char* dst,
-                                    int* srcSizePtr,
-                                    int dstCapacity,
-                                    int const nbSearches,
-                                    size_t sufficient_len,
-                                    const limitedOutput_directive limit,
-                                    int const fullUpdate,
-                                    const dictCtx_directive dict,
-                                    const HCfavor_e favorDecSpeed)
+static int LZ4HC_compress_optimal(LZ4HC_CCtx_internal*          ctx,
+                                  const char* const             source,
+                                  char*                         dst,
+                                  int*                          srcSizePtr,
+                                  int                           dstCapacity,
+                                  const int                     nbSearches,
+                                  size_t                        sufficient_len,
+                                  const limitedOutput_directive limit,
+                                  const int                     fullUpdate,
+                                  const dictCtx_directive       dict,
+                                  const HCfavor_e               favorDecSpeed)
 {
     int retval = 0;
 #define TRAILING_LITERALS 3
-#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
-    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)ALLOC(sizeof(LZ4HC_optimal_t) * (LZ4_OPT_NUM + TRAILING_LITERALS));
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE == 1
+    LZ4HC_optimal_t* const opt = (LZ4HC_optimal_t*)ALLOC(sizeof(LZ4HC_optimal_t) *
+                                                         (LZ4_OPT_NUM + TRAILING_LITERALS));
 #else
-    LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS];   /* ~64 KB, which can be a bit large for some stacks... */
+    LZ4HC_optimal_t opt[LZ4_OPT_NUM + TRAILING_LITERALS]; /* ~64 KB, which can be a bit large for some stacks... */
 #endif
 
-    const BYTE* ip = (const BYTE*) source;
-    const BYTE* anchor = ip;
-    const BYTE* const iend = ip + *srcSizePtr;
-    const BYTE* const mflimit = iend - MFLIMIT;
+    const BYTE*       ip         = (const BYTE*)source;
+    const BYTE*       anchor     = ip;
+    const BYTE* const iend       = ip + *srcSizePtr;
+    const BYTE* const mflimit    = iend - MFLIMIT;
     const BYTE* const matchlimit = iend - LASTLITERALS;
-    BYTE* op = (BYTE*) dst;
-    BYTE* opSaved = (BYTE*) dst;
-    BYTE* oend = op + dstCapacity;
-    int ovml = MINMATCH;  /* overflow - last sequence */
-    int ovoff = 0;
+    BYTE*             op         = (BYTE*)dst;
+    BYTE*             opSaved    = (BYTE*)dst;
+    BYTE*             oend       = op + dstCapacity;
+    int               ovml       = MINMATCH; /* overflow - last sequence */
+    int               ovoff      = 0;
 
     /* init */
     DEBUGLOG(5, "LZ4HC_compress_optimal(dst=%p, dstCapa=%u)", dst, (unsigned)dstCapacity);
-#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE == 1
     if (opt == NULL) goto _return_label;
 #endif
 
@@ -1920,271 +2017,300 @@ static int LZ4HC_compress_optimal ( LZ4HC_CCtx_internal* ctx,
     assert(source != NULL);
 
     *srcSizePtr = 0;
-    if (limit == fillOutput) oend -= LASTLITERALS;   /* Hack for support LZ4 format restriction */
-    if (sufficient_len >= LZ4_OPT_NUM) sufficient_len = LZ4_OPT_NUM-1;
+    if (limit == fillOutput) oend -= LASTLITERALS; /* Hack for support LZ4 format restriction */
+    if (sufficient_len >= LZ4_OPT_NUM) sufficient_len = LZ4_OPT_NUM - 1;
 
     /* Main Loop */
     while (ip <= mflimit) {
-         int const llen = (int)(ip - anchor);
-         int best_mlen, best_off;
-         int cur, last_match_pos = 0;
+        const int llen = (int)(ip - anchor);
+        int       best_mlen, best_off;
+        int       cur, last_match_pos = 0;
 
-         LZ4HC_match_t const firstMatch = LZ4HC_FindLongerMatch(ctx, ip, matchlimit, MINMATCH-1, nbSearches, dict, favorDecSpeed);
-         if (firstMatch.len==0) { ip++; continue; }
+        const LZ4HC_match_t firstMatch = LZ4HC_FindLongerMatch(ctx, ip, matchlimit, MINMATCH - 1, nbSearches,
+                                                               dict, favorDecSpeed);
+        if (firstMatch.len == 0) {
+            ip++;
+            continue;
+        }
 
-         if ((size_t)firstMatch.len > sufficient_len) {
-             /* good enough solution : immediate encoding */
-             int const firstML = firstMatch.len;
-             opSaved = op;
-             if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), firstML, firstMatch.off, limit, oend) ) {  /* updates ip, op and anchor */
-                 ovml = firstML;
-                 ovoff = firstMatch.off;
-                 goto _dest_overflow;
-             }
-             continue;
-         }
+        if ((size_t)firstMatch.len > sufficient_len) {
+            /* good enough solution : immediate encoding */
+            const int firstML = firstMatch.len;
+            opSaved           = op;
+            if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), firstML, firstMatch.off, limit,
+                                     oend)) { /* updates ip, op and anchor */
+                ovml  = firstML;
+                ovoff = firstMatch.off;
+                goto _dest_overflow;
+            }
+            continue;
+        }
 
-         /* set prices for first positions (literals) */
-         {   int rPos;
-             for (rPos = 0 ; rPos < MINMATCH ; rPos++) {
-                 int const cost = LZ4HC_literalsPrice(llen + rPos);
-                 opt[rPos].mlen = 1;
-                 opt[rPos].off = 0;
-                 opt[rPos].litlen = llen + rPos;
-                 opt[rPos].price = cost;
-                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
-                             rPos, cost, opt[rPos].litlen);
-         }   }
-         /* set prices using initial match */
-         {   int const matchML = firstMatch.len;   /* necessarily < sufficient_len < LZ4_OPT_NUM */
-             int const offset = firstMatch.off;
-             int mlen;
-             assert(matchML < LZ4_OPT_NUM);
-             for (mlen = MINMATCH ; mlen <= matchML ; mlen++) {
-                 int const cost = LZ4HC_sequencePrice(llen, mlen);
-                 opt[mlen].mlen = mlen;
-                 opt[mlen].off = offset;
-                 opt[mlen].litlen = llen;
-                 opt[mlen].price = cost;
-                 DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i) -- initial setup",
-                             mlen, cost, mlen);
-         }   }
-         last_match_pos = firstMatch.len;
-         {   int addLit;
-             for (addLit = 1; addLit <= TRAILING_LITERALS; addLit ++) {
-                 opt[last_match_pos+addLit].mlen = 1; /* literal */
-                 opt[last_match_pos+addLit].off = 0;
-                 opt[last_match_pos+addLit].litlen = addLit;
-                 opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
-                 DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup",
-                             last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
-         }   }
+        /* set prices for first positions (literals) */
+        {
+            int rPos;
+            for (rPos = 0; rPos < MINMATCH; rPos++) {
+                const int cost   = LZ4HC_literalsPrice(llen + rPos);
+                opt[rPos].mlen   = 1;
+                opt[rPos].off    = 0;
+                opt[rPos].litlen = llen + rPos;
+                opt[rPos].price  = cost;
+                DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup", rPos, cost, opt[rPos].litlen);
+            }
+        }
+        /* set prices using initial match */
+        {
+            const int matchML = firstMatch.len; /* necessarily < sufficient_len < LZ4_OPT_NUM */
+            const int offset  = firstMatch.off;
+            int       mlen;
+            assert(matchML < LZ4_OPT_NUM);
+            for (mlen = MINMATCH; mlen <= matchML; mlen++) {
+                const int cost   = LZ4HC_sequencePrice(llen, mlen);
+                opt[mlen].mlen   = mlen;
+                opt[mlen].off    = offset;
+                opt[mlen].litlen = llen;
+                opt[mlen].price  = cost;
+                DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i) -- initial setup", mlen, cost, mlen);
+            }
+        }
+        last_match_pos = firstMatch.len;
+        {
+            int addLit;
+            for (addLit = 1; addLit <= TRAILING_LITERALS; addLit++) {
+                opt[last_match_pos + addLit].mlen   = 1; /* literal */
+                opt[last_match_pos + addLit].off    = 0;
+                opt[last_match_pos + addLit].litlen = addLit;
+                opt[last_match_pos + addLit].price  = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
+                DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i) -- initial setup", last_match_pos + addLit,
+                         opt[last_match_pos + addLit].price, addLit);
+            }
+        }
 
-         /* check further positions */
-         for (cur = 1; cur < last_match_pos; cur++) {
-             const BYTE* const curPtr = ip + cur;
-             LZ4HC_match_t newMatch;
+        /* check further positions */
+        for (cur = 1; cur < last_match_pos; cur++) {
+            const BYTE* const curPtr = ip + cur;
+            LZ4HC_match_t     newMatch;
 
-             if (curPtr > mflimit) break;
-             DEBUGLOG(7, "rPos:%u[%u] vs [%u]%u",
-                     cur, opt[cur].price, opt[cur+1].price, cur+1);
-             if (fullUpdate) {
-                 /* not useful to search here if next position has same (or lower) cost */
-                 if ( (opt[cur+1].price <= opt[cur].price)
-                   /* in some cases, next position has same cost, but cost rises sharply after, so a small match would still be beneficial */
-                   && (opt[cur+MINMATCH].price < opt[cur].price + 3/*min seq price*/) )
-                     continue;
-             } else {
-                 /* not useful to search here if next position has same (or lower) cost */
-                 if (opt[cur+1].price <= opt[cur].price) continue;
-             }
+            if (curPtr > mflimit) break;
+            DEBUGLOG(7, "rPos:%u[%u] vs [%u]%u", cur, opt[cur].price, opt[cur + 1].price, cur + 1);
+            if (fullUpdate) {
+                /* not useful to search here if next position has same (or lower) cost */
+                if ((opt[cur + 1].price <= opt[cur].price)
+                    /* in some cases, next position has same cost, but cost rises sharply after, so a small match would still be beneficial */
+                    && (opt[cur + MINMATCH].price < opt[cur].price + 3 /*min seq price*/))
+                    continue;
+            } else {
+                /* not useful to search here if next position has same (or lower) cost */
+                if (opt[cur + 1].price <= opt[cur].price) continue;
+            }
 
-             DEBUGLOG(7, "search at rPos:%u", cur);
-             if (fullUpdate)
-                 newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, MINMATCH-1, nbSearches, dict, favorDecSpeed);
-             else
-                 /* only test matches of minimum length; slightly faster, but misses a few bytes */
-                 newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, last_match_pos - cur, nbSearches, dict, favorDecSpeed);
-             if (!newMatch.len) continue;
+            DEBUGLOG(7, "search at rPos:%u", cur);
+            if (fullUpdate)
+                newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, MINMATCH - 1, nbSearches, dict,
+                                                 favorDecSpeed);
+            else /* only test matches of minimum length; slightly faster, but misses a few bytes */
+                newMatch = LZ4HC_FindLongerMatch(ctx, curPtr, matchlimit, last_match_pos - cur, nbSearches,
+                                                 dict, favorDecSpeed);
+            if (!newMatch.len) continue;
 
-             if ( ((size_t)newMatch.len > sufficient_len)
-               || (newMatch.len + cur >= LZ4_OPT_NUM) ) {
-                 /* immediate encoding */
-                 best_mlen = newMatch.len;
-                 best_off = newMatch.off;
-                 last_match_pos = cur + 1;
-                 goto encode;
-             }
+            if (((size_t)newMatch.len > sufficient_len) || (newMatch.len + cur >= LZ4_OPT_NUM)) {
+                /* immediate encoding */
+                best_mlen      = newMatch.len;
+                best_off       = newMatch.off;
+                last_match_pos = cur + 1;
+                goto encode;
+            }
 
-             /* before match : set price with literals at beginning */
-             {   int const baseLitlen = opt[cur].litlen;
-                 int litlen;
-                 for (litlen = 1; litlen < MINMATCH; litlen++) {
-                     int const price = opt[cur].price - LZ4HC_literalsPrice(baseLitlen) + LZ4HC_literalsPrice(baseLitlen+litlen);
-                     int const pos = cur + litlen;
-                     if (price < opt[pos].price) {
-                         opt[pos].mlen = 1; /* literal */
-                         opt[pos].off = 0;
-                         opt[pos].litlen = baseLitlen+litlen;
-                         opt[pos].price = price;
-                         DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)",
-                                     pos, price, opt[pos].litlen);
-             }   }   }
+            /* before match : set price with literals at beginning */
+            {
+                const int baseLitlen = opt[cur].litlen;
+                int       litlen;
+                for (litlen = 1; litlen < MINMATCH; litlen++) {
+                    const int price = opt[cur].price - LZ4HC_literalsPrice(baseLitlen) +
+                                      LZ4HC_literalsPrice(baseLitlen + litlen);
+                    const int pos   = cur + litlen;
+                    if (price < opt[pos].price) {
+                        opt[pos].mlen   = 1; /* literal */
+                        opt[pos].off    = 0;
+                        opt[pos].litlen = baseLitlen + litlen;
+                        opt[pos].price  = price;
+                        DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)", pos, price, opt[pos].litlen);
+                    }
+                }
+            }
 
-             /* set prices using match at position = cur */
-             {   int const matchML = newMatch.len;
-                 int ml = MINMATCH;
+            /* set prices using match at position = cur */
+            {
+                const int matchML = newMatch.len;
+                int       ml      = MINMATCH;
 
-                 assert(cur + newMatch.len < LZ4_OPT_NUM);
-                 for ( ; ml <= matchML ; ml++) {
-                     int const pos = cur + ml;
-                     int const offset = newMatch.off;
-                     int price;
-                     int ll;
-                     DEBUGLOG(7, "testing price rPos %i (last_match_pos=%i)",
-                                 pos, last_match_pos);
-                     if (opt[cur].mlen == 1) {
-                         ll = opt[cur].litlen;
-                         price = ((cur > ll) ? opt[cur - ll].price : 0)
-                               + LZ4HC_sequencePrice(ll, ml);
-                     } else {
-                         ll = 0;
-                         price = opt[cur].price + LZ4HC_sequencePrice(0, ml);
-                     }
+                assert(cur + newMatch.len < LZ4_OPT_NUM);
+                for (; ml <= matchML; ml++) {
+                    const int pos    = cur + ml;
+                    const int offset = newMatch.off;
+                    int       price;
+                    int       ll;
+                    DEBUGLOG(7, "testing price rPos %i (last_match_pos=%i)", pos, last_match_pos);
+                    if (opt[cur].mlen == 1) {
+                        ll    = opt[cur].litlen;
+                        price = ((cur > ll) ? opt[cur - ll].price : 0) + LZ4HC_sequencePrice(ll, ml);
+                    } else {
+                        ll    = 0;
+                        price = opt[cur].price + LZ4HC_sequencePrice(0, ml);
+                    }
 
                     assert((U32)favorDecSpeed <= 1);
-                     if (pos > last_match_pos+TRAILING_LITERALS
-                      || price <= opt[pos].price - (int)favorDecSpeed) {
-                         DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i)",
-                                     pos, price, ml);
-                         assert(pos < LZ4_OPT_NUM);
-                         if ( (ml == matchML)  /* last pos of last match */
-                           && (last_match_pos < pos) )
-                             last_match_pos = pos;
-                         opt[pos].mlen = ml;
-                         opt[pos].off = offset;
-                         opt[pos].litlen = ll;
-                         opt[pos].price = price;
-             }   }   }
-             /* complete following positions with literals */
-             {   int addLit;
-                 for (addLit = 1; addLit <= TRAILING_LITERALS; addLit ++) {
-                     opt[last_match_pos+addLit].mlen = 1; /* literal */
-                     opt[last_match_pos+addLit].off = 0;
-                     opt[last_match_pos+addLit].litlen = addLit;
-                     opt[last_match_pos+addLit].price = opt[last_match_pos].price + LZ4HC_literalsPrice(addLit);
-                     DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)", last_match_pos+addLit, opt[last_match_pos+addLit].price, addLit);
-             }   }
-         }  /* for (cur = 1; cur <= last_match_pos; cur++) */
+                    if (pos > last_match_pos + TRAILING_LITERALS ||
+                        price <= opt[pos].price - (int)favorDecSpeed) {
+                        DEBUGLOG(7, "rPos:%3i => price:%3i (matchlen=%i)", pos, price, ml);
+                        assert(pos < LZ4_OPT_NUM);
+                        if ((ml == matchML) /* last pos of last match */
+                            && (last_match_pos < pos))
+                            last_match_pos = pos;
+                        opt[pos].mlen   = ml;
+                        opt[pos].off    = offset;
+                        opt[pos].litlen = ll;
+                        opt[pos].price  = price;
+                    }
+                }
+            }
+            /* complete following positions with literals */
+            {
+                int addLit;
+                for (addLit = 1; addLit <= TRAILING_LITERALS; addLit++) {
+                    opt[last_match_pos + addLit].mlen   = 1; /* literal */
+                    opt[last_match_pos + addLit].off    = 0;
+                    opt[last_match_pos + addLit].litlen = addLit;
+                    opt[last_match_pos + addLit].price  = opt[last_match_pos].price +
+                                                          LZ4HC_literalsPrice(addLit);
+                    DEBUGLOG(7, "rPos:%3i => price:%3i (litlen=%i)", last_match_pos + addLit,
+                             opt[last_match_pos + addLit].price, addLit);
+                }
+            }
+        } /* for (cur = 1; cur <= last_match_pos; cur++) */
 
-         assert(last_match_pos < LZ4_OPT_NUM + TRAILING_LITERALS);
-         best_mlen = opt[last_match_pos].mlen;
-         best_off = opt[last_match_pos].off;
-         cur = last_match_pos - best_mlen;
+        assert(last_match_pos < LZ4_OPT_NUM + TRAILING_LITERALS);
+        best_mlen = opt[last_match_pos].mlen;
+        best_off  = opt[last_match_pos].off;
+        cur       = last_match_pos - best_mlen;
 
 encode: /* cur, last_match_pos, best_mlen, best_off must be set */
-         assert(cur < LZ4_OPT_NUM);
-         assert(last_match_pos >= 1);  /* == 1 when only one candidate */
-         DEBUGLOG(6, "reverse traversal, looking for shortest path (last_match_pos=%i)", last_match_pos);
-         {   int candidate_pos = cur;
-             int selected_matchLength = best_mlen;
-             int selected_offset = best_off;
-             while (1) {  /* from end to beginning */
-                 int const next_matchLength = opt[candidate_pos].mlen;  /* can be 1, means literal */
-                 int const next_offset = opt[candidate_pos].off;
-                 DEBUGLOG(7, "pos %i: sequence length %i", candidate_pos, selected_matchLength);
-                 opt[candidate_pos].mlen = selected_matchLength;
-                 opt[candidate_pos].off = selected_offset;
-                 selected_matchLength = next_matchLength;
-                 selected_offset = next_offset;
-                 if (next_matchLength > candidate_pos) break; /* last match elected, first match to encode */
-                 assert(next_matchLength > 0);  /* can be 1, means literal */
-                 candidate_pos -= next_matchLength;
-         }   }
+        assert(cur < LZ4_OPT_NUM);
+        assert(last_match_pos >= 1); /* == 1 when only one candidate */
+        DEBUGLOG(6, "reverse traversal, looking for shortest path (last_match_pos=%i)", last_match_pos);
+        {
+            int candidate_pos        = cur;
+            int selected_matchLength = best_mlen;
+            int selected_offset      = best_off;
+            while (1) { /* from end to beginning */
+                const int next_matchLength = opt[candidate_pos].mlen; /* can be 1, means literal */
+                const int next_offset      = opt[candidate_pos].off;
+                DEBUGLOG(7, "pos %i: sequence length %i", candidate_pos, selected_matchLength);
+                opt[candidate_pos].mlen = selected_matchLength;
+                opt[candidate_pos].off  = selected_offset;
+                selected_matchLength    = next_matchLength;
+                selected_offset         = next_offset;
+                if (next_matchLength > candidate_pos) break; /* last match elected, first match to encode */
+                assert(next_matchLength > 0); /* can be 1, means literal */
+                candidate_pos -= next_matchLength;
+            }
+        }
 
-         /* encode all recorded sequences in order */
-         {   int rPos = 0;  /* relative position (to ip) */
-             while (rPos < last_match_pos) {
-                 int const ml = opt[rPos].mlen;
-                 int const offset = opt[rPos].off;
-                 if (ml == 1) { ip++; rPos++; continue; }  /* literal; note: can end up with several literals, in which case, skip them */
-                 rPos += ml;
-                 assert(ml >= MINMATCH);
-                 assert((offset >= 1) && (offset <= LZ4_DISTANCE_MAX));
-                 opSaved = op;
-                 if ( LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ml, offset, limit, oend) ) {  /* updates ip, op and anchor */
-                     ovml = ml;
-                     ovoff = offset;
-                     goto _dest_overflow;
-         }   }   }
-     }  /* while (ip <= mflimit) */
+        /* encode all recorded sequences in order */
+        {
+            int rPos = 0; /* relative position (to ip) */
+            while (rPos < last_match_pos) {
+                const int ml     = opt[rPos].mlen;
+                const int offset = opt[rPos].off;
+                if (ml == 1) {
+                    ip++;
+                    rPos++;
+                    continue;
+                } /* literal; note: can end up with several literals, in which case, skip them */
+                rPos += ml;
+                assert(ml >= MINMATCH);
+                assert((offset >= 1) && (offset <= LZ4_DISTANCE_MAX));
+                opSaved = op;
+                if (LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ml, offset, limit,
+                                         oend)) { /* updates ip, op and anchor */
+                    ovml  = ml;
+                    ovoff = offset;
+                    goto _dest_overflow;
+                }
+            }
+        }
+    } /* while (ip <= mflimit) */
 
 _last_literals:
-     /* Encode Last Literals */
-     {   size_t lastRunSize = (size_t)(iend - anchor);  /* literals */
-         size_t llAdd = (lastRunSize + 255 - RUN_MASK) / 255;
-         size_t const totalSize = 1 + llAdd + lastRunSize;
-         if (limit == fillOutput) oend += LASTLITERALS;  /* restore correct value */
-         if (limit && (op + totalSize > oend)) {
-             if (limit == limitedOutput) { /* Check output limit */
+    /* Encode Last Literals */
+    {
+        size_t       lastRunSize = (size_t)(iend - anchor); /* literals */
+        size_t       llAdd       = (lastRunSize + 255 - RUN_MASK) / 255;
+        const size_t totalSize   = 1 + llAdd + lastRunSize;
+        if (limit == fillOutput) oend += LASTLITERALS; /* restore correct value */
+        if (limit && (op + totalSize > oend)) {
+            if (limit == limitedOutput) { /* Check output limit */
                 retval = 0;
                 goto _return_label;
-             }
-             /* adapt lastRunSize to fill 'dst' */
-             lastRunSize  = (size_t)(oend - op) - 1 /*token*/;
-             llAdd = (lastRunSize + 256 - RUN_MASK) / 256;
-             lastRunSize -= llAdd;
-         }
-         DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
-         ip = anchor + lastRunSize; /* can be != iend if limit==fillOutput */
+            }
+            /* adapt lastRunSize to fill 'dst' */
+            lastRunSize = (size_t)(oend - op) - 1 /*token*/;
+            llAdd       = (lastRunSize + 256 - RUN_MASK) / 256;
+            lastRunSize -= llAdd;
+        }
+        DEBUGLOG(6, "Final literal run : %i literals", (int)lastRunSize);
+        ip = anchor + lastRunSize; /* can be != iend if limit==fillOutput */
 
-         if (lastRunSize >= RUN_MASK) {
-             size_t accumulator = lastRunSize - RUN_MASK;
-             *op++ = (RUN_MASK << ML_BITS);
-             for(; accumulator >= 255 ; accumulator -= 255) *op++ = 255;
-             *op++ = (BYTE) accumulator;
-         } else {
-             *op++ = (BYTE)(lastRunSize << ML_BITS);
-         }
-         LZ4_memcpy(op, anchor, lastRunSize);
-         op += lastRunSize;
-     }
+        if (lastRunSize >= RUN_MASK) {
+            size_t accumulator = lastRunSize - RUN_MASK;
+            *op++              = (RUN_MASK << ML_BITS);
+            for (; accumulator >= 255; accumulator -= 255)
+                *op++ = 255;
+            *op++ = (BYTE)accumulator;
+        } else {
+            *op++ = (BYTE)(lastRunSize << ML_BITS);
+        }
+        LZ4_memcpy(op, anchor, lastRunSize);
+        op += lastRunSize;
+    }
 
-     /* End */
-     *srcSizePtr = (int) (((const char*)ip) - source);
-     retval = (int) ((char*)op-dst);
-     goto _return_label;
+    /* End */
+    *srcSizePtr = (int)(((const char*)ip) - source);
+    retval      = (int)((char*)op - dst);
+    goto _return_label;
 
 _dest_overflow:
-if (limit == fillOutput) {
-     /* Assumption : ip, anchor, ovml and ovref must be set correctly */
-     size_t const ll = (size_t)(ip - anchor);
-     size_t const ll_addbytes = (ll + 240) / 255;
-     size_t const ll_totalCost = 1 + ll_addbytes + ll;
-     BYTE* const maxLitPos = oend - 3; /* 2 for offset, 1 for token */
-     DEBUGLOG(6, "Last sequence overflowing (only %i bytes remaining)", (int)(oend-1-opSaved));
-     op = opSaved;  /* restore correct out pointer */
-     if (op + ll_totalCost <= maxLitPos) {
-         /* ll validated; now adjust match length */
-         size_t const bytesLeftForMl = (size_t)(maxLitPos - (op+ll_totalCost));
-         size_t const maxMlSize = MINMATCH + (ML_MASK-1) + (bytesLeftForMl * 255);
-         assert(maxMlSize < INT_MAX); assert(ovml >= 0);
-         if ((size_t)ovml > maxMlSize) ovml = (int)maxMlSize;
-         if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + ovml >= MFLIMIT) {
-             DEBUGLOG(6, "Space to end : %i + ml (%i)", (int)((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1), ovml);
-             DEBUGLOG(6, "Before : ip = %p, anchor = %p", ip, anchor);
-             LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ovml, ovoff, notLimited, oend);
-             DEBUGLOG(6, "After : ip = %p, anchor = %p", ip, anchor);
-     }   }
-     goto _last_literals;
-}
+    if (limit == fillOutput) {
+        /* Assumption : ip, anchor, ovml and ovref must be set correctly */
+        const size_t ll           = (size_t)(ip - anchor);
+        const size_t ll_addbytes  = (ll + 240) / 255;
+        const size_t ll_totalCost = 1 + ll_addbytes + ll;
+        BYTE* const  maxLitPos    = oend - 3; /* 2 for offset, 1 for token */
+        DEBUGLOG(6, "Last sequence overflowing (only %i bytes remaining)", (int)(oend - 1 - opSaved));
+        op = opSaved; /* restore correct out pointer */
+        if (op + ll_totalCost <= maxLitPos) {
+            /* ll validated; now adjust match length */
+            const size_t bytesLeftForMl = (size_t)(maxLitPos - (op + ll_totalCost));
+            const size_t maxMlSize      = MINMATCH + (ML_MASK - 1) + (bytesLeftForMl * 255);
+            assert(maxMlSize < INT_MAX);
+            assert(ovml >= 0);
+            if ((size_t)ovml > maxMlSize) ovml = (int)maxMlSize;
+            if ((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1 + ovml >= MFLIMIT) {
+                DEBUGLOG(6, "Space to end : %i + ml (%i)",
+                         (int)((oend + LASTLITERALS) - (op + ll_totalCost + 2) - 1), ovml);
+                DEBUGLOG(6, "Before : ip = %p, anchor = %p", ip, anchor);
+                LZ4HC_encodeSequence(UPDATABLE(ip, op, anchor), ovml, ovoff, notLimited, oend);
+                DEBUGLOG(6, "After : ip = %p, anchor = %p", ip, anchor);
+            }
+        }
+        goto _last_literals;
+    }
 _return_label:
-#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE==1
-     if (opt) FREEMEM(opt);
+#if defined(LZ4HC_HEAPMODE) && LZ4HC_HEAPMODE == 1
+    if (opt) FREEMEM(opt);
 #endif
-     return retval;
+    return retval;
 }
-
 
 /***************************************************
 *  Deprecated Functions
@@ -2193,62 +2319,115 @@ _return_label:
 /* These functions currently generate deprecation warnings */
 
 /* Wrappers for deprecated compression functions */
-int LZ4_compressHC(const char* src, char* dst, int srcSize) { return LZ4_compress_HC (src, dst, srcSize, LZ4_compressBound(srcSize), 0); }
-int LZ4_compressHC_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC(src, dst, srcSize, maxDstSize, 0); }
-int LZ4_compressHC2(const char* src, char* dst, int srcSize, int cLevel) { return LZ4_compress_HC (src, dst, srcSize, LZ4_compressBound(srcSize), cLevel); }
-int LZ4_compressHC2_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize, int cLevel) { return LZ4_compress_HC(src, dst, srcSize, maxDstSize, cLevel); }
-int LZ4_compressHC_withStateHC (void* state, const char* src, char* dst, int srcSize) { return LZ4_compress_HC_extStateHC (state, src, dst, srcSize, LZ4_compressBound(srcSize), 0); }
-int LZ4_compressHC_limitedOutput_withStateHC (void* state, const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC_extStateHC (state, src, dst, srcSize, maxDstSize, 0); }
-int LZ4_compressHC2_withStateHC (void* state, const char* src, char* dst, int srcSize, int cLevel) { return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, LZ4_compressBound(srcSize), cLevel); }
-int LZ4_compressHC2_limitedOutput_withStateHC (void* state, const char* src, char* dst, int srcSize, int maxDstSize, int cLevel) { return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, maxDstSize, cLevel); }
-int LZ4_compressHC_continue (LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize) { return LZ4_compress_HC_continue (ctx, src, dst, srcSize, LZ4_compressBound(srcSize)); }
-int LZ4_compressHC_limitedOutput_continue (LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize, int maxDstSize) { return LZ4_compress_HC_continue (ctx, src, dst, srcSize, maxDstSize); }
+int LZ4_compressHC(const char* src, char* dst, int srcSize)
+{
+    return LZ4_compress_HC(src, dst, srcSize, LZ4_compressBound(srcSize), 0);
+}
 
+int LZ4_compressHC_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize)
+{
+    return LZ4_compress_HC(src, dst, srcSize, maxDstSize, 0);
+}
+
+int LZ4_compressHC2(const char* src, char* dst, int srcSize, int cLevel)
+{
+    return LZ4_compress_HC(src, dst, srcSize, LZ4_compressBound(srcSize), cLevel);
+}
+
+int LZ4_compressHC2_limitedOutput(const char* src, char* dst, int srcSize, int maxDstSize, int cLevel)
+{
+    return LZ4_compress_HC(src, dst, srcSize, maxDstSize, cLevel);
+}
+
+int LZ4_compressHC_withStateHC(void* state, const char* src, char* dst, int srcSize)
+{
+    return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, LZ4_compressBound(srcSize), 0);
+}
+
+int LZ4_compressHC_limitedOutput_withStateHC(void* state, const char* src, char* dst, int srcSize, int maxDstSize)
+{
+    return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, maxDstSize, 0);
+}
+
+int LZ4_compressHC2_withStateHC(void* state, const char* src, char* dst, int srcSize, int cLevel)
+{
+    return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, LZ4_compressBound(srcSize), cLevel);
+}
+
+int LZ4_compressHC2_limitedOutput_withStateHC(void*       state,
+                                              const char* src,
+                                              char*       dst,
+                                              int         srcSize,
+                                              int         maxDstSize,
+                                              int         cLevel)
+{
+    return LZ4_compress_HC_extStateHC(state, src, dst, srcSize, maxDstSize, cLevel);
+}
+
+int LZ4_compressHC_continue(LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize)
+{
+    return LZ4_compress_HC_continue(ctx, src, dst, srcSize, LZ4_compressBound(srcSize));
+}
+
+int LZ4_compressHC_limitedOutput_continue(LZ4_streamHC_t* ctx, const char* src, char* dst, int srcSize, int maxDstSize)
+{
+    return LZ4_compress_HC_continue(ctx, src, dst, srcSize, maxDstSize);
+}
 
 /* Deprecated streaming functions */
-int LZ4_sizeofStreamStateHC(void) { return sizeof(LZ4_streamHC_t); }
+int LZ4_sizeofStreamStateHC(void)
+{
+    return sizeof(LZ4_streamHC_t);
+}
 
 /* state is presumed correctly sized, aka >= sizeof(LZ4_streamHC_t)
  * @return : 0 on success, !=0 if error */
 int LZ4_resetStreamStateHC(void* state, char* inputBuffer)
 {
     LZ4_streamHC_t* const hc4 = LZ4_initStreamHC(state, sizeof(*hc4));
-    if (hc4 == NULL) return 1;   /* init failed */
-    LZ4HC_init_internal (&hc4->internal_donotuse, (const BYTE*)inputBuffer);
+    if (hc4 == NULL) return 1; /* init failed */
+    LZ4HC_init_internal(&hc4->internal_donotuse, (const BYTE*)inputBuffer);
     return 0;
 }
 
 #if !defined(LZ4_STATIC_LINKING_ONLY_DISABLE_MEMORY_ALLOCATION)
-void* LZ4_createHC (const char* inputBuffer)
+void* LZ4_createHC(const char* inputBuffer)
 {
     LZ4_streamHC_t* const hc4 = LZ4_createStreamHC();
-    if (hc4 == NULL) return NULL;   /* not enough memory */
-    LZ4HC_init_internal (&hc4->internal_donotuse, (const BYTE*)inputBuffer);
+    if (hc4 == NULL) return NULL; /* not enough memory */
+    LZ4HC_init_internal(&hc4->internal_donotuse, (const BYTE*)inputBuffer);
     return hc4;
 }
 
-int LZ4_freeHC (void* LZ4HC_Data)
+int LZ4_freeHC(void* LZ4HC_Data)
 {
-    if (!LZ4HC_Data) return 0;  /* support free on NULL */
+    if (!LZ4HC_Data) return 0; /* support free on NULL */
     FREEMEM(LZ4HC_Data);
     return 0;
 }
 #endif
 
-int LZ4_compressHC2_continue (void* LZ4HC_Data, const char* src, char* dst, int srcSize, int cLevel)
+int LZ4_compressHC2_continue(void* LZ4HC_Data, const char* src, char* dst, int srcSize, int cLevel)
 {
-    return LZ4HC_compress_generic (&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize, 0, cLevel, notLimited);
+    return LZ4HC_compress_generic(&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize, 0,
+                                  cLevel, notLimited);
 }
 
-int LZ4_compressHC2_limitedOutput_continue (void* LZ4HC_Data, const char* src, char* dst, int srcSize, int dstCapacity, int cLevel)
+int LZ4_compressHC2_limitedOutput_continue(void*       LZ4HC_Data,
+                                           const char* src,
+                                           char*       dst,
+                                           int         srcSize,
+                                           int         dstCapacity,
+                                           int         cLevel)
 {
-    return LZ4HC_compress_generic (&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize, dstCapacity, cLevel, limitedOutput);
+    return LZ4HC_compress_generic(&((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse, src, dst, &srcSize,
+                                  dstCapacity, cLevel, limitedOutput);
 }
 
 char* LZ4_slideInputBufferHC(void* LZ4HC_Data)
 {
-    LZ4HC_CCtx_internal* const s = &((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse;
-    const BYTE* const bufferStart = s->prefixStart - s->dictLimit + s->lowLimit;
+    LZ4HC_CCtx_internal* const s           = &((LZ4_streamHC_t*)LZ4HC_Data)->internal_donotuse;
+    const BYTE* const          bufferStart = s->prefixStart - s->dictLimit + s->lowLimit;
     LZ4_resetStreamHC_fast((LZ4_streamHC_t*)LZ4HC_Data, s->compressionLevel);
     /* ugly conversion trick, required to evade (const char*) -> (char*) cast-qual warning :( */
     return (char*)(uptrval)bufferStart;


### PR DESCRIPTION
This PR addresses two security vulnerabilities in LZ4's decompression functions by adding input validation checks. The changes prevent potential out-of-bounds reads and pointer arithmetic overflows that could be exploited with malformed compressed data. These fixes maintain backward compatibility while improving the robustness of the safe decompression APIs.