### PR TITLE
ci: pin third-party action references to full commit SHAs

### DIFF
--- a/.github/workflows/cmake-test.yml
+++ b/.github/workflows/cmake-test.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up MSVC (Windows)
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v3
+      uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3
 
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
       with:
         cmake-version: latest
 
@@ -79,10 +79,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Set up CMake
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2
       with:
         cmake-version: ${{ matrix.test_type == 'cmake_versions' && '3.10.0' || 'latest' }}
 
@@ -122,6 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Test via Makefile
       run: make clean && make cmakebuild

--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -23,14 +23,14 @@ jobs:
     steps:
     - name: Build Fuzzers
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@f9bb0e53534a5bf5a8e08524d10ad7b3fdfb0c7b # 2026-08-11
       with:
         oss-fuzz-project-name: 'lz4'
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
 
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@f9bb0e53534a5bf5a8e08524d10ad7b3fdfb0c7b # 2026-08-11
       with:
         oss-fuzz-project-name: 'lz4'
         fuzz-seconds: 100


### PR DESCRIPTION
## Summary

Two workflow files use mutable action references that could allow supply-chain attacks if the referenced repositories are compromised:

**`oss-fuzz.yml`** — both CI Fuzz steps reference `@master` (the highest-risk form: resolves to HEAD of `google/oss-fuzz` at runtime). Any commit pushed to that branch would immediately execute inside lz4's CI environment.

**`cmake-test.yml`** — three actions use version tags (`@v6.0.2`, `@v3`, `@v2`) instead of commit SHAs. This is inconsistent with the other eight workflow files in this repository, which all use the pinned SHA+comment form (e.g. `actions/checkout@de0fac2e... # v6.0.2`).

## Changes

| File | Action | Before | After |
|---|---|---|---|
| `oss-fuzz.yml` | `google/oss-fuzz/.../build_fuzzers` | `@master` | `@f9bb0e5...` |
| `oss-fuzz.yml` | `google/oss-fuzz/.../run_fuzzers` | `@master` | `@f9bb0e5...` |
| `cmake-test.yml` | `actions/checkout` | `@v6.0.2` | `@de0fac2...` (matches other workflows) |
| `cmake-test.yml` | `microsoft/setup-msbuild` | `@v3` | `@30375c6...` |
| `cmake-test.yml` | `jwlawson/actions-setup-cmake` | `@v2` | `@0d6a7d6...` |

No functional change. SHAs recorded are current as of 2026-08-11.