### PR TITLE
Improve LZ4 HC match search early exit

### DIFF
--- a/lib/lz4hc.c
+++ b/lib/lz4hc.c
@@ -971,6 +971,8 @@ LZ4HC_InsertAndGetWiderMatch (
                         sBack = back;
                         DEBUGLOG(7, "Found match of len=%i within prefix, offset=%i, back=%i", longest, offset, -back);
                         HEX_CMP(7, ip + back, ip + back - offset, (size_t)matchLength);
+                        /* Early exit after a sufficiently strong match to avoid tail searches. */
+                        if (longest >= OPTIMAL_ML + 4) goto _findBestMatch_done;
             }   }   }
         } else {   /* lowestMatchIndex <= matchIndex < dictLimit : within Ext Dict */
             const BYTE* const matchPtr = dictStart + (matchIndex - dictIdx);
@@ -991,6 +993,8 @@ LZ4HC_InsertAndGetWiderMatch (
                     sBack = back;
                     DEBUGLOG(7, "Found match of len=%i within dict, offset=%i, back=%i", longest, offset, -back);
                     HEX_CMP(7, ip + back, matchPtr + back, (size_t)matchLength);
+                    /* Early exit after a sufficiently strong match to avoid tail searches. */
+                    if (longest >= OPTIMAL_ML + 4) goto _findBestMatch_done;
         }   }   }
 
         if (chainSwap && matchLength==longest) {   /* better match => select a better chain */
@@ -1095,6 +1099,7 @@ LZ4HC_InsertAndGetWiderMatch (
 
     }  /* while ((matchIndex>=lowestMatchIndex) && (nbAttempts)) */
 
+    _findBestMatch_done:
     if ( dict == usingDictCtxHc
       && nbAttempts > 0
       && withinStartDistance) {


### PR DESCRIPTION
## Summary

This improves `LZ4_compress_HC` performance by allowing the HC match finder to stop searching once it has already found a sufficiently strong match.

The cutoff uses `OPTIMAL_ML + 4`, which keeps the change small and limits the compression-ratio impact.

## Why

HC compression can spend extra time walking the match chain even after it has already found a strong match. For some inputs, that tail search adds compression time without producing a large enough improvement in output size.

This change exits the match search once the current best match reaches `OPTIMAL_ML + 4`.

## Local benchmark

Measured with `./tests/fullbench -i9 -c10 compressible.txt`.

Input size: `12,052,900 bytes`.

| Version | Speed | Compressed size | Ratio |
|---|---:|---:|---:|
| Baseline | 75.1 MB/s | 3,093,619 bytes | 25.67% |
| Optimized | 87.6 MB/s | 3,110,614 bytes | 25.81% |

This is about `+16.6%` faster on this local input, with compressed size increasing by `16,995 bytes` (`~0.55%`).