### PR TITLE
lz4file: fix wrong pointer freed on LZ4F_writeOpen() error path

### DIFF
--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -285,7 +285,7 @@ LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4
   /* Initialize compression context */
   { LZ4F_errorCode_t const status = LZ4F_createCompressionContext(&writeFile->cctxPtr, LZ4F_VERSION);
     if (LZ4F_isError(status)) {
-        freeAndNullWriteFile(lz4fWrite);
+        freeAndNullWriteFile(&writeFile);
         return status;
   } }
 


### PR DESCRIPTION
When LZ4F_createCompressionContext() fails inside LZ4F_writeOpen(), the cleanup called freeAndNullWriteFile(lz4fWrite) -- the caller's output parameter, which has not been assigned yet (*lz4fWrite is only set on the success path). freeWriteFileResources() then dereferences and free()s the caller's uninitialized/stale pointer, and the freshly allocated writeFile struct and its dstBuf are leaked.

The two other error paths in the same function already use freeAndNullWriteFile(&writeFile); make this one consistent.

This problem had been confirmed with an ASan/LSan PoC that injects the allocation failure (--wrap=calloc): SEGV in freeWriteFileResources (lz4file.c:220) and a 48-byte leak without the fix; clean error return with the fix.