### PR TITLE
Fix read oob

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1998,10 +1998,6 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
     s = **ip;
     (*ip)++;
     length += s;
-    /* accumulator overflow detection (32-bit mode only) */
-    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
-        return rvl_error;
-    }
     if (likely(s != 255)) return length;
     do {
         if (unlikely((*ip) >= ilimit)) {    /* read limit reached */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1992,6 +1992,7 @@ read_variable_length(const BYTE** ipPtr, const BYTE* ilimit,
     assert(ipPtr != NULL);
     assert(*ipPtr !=  NULL);
     assert(ilimit != NULL);
+    assert(initial_check || (*ipPtr < ilimit));  /* if no initial_check, caller guarantees ip < ilimit */
     if (initial_check && unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */
         return rvl_error;
     }
@@ -2132,7 +2133,7 @@ LZ4_decompress_generic(
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 0);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 1);
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1998,21 +1998,18 @@ read_variable_length(const BYTE** ip, const BYTE* ilimit,
     s = **ip;
     (*ip)++;
     length += s;
-    if (unlikely((*ip) > ilimit)) {    /* read limit reached */
-        return rvl_error;
-    }
     /* accumulator overflow detection (32-bit mode only) */
     if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
         return rvl_error;
     }
     if (likely(s != 255)) return length;
     do {
+        if (unlikely((*ip) >= ilimit)) {    /* read limit reached */
+            return rvl_error;
+        }
         s = **ip;
         (*ip)++;
         length += s;
-        if (unlikely((*ip) > ilimit)) {    /* read limit reached */
-            return rvl_error;
-        }
         /* accumulator overflow detection (32-bit mode only) */
         if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
             return rvl_error;

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1977,10 +1977,10 @@ LZ4_decompress_unsafe_generic(
 
 /* Read the variable-length literal or match length.
  *
- * @ip : input pointer
- * @ilimit : position after which if length is not decoded, the input is necessarily corrupted.
- * @initial_check - check ip >= ipmax before start of loop.  Returns initial_error if so.
- * @error (output) - error code.  Must be set to 0 before call.
+ * @ipPtr : pointer to input pointer, will be advanced
+ * @ilimit : read is forbidden beyond this position (must be within input buffer)
+ * @initial_check : if non-zero, check *ipPtr >= ilimit before reading.
+ *                  if zero, caller guarantees *ipPtr < ilimit.
 **/
 typedef size_t Rvl_t;
 static const Rvl_t rvl_error = (Rvl_t)(-1);

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1979,21 +1979,17 @@ LZ4_decompress_unsafe_generic(
  *
  * @ipPtr : pointer to input pointer, will be advanced
  * @ilimit : read is forbidden beyond this position (must be within input buffer)
- * @initial_check : if non-zero, check *ipPtr >= ilimit before reading.
- *                  if zero, caller guarantees *ipPtr < ilimit.
 **/
 typedef size_t Rvl_t;
 static const Rvl_t rvl_error = (Rvl_t)(-1);
 LZ4_FORCE_INLINE Rvl_t
-read_variable_length(const BYTE** ipPtr, const BYTE* ilimit,
-                     int initial_check)
+read_variable_length(const BYTE** ipPtr, const BYTE* ilimit)
 {
     Rvl_t s, length = 0;
     assert(ipPtr != NULL);
     assert(*ipPtr !=  NULL);
     assert(ilimit != NULL);
-    assert(initial_check || (*ipPtr < ilimit));  /* if no initial_check, caller guarantees ip < ilimit */
-    if (initial_check && unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */
+    if (unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */
         return rvl_error;
     }
     s = **ipPtr;
@@ -2095,7 +2091,7 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - RUN_MASK, 0);
+                size_t const addl = read_variable_length(&ip, iend - RUN_MASK);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
@@ -2133,7 +2129,7 @@ LZ4_decompress_generic(
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 1);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS);
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
@@ -2278,7 +2274,7 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend-RUN_MASK, 1);
+                size_t const addl = read_variable_length(&ip, iend-RUN_MASK);
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)(op))) { goto _output_error; } /* overflow detection */
@@ -2360,7 +2356,7 @@ LZ4_decompress_generic(
 
     _copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 1);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS);
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2094,7 +2094,7 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
-                size_t const addl = read_variable_length(&ip, iend, 0);
+                size_t const addl = read_variable_length(&ip, iend - RUN_MASK, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
                     goto _output_error;
@@ -2132,7 +2132,7 @@ LZ4_decompress_generic(
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 0);
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
@@ -2359,7 +2359,7 @@ LZ4_decompress_generic(
 
     _copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS + 1, 0);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 0);
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2360,7 +2360,7 @@ LZ4_decompress_generic(
 
     _copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 0);
+                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS, 1);
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -2091,6 +2091,8 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
+                /* literal length >= RUN_MASK means >= RUN_MASK literal bytes follow the extension bytes,
+                 * so extension bytes cannot reach the last RUN_MASK bytes of input */
                 size_t const addl = read_variable_length(&ip, iend - RUN_MASK);
                 if (addl == rvl_error) {
                     DEBUGLOG(6, "error reading long literal length");
@@ -2129,7 +2131,8 @@ LZ4_decompress_generic(
             DEBUGLOG(7, "  match length token = %u (len==%u)", (unsigned)length, (unsigned)length+MINMATCH);
 
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS);
+                /* after match length extension bytes, at least 1 token + LASTLITERALS literals must remain */
+                size_t const addl = read_variable_length(&ip, iend - (1 + LASTLITERALS));
                 if (addl == rvl_error) {
                     DEBUGLOG(5, "error reading long match length");
                     goto _output_error;
@@ -2274,6 +2277,8 @@ LZ4_decompress_generic(
 
             /* decode literal length */
             if (length == RUN_MASK) {
+                /* literal length >= RUN_MASK means >= RUN_MASK literal bytes follow the extension bytes,
+                 * so extension bytes cannot reach the last RUN_MASK bytes of input */
                 size_t const addl = read_variable_length(&ip, iend-RUN_MASK);
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
@@ -2356,7 +2361,8 @@ LZ4_decompress_generic(
 
     _copy_match:
             if (length == ML_MASK) {
-                size_t const addl = read_variable_length(&ip, iend - LASTLITERALS);
+                /* after match length extension bytes, at least 1 token + LASTLITERALS literals must remain */
+                size_t const addl = read_variable_length(&ip, iend - (1 + LASTLITERALS));
                 if (addl == rvl_error) { goto _output_error; }
                 length += addl;
                 if (unlikely((uptrval)(op)+length<(uptrval)op)) goto _output_error;   /* overflow detection */

--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1985,26 +1985,26 @@ LZ4_decompress_unsafe_generic(
 typedef size_t Rvl_t;
 static const Rvl_t rvl_error = (Rvl_t)(-1);
 LZ4_FORCE_INLINE Rvl_t
-read_variable_length(const BYTE** ip, const BYTE* ilimit,
+read_variable_length(const BYTE** ipPtr, const BYTE* ilimit,
                      int initial_check)
 {
     Rvl_t s, length = 0;
-    assert(ip != NULL);
-    assert(*ip !=  NULL);
+    assert(ipPtr != NULL);
+    assert(*ipPtr !=  NULL);
     assert(ilimit != NULL);
-    if (initial_check && unlikely((*ip) >= ilimit)) {    /* read limit reached */
+    if (initial_check && unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */
         return rvl_error;
     }
-    s = **ip;
-    (*ip)++;
+    s = **ipPtr;
+    (*ipPtr)++;
     length += s;
     if (likely(s != 255)) return length;
     do {
-        if (unlikely((*ip) >= ilimit)) {    /* read limit reached */
+        if (unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */
             return rvl_error;
         }
-        s = **ip;
-        (*ip)++;
+        s = **ipPtr;
+        (*ipPtr)++;
         length += s;
         /* accumulator overflow detection (32-bit mode only) */
         if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {

--- a/ossfuzz/.gitignore
+++ b/ossfuzz/.gitignore
@@ -1,5 +1,14 @@
 
 # build artefacts
+compress_fuzzer
+decompress_fuzzer
+compress_frame_fuzzer
+decompress_frame_fuzzer
+compress_hc_fuzzer
+round_trip_fuzzer
+round_trip_hc_fuzzer
+round_trip_stream_fuzzer
+round_trip_frame_fuzzer
 round_trip_frame_uncompressed_fuzzer
 
 # test artefacts

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1167,6 +1167,22 @@ static void FUZ_unitTests(int compressionLevel)
             FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail on this crafted input");
     }   }
 
+    /* Test that ip does not go beyond iend in the safe decode loop shortcut path.
+     * Same block as above, but output buffer is 40 bytes: small enough to skip
+     * the fast loop (<64), large enough for the shortcut (>=32).
+     * The shortcut reads literals+offset, landing ip at iend-1, then goto _copy_match
+     * calls read_variable_length with ip >= ilimit. */
+    DISPLAYLEVEL(3, "LZ4_decompress_safe() safe-loop shortcut ip-at-iend regression test \n");
+    {   char block[18];
+        char out[40];
+        block[0] = (char)0xEF;          /* 14 literals, ML_MASK match */
+        memset(block + 1, 'A', 14);     /* 14 literal bytes */
+        block[15] = 0x0E; block[16] = 0x00;  /* offset = 14 */
+        block[17] = 0x00;               /* match length extension = 0 */
+        {   int const r = LZ4_decompress_safe(block, out, sizeof(block), sizeof(out));
+            FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail on this crafted input");
+    }   }
+
     /* to be tested with undefined sanitizer */
     DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input:");
     {	int const maxCSize = LZ4_compressBound(0);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1142,6 +1142,14 @@ static void FUZ_unitTests(int compressionLevel)
     }   }
 
 
+    /* Test decoding with all 0xFF input - OOB read regression test */
+    DISPLAYLEVEL(3, "LZ4_decompress_safe() with all-0xFF input \n");
+    {   char tmp[31];
+        memset(tmp, 0xFF, sizeof(tmp));
+        {   int const r = LZ4_decompress_safe(tmp, testVerify, sizeof(tmp), testInputSize);
+            FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail on all-0xFF input");
+    }   }
+
     /* to be tested with undefined sanitizer */
     DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input:");
     {	int const maxCSize = LZ4_compressBound(0);

--- a/tests/fuzzer.c
+++ b/tests/fuzzer.c
@@ -1150,6 +1150,23 @@ static void FUZ_unitTests(int compressionLevel)
             FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail on all-0xFF input");
     }   }
 
+    /* Test that ip does not go beyond iend in the fast decode loop.
+     * The block has 14 literals, ML_MASK match token, offset=14, one extension byte=0.
+     * This positions ip exactly at iend when read_variable_length reads the extension,
+     * then goto safe_match_copy would loop back with ip==iend, triggering assert(ip<iend).
+     * Output buffer is 65 bytes: large enough to enter the fast loop (>=64),
+     * small enough that op+length >= oend-64 triggers the safe_match_copy path. */
+    DISPLAYLEVEL(3, "LZ4_decompress_safe() fast-loop ip-at-iend regression test \n");
+    {   char block[18];
+        char out[65];
+        block[0] = (char)0xEF;          /* 14 literals, ML_MASK match */
+        memset(block + 1, 'A', 14);     /* 14 literal bytes */
+        block[15] = 0x0E; block[16] = 0x00;  /* offset = 14 */
+        block[17] = 0x00;               /* match length extension = 0 */
+        {   int const r = LZ4_decompress_safe(block, out, sizeof(block), sizeof(out));
+            FUZ_CHECKTEST(r >= 0, "LZ4_decompress_safe() should fail on this crafted input");
+    }   }
+
     /* to be tested with undefined sanitizer */
     DISPLAYLEVEL(3, "LZ4_compress_default() with NULL input:");
     {	int const maxCSize = LZ4_compressBound(0);


### PR DESCRIPTION
The recent https://github.com/lz4/lz4/commit/93e8b693f4c54434ac29c5714d01591e2aeafe98 introduced a small read out-of-bound issue, which is triggered in some invalid input scenarios.

This PR fixes it by introducing a double layers defense,

first there is no more call site that invokes `read_variable_length()` with the buffer boundary as `iLimit` parameter, as it was expected when this method was designed. Also, call-site pre-conditions guarantees proved brittle, so the code is simplified to always perform the entry test.

second `read_variable_length()` is also made compatible with `iLimit` as buffer boundary, in case this erroneous condition is introduced again in some future contribution.

Additional `assert()` and tests to continuously verify these invariants in future contributions.

In term of performance, this is expected to be neutral, 
though unfortunately one can observe big performance swings on specific binaries in either direction, 
due to random instruction alignment effects (non controllable), 
particularly sensible on skylake-era cpus:

<details>

| Compiler | File | `dev` | `fix_oob` | Delta |
|---|---|---:|---:|---:|
| gcc-9  | silesia.tar | 4742.5 | 3787.0 | **-20.1%** |
| gcc-9  | calgary.tar | 4576.2 | 3453.1 | **-24.5%** |
| gcc-9  | enwik9      | 4170.2 | 3213.3 | **-22.9%** |
| gcc-10 | silesia.tar | 4675.0 | 4685.3 | +0.2% |
| gcc-10 | calgary.tar | 4520.7 | 4545.4 | +0.5% |
| gcc-10 | enwik9      | 4123.5 | 4153.9 | +0.7% |
| gcc-11 | silesia.tar | 4833.7 | 4771.6 | -1.3% |
| gcc-11 | calgary.tar | 4652.3 | 4639.6 | -0.3% |
| gcc-11 | enwik9      | 4229.4 | 4214.8 | -0.3% |
| gcc-12 | silesia.tar | 4221.0 | 4250.4 | +0.7% |
| gcc-12 | calgary.tar | 3955.7 | 3972.3 | +0.4% |
| gcc-12 | enwik9      | 3654.9 | 3657.6 | +0.1% |
| gcc-13 | silesia.tar | 3919.7 | 3956.1 | +0.9% |
| gcc-13 | calgary.tar | 3656.5 | 3673.7 | +0.5% |
| gcc-13 | enwik9      | 3358.8 | 3380.0 | +0.6% |
| gcc-14 | silesia.tar | 3753.2 | 4324.6 | **+15.2%** |
| gcc-14 | calgary.tar | 3435.3 | 4166.4 | **+21.3%** |
| gcc-14 | enwik9      | 3174.1 | 3815.9 | **+20.2%** |
| clang-14 | silesia.tar | 3792.0 | 4126.4 | **+8.8%** |
| clang-14 | calgary.tar | 3462.1 | 3911.2 | **+13.0%** |
| clang-14 | enwik9      | 3199.9 | 3591.5 | **+12.2%** |
| clang-15 | silesia.tar | 3754.2 | 3942.0 | +5.0% |
| clang-15 | calgary.tar | 3434.6 | 3656.6 | +6.5% |
| clang-15 | enwik9      | 3178.6 | 3365.7 | +5.9% |
| clang-16 | silesia.tar | 4230.0 | 4133.9 | -2.3% |
| clang-16 | calgary.tar | 3948.8 | 3923.1 | -0.7% |
| clang-16 | enwik9      | 3592.4 | 3600.1 | +0.2% |
| clang-17 | silesia.tar | 4389.5 | 3806.7 | **-13.3%** |
| clang-17 | calgary.tar | 4247.7 | 3453.1 | **-18.7%** |
| clang-17 | enwik9      | 3840.5 | 3214.3 | **-16.3%** |
| clang-18 | silesia.tar | 3957.2 | 3955.6 | ~0% |
| clang-18 | calgary.tar | 3664.4 | 3670.2 | +0.2% |
| clang-18 | enwik9      | 3387.5 | 3399.1 | +0.3% |
| clang-19 | silesia.tar | 3940.9 | 3969.8 | +0.7% |
| clang-19 | calgary.tar | 3659.9 | 3670.8 | +0.3% |
| clang-19 | enwik9      | 3385.7 | 3394.7 | +0.3% |
