### PR TITLE
Inline read_variable_length

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2102,19 +2102,21 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t s;
-                do {
-                    s = *ip++;
-                    if (unlikely(ip >= iend)) { goto _output_error; } /* overflow detection */
-                    length += s;
-                    if ((sizeof(length)<8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
-                        goto _output_error;
-                    }
-                } while (s==255);
+                size_t s = *ip++;
+                length += s;
+                if (s == 255) {
+                    do {
+                        s = *ip++;
+                        if (unlikely(ip >= iend)) { goto _output_error; } /* overflow detection */
+                        length += s;
+                        if ((sizeof(length)<8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+                            goto _output_error;
+                        }
+                    } while (s == 255);
+                    if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
+                    if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
+                }
                 cpy = op+length;
-                if (unlikely((uptrval)(cpy)<(uptrval)(op))) { goto _output_error; } /* overflow detection */
-                if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */
-
                 /* copy literals */
                 LZ4_STATIC_ASSERT(MFLIMIT >= WILDCOPYLENGTH);
               #ifdef __aarch64__

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2102,12 +2102,15 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend, 0);
-                if (addl == rvl_error) {
-                    DEBUGLOG(6, "error reading long literal length");
-                    goto _output_error;
-                }
-                length += addl;
+                size_t s;
+                do {
+                    s = *ip++;
+                    if (unlikely(ip >= iend)) { goto _output_error; } /* overflow detection */
+                    length += s;
+                    if ((sizeof(length)<8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+                        goto _output_error;
+                    }
+                } while (s==255);
                 cpy = op+length;
                 if (unlikely((uptrval)(cpy)<(uptrval)(op))) { goto _output_error; } /* overflow detection */
                 if (unlikely((uptrval)(ip)+length<(uptrval)(ip))) { goto _output_error; } /* overflow detection */


### PR DESCRIPTION
Inline reading of literal length at the loop's beginning.
Idea is to avoid having to compare the result against the error value and accumulate into length directly.