### PR TITLE
ossfuzz: restore full-width data producer values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ list:
 .PHONY: check
 check:
 	$(MAKE) -C $(TESTDIR) test-lz4-essentials
+	$(MAKE) -C $(FUZZDIR) test
 
 .PHONY: test
 test:

--- a/ossfuzz/Makefile
+++ b/ossfuzz/Makefile
@@ -36,6 +36,8 @@ LZ4_CXXFLAGS = $(CXXFLAGS) $(DEBUGFLAGS) $(MOREFLAGS)
 LZ4_CPPFLAGS = $(CPPFLAGS) -I$(LZ4DIR) -DXXH_NAMESPACE=LZ4_ \
                -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
+FUZZ_DATA_PRODUCER_TEST := fuzz_data_producer_test$(EXT)
+
 FUZZERS := \
 	compress_fuzzer \
 	decompress_fuzzer \
@@ -50,6 +52,10 @@ FUZZERS := \
 
 .PHONY: all
 all: $(FUZZERS)
+
+.PHONY: test
+test: $(FUZZ_DATA_PRODUCER_TEST)
+	./$(FUZZ_DATA_PRODUCER_TEST)
 
 # Include a rule to build the static library if calling this target
 # directly.
@@ -68,6 +74,9 @@ endif
 %_fuzzer: %_fuzzer.o lz4_helpers.o fuzz_data_producer.o $(LZ4DIR)/liblz4.a $(LIB_FUZZING_DEPS)
 	$(CXX) $(LZ4_CXXFLAGS) $(LZ4_CPPFLAGS) $(LDFLAGS) $(LIB_FUZZING_ENGINE) $^ -o $@$(EXT)
 
+$(FUZZ_DATA_PRODUCER_TEST): fuzz_data_producer_test.o fuzz_data_producer.o
+	$(CC) $(LZ4_CFLAGS) $(LZ4_CPPFLAGS) $(LDFLAGS) $^ -o $@
+
 %_fuzzer_clean:
 	$(RM) $*_fuzzer $*_fuzzer.o standaloneengine.o
 
@@ -76,4 +85,5 @@ clean: compress_fuzzer_clean decompress_fuzzer_clean \
 	compress_frame_fuzzer_clean compress_hc_fuzzer_clean \
 	decompress_frame_fuzzer_clean round_trip_frame_fuzzer_clean \
 	round_trip_fuzzer_clean round_trip_hc_fuzzer_clean round_trip_stream_fuzzer_clean
+	$(RM) $(FUZZ_DATA_PRODUCER_TEST) fuzz_data_producer_test.o fuzz_data_producer.o
 	$(MAKE) -C $(LZ4DIR) clean

--- a/ossfuzz/fuzz_data_producer.c
+++ b/ossfuzz/fuzz_data_producer.c
@@ -27,7 +27,10 @@ uint32_t FUZZ_dataProducer_retrieve32(FUZZ_dataProducer_t *producer) {
         return (uint32_t)data[size - 1];
     } else {
         producer->size -= 4;
-        return *(data + size - 4);
+        return (uint32_t)data[size - 4]
+             | ((uint32_t)data[size - 3] << 8)
+             | ((uint32_t)data[size - 2] << 16)
+             | ((uint32_t)data[size - 1] << 24);
     }
 }
 

--- a/ossfuzz/fuzz_data_producer.h
+++ b/ossfuzz/fuzz_data_producer.h
@@ -16,7 +16,7 @@ FUZZ_dataProducer_t *FUZZ_dataProducer_create(const uint8_t *data, size_t size);
 /* Frees the data producer */
 void FUZZ_dataProducer_free(FUZZ_dataProducer_t *producer);
 
-/* Returns 32 bits from the end of data */
+/* Returns 32 bits in little-endian order from the end of data */
 uint32_t FUZZ_dataProducer_retrieve32(FUZZ_dataProducer_t *producer);
 
 /* Returns value between [min, max] */

--- a/ossfuzz/fuzz_data_producer_test.c
+++ b/ossfuzz/fuzz_data_producer_test.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "fuzz_data_producer.h"
+
+static int expect32(uint32_t actual, uint32_t expected, const char* name)
+{
+    if (actual == expected) return 0;
+    fprintf(stderr, "%s: expected 0x%08x, got 0x%08x\n", name, (unsigned)expected, (unsigned)actual);
+    return 1;
+}
+
+int main(void)
+{
+    static const uint8_t data[]   = {0xAA, 0x01, 0x23, 0x45, 0x67};
+    FUZZ_dataProducer_t* producer = FUZZ_dataProducer_create(data, sizeof(data));
+    int                  result   = 0;
+
+    result |= expect32(FUZZ_dataProducer_retrieve32(producer), 0x67452301U, "four-byte value");
+    result |= expect32((uint32_t)FUZZ_dataProducer_remainingBytes(producer), 1U, "four-byte consumption");
+    result |= expect32(FUZZ_dataProducer_retrieve32(producer), 0xAAU, "single-byte value");
+    result |= expect32((uint32_t)FUZZ_dataProducer_remainingBytes(producer), 0U, "single-byte consumption");
+    result |= expect32(FUZZ_dataProducer_retrieve32(producer), 0U, "empty value");
+
+    FUZZ_dataProducer_free(producer);
+    return result;
+}


### PR DESCRIPTION
## Summary

- return all four consumed bytes from `FUZZ_dataProducer_retrieve32()` in a deterministic little-endian order
- add a focused regression test for full-width values and producer byte consumption
- run the regression test from the existing top-level `check` target

## Why

When at least four bytes remained, `FUZZ_dataProducer_retrieve32()` decremented the remaining size by four but dereferenced only `data[size - 4]`. Every supposedly 32-bit control was therefore limited to 0..255.

This systematically narrowed several OSS-Fuzz targets. For example, `decompress_frame_fuzzer` intended to vary dictionary size over 0..64 KiB but could only select 0..255 bytes. Destination-capacity controls were similarly capped at 255 for larger inputs. The official OSS-Fuzz project invokes this repository's `ossfuzz/ossfuzz.sh`, so the helper is used by the continuous fuzz targets.

The regression test fails on the previous tip with:

```text
four-byte value: expected 0x67452301, got 0x00000001
```

and passes with this change.

## Validation

- `make -j2 check`
- `make -C ossfuzz -j2 all test`
- focused ASan/UBSan regression test
- 60-second ASan/UBSan/libFuzzer block-decoder campaign: 3,014,782 executions, no sanitizer finding

Fixed-seed, 30-second A/B campaigns from empty corpora produced these final corpus metrics:

| Target | Version | Edges | Features | Max input | Executions |
| --- | --- | ---: | ---: | ---: | ---: |
| block decoder | previous tip | 933 | 3,501 | 260 B | 2,594,359 |
| block decoder | this change | 939 | 4,009 | 3,429 B | 1,606,331 |
| frame decoder | previous tip | 1,337 | 4,013 | 581 B | 2,278,052 |
| frame decoder | this change | 1,521 | 4,397 | 1,748 B | 1,501,979 |

The corrected helper reached broader states despite executing fewer test cases in both comparisons.