### PR TITLE
ci: pin actions in cmake-test.yml to full commit SHAs

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up MSVC (Windows)
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
       with:
         cmake-version: latest
 
@@ -79,10 +79,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
       with:
         cmake-version: ${{ matrix.test_type == 'cmake_versions' && '3.10.0' || 'latest' }}
 
@@ -122,6 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Test via Makefile
       run: make clean && make cmakebuild


### PR DESCRIPTION
## Summary

`cmake-test.yml` uses three mutable action tag references that can be silently re-pointed to different commits, creating a supply-chain risk.

### Changes

Pin each `uses:` to its full commit SHA (original tag kept as a comment):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6.0.2` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `microsoft/setup-msbuild` | `@v3` | `@30375c66a4eea26614e0d39710365f22f8b0af57` |
| `jwlawson/actions-setup-cmake` | `@v2` | `@0d6a7d60b009d01c9e7523be22153ff8f19460d3` |

The workflow already has `permissions: contents: read` so no change needed there.

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.