### PR TITLE
[ci] restore FreeBSD testing on GitHub Actions

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,45 @@
+# FreeBSD testing, in a VM on a Linux runner
+name: FreeBSD
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  freebsd:
+    name: FreeBSD ${{ matrix.release }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ['14', '15']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Build and test in a FreeBSD VM
+      timeout-minutes: 30
+      uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1.5.3
+      with:
+        # Only the leading part of the version is needed, the newest matching
+        # release is used, so this tracks 14.4 and 15.1 without an edit here.
+        release: ${{ matrix.release }}
+        usesh: true
+        copyback: false
+        cache-after-prepare: true
+        prepare: |
+          # tests/Makefile runs test-lz4-list.py through $(PYTHON); the base
+          # system has no python, which is why listTest exits 127 without it.
+          pkg install -y gmake python3
+        run: |
+          set -e
+          cc -v
+          gmake test


### PR DESCRIPTION
.cirrus.yml went away with Cirrus in 9a64b896, and with it the only FreeBSD
coverage. This puts the same task back as a GitHub Actions workflow, running
FreeBSD in a VM on the Linux runner.

It is the old task, unchanged: cc -v, then gmake test.

One addition. tests/Makefile:156 runs test-lz4-list.py through $(PYTHON),
and the FreeBSD base system has no python, so listTest exits 127 and takes
gmake test down with it. The Cirrus images happened to ship one; these do
not, so python3 joins gmake in the install step.

The old task ran 15 only. This runs 14 and 15 -- the release input takes the
leading part of the version and picks the newest match, so '14' and '15'
follow 14.4 and 15.1 without an edit here.

Both green on a fork. Each job is four to five minutes end to end, VM boot
and package install included:

    FreeBSD 14  success  resolved 14.4  clang 19.1.7
    FreeBSD 15  success  resolved 15.1  clang 19.1.7

https://github.com/neilpang/lz4/actions/runs/31099898986

Both actions are pinned by commit with the version in a comment, matching
the other workflows.
