### PR TITLE
fix result buffer overflow in decode-only benchmark

### DIFF
--- a/programs/bench.c
+++ b/programs/bench.c
@@ -351,6 +351,7 @@ typedef struct {
     size_t cRoom;
     size_t cSize;
     char*  resPtr;
+    size_t resCapa;
     size_t resSize;
 } blockParam_t;
 
@@ -402,12 +403,15 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
             for ( ; nbBlocks<blockEnd; nbBlocks++) {
                 size_t const thisBlockSize = MIN(remaining, blockSize);
                 size_t const resMaxSize = thisBlockSize * decMultiplier;
-                size_t const resCapa = (thisBlockSize < maxInSize) ? resMaxSize : LZ4_MAX_INPUT_SIZE;
+                size_t resCapa = (thisBlockSize < maxInSize) ? resMaxSize : LZ4_MAX_INPUT_SIZE;
+                size_t const resRoomLeft = maxDecSize - (size_t)(resPtr - (char*)resultBuffer);
+                if (resCapa > resRoomLeft) resCapa = resRoomLeft;  /* never hand the decoder more room than is actually allocated */
                 blockTable[nbBlocks].srcPtr = srcPtr;
                 blockTable[nbBlocks].cPtr = cPtr;
                 blockTable[nbBlocks].resPtr = resPtr;
                 blockTable[nbBlocks].srcSize = thisBlockSize;
                 blockTable[nbBlocks].cRoom = (size_t)LZ4_compressBound((int)thisBlockSize);
+                blockTable[nbBlocks].resCapa = resCapa;
                 srcPtr += thisBlockSize;
                 cPtr += blockTable[nbBlocks].cRoom;
                 resPtr += resCapa;
@@ -522,13 +526,9 @@ static int BMK_benchMem(const void* srcBuffer, size_t srcSize,
                 for (nbLoops=0; nbLoops < nbDecodeLoops; nbLoops++) {
                     U32 blockNb;
                     for (blockNb=0; blockNb<nbBlocks; blockNb++) {
-                        size_t const inMaxSize = (size_t)INT_MAX / decMultiplier;
-                        size_t const resCapa = (blockTable[blockNb].srcSize < inMaxSize) ?
-                                                blockTable[blockNb].srcSize * decMultiplier :
-                                                INT_MAX;
                         int const regenSize = decFunction(
                             blockTable[blockNb].cPtr, blockTable[blockNb].resPtr,
-                            (int)blockTable[blockNb].cSize, (int)resCapa,
+                            (int)blockTable[blockNb].cSize, (int)blockTable[blockNb].resCapa,
                             dictBuf, dictSize);
                         if (regenSize < 0) {
                             DISPLAY("%s() failed on block %u of size %u \n",


### PR DESCRIPTION
In decode-only mode (`lz4 -b -d`) BMK_benchMem allocates the result buffer with each block's capacity clamped to LZ4_MAX_INPUT_SIZE, but the decode loop recomputes the destination capacity with an INT_MAX clamp instead, so for a compressed frame around 8.3 MB it hands LZ4F_decompress up to ~28 MB more room than was actually allocated and a frame expanding past 2 GB writes past the buffer. The multi-file layout shares the same root cause, since the per-block capacities can sum past the total-clamped allocation. The fix stores the capacity computed when the buffer is laid out, caps it to the room actually left, and reuses that value in the decode loop.

Reproduced with a frame that expands just past the cap:

```
head -c 2130000000 /dev/zero | ./lz4 -1 -c > big.lz4   # ~8.36 MB frame
./lz4 -b -d big.lz4        # built with -fsanitize=address
```

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 16
    #1 LZ4_decompress_safe lz4.c
    #2 LZ4F_decompress lz4frame.c
    #3 LZ4F_decompress_binding bench.c:331
    #4 BMK_benchCLevel bench.c
0x... is located 0 bytes after 2113929216-byte region
```

After the patch the same input reports a decode error for that block instead of writing out of bounds, and normal single-file, multi-file, and multi-level benchmarks are unchanged.
