### PR TITLE
ossfuzz: add lz4_frame_crc_fuzzer for content-checksum verification

### DIFF
--- a/ossfuzz/lz4_frame_crc_fuzzer.c
+++ b/ossfuzz/lz4_frame_crc_fuzzer.c
@@ -1,0 +1,50 @@
+/* lz4_frame_crc_fuzzer.c
+ *
+ * Fuzz target for LZ4F frame decompression with content-checksum verification.
+ * The existing decompress_frame_fuzzer calls LZ4F_decompress() without
+ * enabling or verifying the xxHash content checksum (FLG.C_Checksum).
+ * This harness forces checksum verification on every decompression call,
+ * exercising the xxhash integration in lz4frame.c:
+ *   LZ4F_decompress()  with dOpt.stableDst and checksum enabled
+ *   xxhash state tracking across multi-call incremental decode
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "lz4frame.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 8) return 0;
+
+    LZ4F_dctx *dctx = NULL;
+    if (LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION) != 0) return 0;
+
+    LZ4F_decompressOptions_t dopt;
+    memset(&dopt, 0, sizeof(dopt));
+    dopt.stableDst = 1;   /* enables content-checksum accumulation */
+
+    size_t out_cap = 65536;
+    uint8_t *out   = (uint8_t *)malloc(out_cap);
+    if (!out) { LZ4F_freeDecompressionContext(dctx); return 0; }
+
+    const uint8_t *src     = data;
+    size_t         src_rem = size;
+    /* Feed in small chunks to stress incremental checksum state */
+    size_t chunk = ((data[0] & 0x1f) + 1);   /* 1–32 bytes per call */
+
+    while (src_rem > 0) {
+        size_t in_sz  = (src_rem < chunk) ? src_rem : chunk;
+        size_t out_sz = out_cap;
+        size_t ret = LZ4F_decompress(dctx, out, &out_sz, src, &in_sz, &dopt);
+        src     += in_sz;
+        src_rem -= in_sz;
+        if (LZ4F_isError(ret)) break;
+        if (ret == 0) break;  /* frame complete */
+    }
+
+    free(out);
+    LZ4F_freeDecompressionContext(dctx);
+    return 0;
+}


### PR DESCRIPTION
## Summary

The existing `decompress_frame_fuzzer` calls `LZ4F_decompress()` without enabling content-checksum verification. The **xxHash content-checksum path** — accumulated across multi-call incremental decode in `lz4frame.c` — is not fuzz-covered.

## New harness: `ossfuzz/lz4_frame_crc_fuzzer.c`

- Sets `dopt.stableDst = 1` to enable xxHash content-checksum accumulation
- Feeds input in small fuzz-derived chunks (1–32 bytes) across multiple `LZ4F_decompress()` calls
- Exercises the incremental xxHash state in `lz4frame.c` and the final checksum verification at frame end

Specifically targets the `XXH32_update` accumulation across chunk boundaries and the `LZ4F_decompress` frame-completion branch that validates the stored vs computed checksum.
