### PR TITLE
Enable bounds-safety checks for lz4file

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -82,6 +82,11 @@ jobs:
         make clean
         CFLAGS="-Werror -O0" make default V=1
 
+    - name: Test file API with bounds safety
+      run: |
+        export DEVELOPER_DIR="$(ls -d /Applications/Xcode_26*.app | head -n 1)/Contents/Developer"
+        make -C tests test-bounds-safety V=1 CC="xcrun cc"
+
     - name: Run comprehensive tests
       run: |
         make clean

--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -51,7 +51,7 @@ static LZ4F_errorCode_t returnErrorCode(LZ4F_errorCodes code)
 struct LZ4_readFile_s {
   LZ4F_dctx* dctxPtr;
   FILE* fp;
-  LZ4_byte* srcBuf;
+  LZ4_byte* LZ4F_FILE_SIZED_BY(srcBufMaxSize) srcBuf;
   size_t srcBufNext;
   size_t srcBufSize;
   size_t srcBufMaxSize;
@@ -93,17 +93,18 @@ static LZ4F_errorCode_t readAndParseHeader(LZ4_readFile_t* readFile, FILE* fp)
 
     /* Determine buffer size based on block size */
     { const size_t blockSize = LZ4F_getBlockSize(frameInfo.blockSizeID);
+      LZ4_byte* srcBuf;
       if (blockSize == 0) {
           RETURN_ERROR(maxBlockSize_invalid);
       }
-      readFile->srcBufMaxSize = blockSize;
-    }
-
-    /* Allocate source buffer */
-    assert(readFile->srcBuf == NULL); /* Should be NULL from calloc */
-    readFile->srcBuf = (LZ4_byte*)malloc(readFile->srcBufMaxSize);
-    if (readFile->srcBuf == NULL) {
+      /* Allocate source buffer */
+      srcBuf = (LZ4_byte*)malloc(blockSize);
+      if (srcBuf == NULL) {
         RETURN_ERROR(allocation_failed);
+      }
+      assert(readFile->srcBuf == NULL); /* Should be NULL from calloc */
+      readFile->srcBufMaxSize = blockSize;
+      readFile->srcBuf = srcBuf;
     }
 
     /* Store remaining header data in buffer */
@@ -118,7 +119,7 @@ static LZ4F_errorCode_t readAndParseHeader(LZ4_readFile_t* readFile, FILE* fp)
 
 LZ4F_errorCode_t LZ4F_readOpen(LZ4_readFile_t** lz4fRead, FILE* fp)
 {
-    LZ4_readFile_t* readFile;
+    LZ4_readFile_t* LZ4F_FILE_SINGLE readFile;
 
     /* Validate parameters */
     if (fp == NULL || lz4fRead == NULL) {
@@ -151,7 +152,7 @@ LZ4F_errorCode_t LZ4F_readOpen(LZ4_readFile_t** lz4fRead, FILE* fp)
     return LZ4F_OK_NoError;
 }
 
-size_t LZ4F_read(LZ4_readFile_t* lz4fRead, void* buf, size_t size)
+size_t LZ4F_read(LZ4_readFile_t* lz4fRead, void* LZ4F_FILE_SIZED_BY(size) buf, size_t size)
 {
   LZ4_byte* outPtr = (LZ4_byte*)buf;
   size_t totalBytesRead = 0;
@@ -208,7 +209,7 @@ LZ4F_errorCode_t LZ4F_readClose(LZ4_readFile_t* lz4fRead)
 struct LZ4_writeFile_s {
   LZ4F_cctx* cctxPtr;
   FILE* fp;
-  LZ4_byte* dstBuf;
+  LZ4_byte* LZ4F_FILE_SIZED_BY(dstBufMaxSize) dstBuf;
   size_t maxWriteSize;
   size_t dstBufMaxSize;
   LZ4F_errorCode_t errCode;
@@ -252,7 +253,7 @@ static LZ4F_errorCode_t writeHeader(LZ4_writeFile_t* writeFile,
 
 LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4F_preferences_t* prefsPtr)
 {
-  LZ4_writeFile_t* writeFile;
+  LZ4_writeFile_t* LZ4F_FILE_SINGLE writeFile;
   size_t blockSize;
 
   if (fp == NULL || lz4fWrite == NULL)
@@ -275,11 +276,14 @@ LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4
   writeFile->maxWriteSize = blockSize;
 
   /* Calculate and allocate destination buffer */
-  writeFile->dstBufMaxSize = LZ4F_compressBound(blockSize, prefsPtr);
-  writeFile->dstBuf = (LZ4_byte*)malloc(writeFile->dstBufMaxSize);
-  if (writeFile->dstBuf == NULL) {
-    freeAndNullWriteFile(&writeFile);
-    RETURN_ERROR(allocation_failed);
+  { size_t const dstBufMaxSize = LZ4F_compressBound(blockSize, prefsPtr);
+    LZ4_byte* const dstBuf = (LZ4_byte*)malloc(dstBufMaxSize);
+    if (dstBuf == NULL) {
+      freeAndNullWriteFile(&writeFile);
+      RETURN_ERROR(allocation_failed);
+    }
+    writeFile->dstBufMaxSize = dstBufMaxSize;
+    writeFile->dstBuf = dstBuf;
   }
 
   /* Initialize compression context */
@@ -300,7 +304,7 @@ LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4
   return LZ4F_OK_NoError;
 }
 
-size_t LZ4F_write(LZ4_writeFile_t* lz4fWrite, const void* buf, size_t size)
+size_t LZ4F_write(LZ4_writeFile_t* lz4fWrite, const void* LZ4F_FILE_SIZED_BY(size) buf, size_t size)
 {
   const LZ4_byte* p = (const LZ4_byte*)buf;
   size_t remainingBytes = size;

--- a/lib/lz4file.h
+++ b/lib/lz4file.h
@@ -42,6 +42,25 @@ extern "C" {
 #include <stdio.h>  /* FILE* */
 #include "lz4frame_static.h"
 
+#if defined(__has_include)
+#  if __has_include(<ptrcheck.h>)
+#    include <ptrcheck.h>
+#  endif
+#endif
+
+/* Optional pointer annotations for Clang's bounds-safety extension. */
+#if defined(__sized_by)
+#  define LZ4F_FILE_SIZED_BY(size) __sized_by(size)
+#else
+#  define LZ4F_FILE_SIZED_BY(size)
+#endif
+
+#if defined(__single)
+#  define LZ4F_FILE_SINGLE __single
+#else
+#  define LZ4F_FILE_SINGLE
+#endif
+
 typedef struct LZ4_readFile_s LZ4_readFile_t;
 typedef struct LZ4_writeFile_s LZ4_writeFile_t;
 
@@ -54,6 +73,7 @@ typedef struct LZ4_writeFile_s LZ4_writeFile_t;
  * @param lz4fRead  Pointer to receive the read file handle.
  *                  It is an OUT parameter, so its initial value is ignored and will be overwritten.
  *                  Its value on exit is only valid if the function returns LZ4F_OK_NoError.
+ *                  With -fbounds-safety, declare the handle with LZ4F_FILE_SINGLE.
  * @param fp        FILE* positioned at start of LZ4 file (binary mode).
  *
  * @return LZ4F_OK_NoError on success, or error code on failure.
@@ -69,7 +89,7 @@ LZ4FLIB_STATIC_API LZ4F_errorCode_t LZ4F_readOpen(LZ4_readFile_t** lz4fRead, FIL
  * `buf` read data buffer.
  * `size` read data buffer size.
  */
-LZ4FLIB_STATIC_API size_t LZ4F_read(LZ4_readFile_t* lz4fRead, void* buf, size_t size);
+LZ4FLIB_STATIC_API size_t LZ4F_read(LZ4_readFile_t* lz4fRead, void* LZ4F_FILE_SIZED_BY(size) buf, size_t size);
 
 /*! LZ4F_readClose() :
  * Close lz4file handle.
@@ -86,6 +106,7 @@ LZ4FLIB_STATIC_API LZ4F_errorCode_t LZ4F_readClose(LZ4_readFile_t* lz4fRead);
  * @param lz4fWrite Pointer to receive the write file handle.
  *                  It is an OUT parameter, so its initial value is ignored and will be overwritten.
  *                  Its value on exit is only valid if the function returns LZ4F_OK_NoError.
+ *                  With -fbounds-safety, declare the handle with LZ4F_FILE_SINGLE.
  * @param fp        FILE* positioned at start of LZ4 file (binary mode).
  *
  * @return LZ4F_OK_NoError on success, or error code on failure.
@@ -101,7 +122,7 @@ LZ4FLIB_STATIC_API LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, 
  * `buf` write data buffer.
  * `size` write data buffer size.
  */
-LZ4FLIB_STATIC_API size_t LZ4F_write(LZ4_writeFile_t* lz4fWrite, const void* buf, size_t size);
+LZ4FLIB_STATIC_API size_t LZ4F_write(LZ4_writeFile_t* lz4fWrite, const void* LZ4F_FILE_SIZED_BY(size) buf, size_t size);
 
 /*! LZ4F_writeClose() :
  * Close lz4file handle.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -124,6 +124,11 @@ $(eval $(call c_program_shared_o,fuzzer,lz4.o lz4hc.o xxhash.o fuzzer.o))
 frametest:
 $(eval $(call c_program_shared_o,frametest,lz4frame.o lz4file.o lz4.o lz4hc.o xxhash.o frametest.o))
 
+boundsSafety:
+$(eval $(call c_program_shared_o,boundsSafety,lz4frame.o lz4file.o lz4.o lz4hc.o xxhash.o boundsSafety.o))
+
+$(CACHE_ROOT)/%/lz4file.o $(CACHE_ROOT)/%/boundsSafety.o: CFLAGS += $(BOUNDS_SAFETY_FLAGS)
+
 roundTripTest:
 $(eval $(call c_program_shared_o,roundTripTest,lz4.o lz4hc.o xxhash.o roundTripTest.o))
 
@@ -195,6 +200,12 @@ test_targets:
 check: test-lz4-essentials
 
 test: test-lz4 test-lz4c test-frametest test-fullbench test-fuzzer test-amalgamation listTest test-decompress-partial
+
+.PHONY: test-bounds-safety
+test-bounds-safety:
+	$(MAKE) CACHE_ROOT=$(CACHE_ROOT)/bounds-safety BOUNDS_SAFETY_FLAGS="-fbounds-safety -Werror" boundsSafety frametest
+	./boundsSafety
+	./frametest -s1 -i1000
 
 test32: CFLAGS+=-m32
 test32: test

--- a/tests/boundsSafety.c
+++ b/tests/boundsSafety.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Yann Collet and LZ4 contributors.
+ * All rights reserved.
+ *
+ * This source code is licensed under both the BSD-style license (found in the
+ * LICENSE file in the root directory of this source tree) and the GPLv2 (found
+ * in the COPYING file in the root directory of this source tree),
+ * meaning you may select, at your option, one of the above-listed licenses.
+ */
+
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "lz4file.h"
+
+int main(void)
+{
+    FILE* const file = tmpfile();
+    LZ4_readFile_t* LZ4F_FILE_SINGLE readFile = NULL;
+    LZ4_writeFile_t* LZ4F_FILE_SINGLE writeFile = NULL;
+    struct rlimit const noCore = { 0, 0 };
+    char input[1] = { 0 };
+    int childStatus;
+    pid_t child;
+
+    if (file == NULL) return 1;
+    if (LZ4F_isError(LZ4F_writeOpen(&writeFile, file, NULL))) return 1;
+    if (setrlimit(RLIMIT_CORE, &noCore) != 0) return 1;
+
+    /* The annotated write API must trap before reading past input. */
+    child = fork();
+    if (child == 0) {
+        volatile size_t inputSize = sizeof(input) + 1;
+        (void)LZ4F_write(writeFile, input, inputSize);
+        _exit(0);
+    }
+    if (child < 0) return 1;
+    if (waitpid(child, &childStatus, 0) != child) return 1;
+    if (!WIFSIGNALED(childStatus)) return 1;
+
+    if (LZ4F_write(writeFile, input, sizeof(input)) != sizeof(input)) return 1;
+    if (LZ4F_isError(LZ4F_writeClose(writeFile))) return 1;
+
+    rewind(file);
+    if (LZ4F_isError(LZ4F_readOpen(&readFile, file))) return 1;
+
+    /* The annotated read API must trap before writing past output. */
+    child = fork();
+    if (child == 0) {
+        char output[1];
+        volatile size_t outputSize = sizeof(output) + 1;
+        (void)LZ4F_read(readFile, output, outputSize);
+        _exit(0);
+    }
+    if (child < 0) return 1;
+    if (waitpid(child, &childStatus, 0) != child) return 1;
+    if (!WIFSIGNALED(childStatus)) return 1;
+
+    if (LZ4F_isError(LZ4F_readClose(readFile))) return 1;
+    if (fclose(file) != 0) return 1;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- adopt Clang's `-fbounds-safety` for `lz4file.c` as a first file-by-file stage for #1552
- annotate the public read/write buffers and internal file buffers with their byte capacities
- add a focused runtime trap test and a short hardened frame regression run on macOS

## Details

Clang's adoption guide recommends enabling bounds safety one C file at a time. Applying the flag to the complete library still produces diagnostics throughout the compression core, so this change intentionally limits the first stage to the file API rather than weakening checks or marking the entire library as migrated.

The public `LZ4F_read()` and `LZ4F_write()` buffers now use ABI-neutral `__sized_by` annotations. The internal source and destination buffers are tied to their allocation capacities. Their initialization uses local pointer/size values followed by consecutive dependent-field assignments, which keeps the bounded-pointer invariant valid.

The compatibility macros expand to nothing on toolchains without pointer-checking support, and normal C and C++ builds retain the existing ABI.

`test-bounds-safety` compiles only `lz4file.c` and its focused test with `-fbounds-safety -Werror`; the remaining core files keep their ordinary flags. The test requires oversized public read and write calls to trap, then runs the existing frame unit tests and 1,000 deterministic fuzz cases with the hardened file object.

## Tests

- `make -C tests test-bounds-safety V=1 CC="xcrun cc"`
- `make -C tests test-frametest`
- `make check`
- `CFLAGS="-Werror -O0" make default`
- `make -C examples test`
- GCC 15 library/examples builds with `-Werror`
- Apple Clang/GCC C90 and Apple Clang++/G++ header compatibility checks