### PR TITLE
Fix integer overflow in read_variable_length() on 32-bit systems

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1995,6 +1995,10 @@ read_variable_length(const BYTE** ipPtr, const BYTE* ilimit)
     s = **ipPtr;
     (*ipPtr)++;
     length += s;
+    /* accumulator overflow detection (32-bit mode only) */
+    if ((sizeof(length) < 8) && unlikely(length > ((Rvl_t)(-1)/2)) ) {
+        return rvl_error;
+    }
     if (likely(s != 255)) return length;
     do {
         if (unlikely((*ipPtr) >= ilimit)) {    /* read limit reached */


### PR DESCRIPTION
The first addition in read_variable_length() was not checked for overflow, while subsequent additions in the loop were checked. On 32-bit systems where sizeof(length) < 8, this could allow an attacker to craft malicious input causing an integer overflow before the check, potentially leading to buffer overflows.

This fix adds the same overflow check after the initial addition that already exists in the loop, ensuring consistent overflow protection.