### PR TITLE
docs: require exact size for all synchronized-mode blocks

### DIFF
--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -520,7 +520,8 @@ LZ4LIB_API int LZ4_decoderRingBufferSize(int maxBlockSize);
  *  - Synchronized mode :
  *    Decompression buffer size is _exactly_ the same as compression buffer size,
  *    and follows exactly same update rule (block boundaries at same positions),
- *    and decoding function is provided with exact decompressed size of each block (exception for last block of the stream),
+ *    and decoding function is provided with exact decompressed size of each block
+ *    (including the last block of the stream),
  *    _then_ decoding & encoding ring buffer can have any size, including small ones ( < 64 KB).
  *  - Decompression buffer is larger than encoding buffer, by a minimum of maxBlockSize more bytes.
  *    In which case, encoding and decoding buffers do not need to be synchronized,


### PR DESCRIPTION
## Summary

The synchronized ring-buffer mode docs for `LZ4_decompress_safe_continue` said the exact decompressed size was required for each block with an "exception for last block of the stream". That exception is incorrect: using a larger `dstCapacity` on the last block can overwrite ring data still needed by later sequences in the same block and corrupt output.

Document that the exact decompressed size is required for every block, including the last.

## Test plan

- [x] Docs-only change in `lib/lz4.h`.
- [ ] No code behavior change.

Fixes #1779
