### PR TITLE
util: check UTIL_realloc result before computing *bufEnd in UTIL_prep…

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -408,8 +408,8 @@ UTIL_STATIC int UTIL_prepareFileList(const char* dirName, char** bufStart, size_
             if (*bufStart + *pos + pathLength >= *bufEnd) {
                 ptrdiff_t newListSize = (*bufEnd - *bufStart) + LIST_SIZE_INCREASE;
                 *bufStart = (char*)UTIL_realloc(*bufStart, newListSize);
-                *bufEnd = *bufStart + newListSize;
                 if (*bufStart == NULL) { free(path); FindClose(hFile); return 0; }
+                *bufEnd = *bufStart + newListSize;
             }
             if (*bufStart + *pos + pathLength < *bufEnd) {
                 strncpy(*bufStart + *pos, path, *bufEnd - (*bufStart + *pos));
@@ -465,8 +465,8 @@ UTIL_STATIC int UTIL_prepareFileList(const char* dirName, char** bufStart, size_
             if (*bufStart + *pos + pathLength >= *bufEnd) {
                 size_t const newListSize = (size_t)(*bufEnd - *bufStart) + LIST_SIZE_INCREASE;
                 *bufStart = (char*)UTIL_realloc(*bufStart, newListSize);
-                *bufEnd = *bufStart + newListSize;
                 if (*bufStart == NULL) { free(path); closedir(dir); return 0; }
+                *bufEnd = *bufStart + newListSize;
             }
             if (*bufStart + *pos + pathLength < *bufEnd) {
                 strncpy(*bufStart + *pos, path, *bufEnd - (*bufStart + *pos));


### PR DESCRIPTION
…areFileList

In both the _WIN32 and the POSIX variant of UTIL_prepareFileList(), the buffer-growth branch computed

    *bufEnd = *bufStart + newListSize;

before checking whether UTIL_realloc() succeeded. UTIL_realloc frees the old block and returns NULL on failure, so the statement performs pointer arithmetic on a null pointer (undefined behavior, C17 6.5.6) and leaves *bufEnd holding a bogus non-NULL extent.

Found via cppcheck nullPointerArithmeticRedundantCheck warnings (util.h:411 and util.h:468); confirmed end-to-end by building the real lz4 CLI with clang -fsanitize=pointer-overflow and failing the growth realloc via LD_PRELOAD: 'util.h:468:37: runtime error: applying non-zero offset 16384 to null pointer'. With this patch the same run completes with no sanitizer report.