### PR TITLE
fix unvalidated blockSizeID in LZ4F_compressBegin_internal()

### DIFF
--- a/lib/lz4frame.c
+++ b/lib/lz4frame.c
@@ -715,6 +715,7 @@ static size_t LZ4F_compressBegin_internal(LZ4F_cctx* cctx,
 
     RETURN_ERROR_IF(dstCapacity < maxFHSize, dstMaxSize_tooSmall);
     if (preferencesPtr == NULL) preferencesPtr = &prefNull;
+    FORWARD_IF_ERROR( LZ4F_getBlockSize(preferencesPtr->frameInfo.blockSizeID) ); /* validate before modifying @cctx */
     cctx->prefs = *preferencesPtr;
     DEBUGLOG(5, "LZ4F_compressBegin_internal: Independent_blocks=%u", cctx->prefs.frameInfo.blockMode);
 

--- a/tests/frametest.c
+++ b/tests/frametest.c
@@ -728,6 +728,77 @@ static int unitTests(U32 seed, double compressibility)
         cctx = NULL;
     }
 
+    /* blockSizeID validation tests */
+    {   int const invalidBSID[] = { 1, 2, 3, 8, 9 };
+        int const validBSID[] = { 0 /* == default */, 4, 5, 6, 7 };
+        size_t const srcSize = 256 KB;
+        size_t nb;
+        LZ4F_preferences_t bsidPrefs;
+
+        assert(srcSize <= COMPRESSIBLE_NOISE_LENGTH);
+        CHECK( LZ4F_createCompressionContext(&cctx, LZ4F_VERSION) );
+
+        DISPLAYLEVEL(3, "LZ4F_compressBegin rejects invalid blockSizeID : ");
+        for (nb = 0; nb < sizeof(invalidBSID) / sizeof(invalidBSID[0]); nb++) {
+            memset(&bsidPrefs, 0, sizeof(bsidPrefs));
+            bsidPrefs.frameInfo.blockSizeID = (LZ4F_blockSizeID_t)invalidBSID[nb];
+            {   size_t const r = LZ4F_compressBegin(cctx, compressedBuffer, cBuffSize, &bsidPrefs);
+                if (!LZ4F_isError(r)) {
+                    DISPLAYLEVEL(3, "blockSizeID %i not rejected ! \n", invalidBSID[nb]);
+                    goto _output_error;
+        }   }   }
+        DISPLAYLEVEL(3, "OK \n");
+
+        DISPLAYLEVEL(3, "valid blockSizeID still accepted : ");
+        for (nb = 0; nb < sizeof(validBSID) / sizeof(validBSID[0]); nb++) {
+            memset(&bsidPrefs, 0, sizeof(bsidPrefs));
+            bsidPrefs.frameInfo.blockSizeID = (LZ4F_blockSizeID_t)validBSID[nb];
+            CHECK( LZ4F_compressFrame(compressedBuffer, cBuffSize,
+                                      CNBuffer, srcSize, &bsidPrefs) );
+        }
+        DISPLAYLEVEL(3, "OK \n");
+
+        DISPLAYLEVEL(3, "failed LZ4F_compressBegin preserves cctx : ");
+        {   BYTE* const ostart = (BYTE*)compressedBuffer;
+            BYTE* op = ostart;
+            size_t cErr;
+
+            memset(&bsidPrefs, 0, sizeof(bsidPrefs));
+            bsidPrefs.frameInfo.blockSizeID = LZ4F_max64KB;
+            bsidPrefs.frameInfo.contentChecksumFlag = LZ4F_contentChecksumEnabled;
+            CHECK_V(cErr, LZ4F_compressBegin(cctx, op, cBuffSize, &bsidPrefs));
+            op += cErr;
+
+            memset(&bsidPrefs, 0, sizeof(bsidPrefs));   /* must differ by more than blockSizeID */
+            bsidPrefs.frameInfo.blockSizeID = (LZ4F_blockSizeID_t)3;   /* invalid */
+            cErr = LZ4F_compressBegin(cctx, op, cBuffSize, &bsidPrefs);
+            if (!LZ4F_isError(cErr)) goto _output_error;
+
+            /* resume the frame started above */
+            CHECK_V(cErr, LZ4F_compressUpdate(cctx, op, cBuffSize - (size_t)(op-ostart),
+                                              CNBuffer, srcSize, NULL));
+            op += cErr;
+            CHECK_V(cErr, LZ4F_compressEnd(cctx, op, cBuffSize - (size_t)(op-ostart), NULL));
+            op += cErr;
+
+            {   size_t iSize = (size_t)(op - ostart);
+                size_t decodedSize = COMPRESSIBLE_NOISE_LENGTH;
+                LZ4F_decompressionContext_t dctx;
+                CHECK( LZ4F_createDecompressionContext(&dctx, LZ4F_VERSION) );
+                CHECK_V(cErr, LZ4F_decompress(dctx, decodedBuffer, &decodedSize, ostart, &iSize, NULL));
+                CHECK( LZ4F_freeDecompressionContext(dctx) );
+                if (cErr != 0) goto _output_error;   /* frame must be entirely decoded */
+                if (decodedSize != srcSize) goto _output_error;
+                {   U64 const crcDest = XXH64(decodedBuffer, decodedSize, extCrcSeed);
+                    U64 const crcSrc = XXH64(CNBuffer, srcSize, extCrcSeed);
+                    if (crcDest != crcSrc) goto _output_error;
+        }   }   }
+        DISPLAYLEVEL(3, "OK \n");
+
+        CHECK( LZ4F_freeCompressionContext(cctx) );
+        cctx = NULL;
+    }
+
     /* dictID tests */
     {   size_t cErr;
         U32 const dictID = 0x99;


### PR DESCRIPTION
### Summary

`LZ4F_getBlockSize()` returns an error code when `blockSizeID` is outside the documented `4..7` range, but `LZ4F_compressBegin_internal()` assigns that result to `cctx->maxBlockSize` without checking it. The error code is a huge `size_t`, so the buffer sizing that follows wraps around:

- `requiredBuffSize` becomes `~128 KB` instead of `maxBlockSize + 128 KB`, so `tmpBuff` is far too small;
- `LZ4F_compressBound()` wraps down to a handful of bytes.

A subsequent `LZ4F_compressUpdate()` then copies the input into that undersized `tmpBuff` and overflows it.

The decoder already rejects these values (`lz4frame.c`, `blockSizeID < 4` → `maxBlockSize_invalid`); this restores the same check on the compression side.

### Reproducer

```c
LZ4F_preferences_t prefs;
memset(&prefs, 0, sizeof(prefs));
prefs.frameInfo.blockSizeID = (LZ4F_blockSizeID_t)3;   /* invalid */

size_t cb = LZ4F_compressBound(1 MB, &prefs);          /* returns 4 (!) */
LZ4F_compressBegin(cctx, hdr, sizeof(hdr), &prefs);    /* returns 7, no error */
LZ4F_compressUpdate(cctx, dst, cb, src, 1 MB, NULL);   /* overflows */
```

Under ASan, before this patch:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 1048576 ... 0 bytes after 131070-byte region
    #1 LZ4F_compressUpdateImpl lz4frame.c:1112
    allocated by LZ4F_compressBegin_internal lz4frame.c:766
```

Affected entry points, before / after:

| entry point | before | after |
|---|---|---|
| `LZ4F_compressBegin` + `LZ4F_compressUpdate` | heap-buffer-overflow | `ERROR_maxBlockSize_invalid` |
| `LZ4F_compressFrame` | accepted; emits `BD=0x30`, undecodable | `ERROR_maxBlockSize_invalid` |
| `LZ4F_writeOpen` + `LZ4F_write` (lz4file) | heap-buffer-overflow | `ERROR_maxBlockSize_invalid` |
| valid IDs (`0`, `4`..`7`) | ok | unchanged |

**The `lz4` CLI is not affected** — `LZ4IO_setBlockSizeID()` already clamps to `4..7`. This reaches third-party callers of the `LZ4F_*` / `lz4file` APIs, which is likely why fuzzing hasn't surfaced it: the fuzzers drive the decoder with hostile input but the encoder with valid preferences.

### Note on the shape of the fix

The obvious one-liner is *not* sufficient:

```c
cctx->maxBlockSize = LZ4F_getBlockSize(cctx->prefs.frameInfo.blockSizeID);
FORWARD_IF_ERROR(cctx->maxBlockSize);   /* insufficient */
```

That writes the error code into `cctx->maxBlockSize` before returning. Since `LZ4F_compressBegin_internal()` does not clear `cStage` on the error path, a context that had already been initialized stays at `cStage == 1`, and the next `LZ4F_compressUpdate()` runs with the poisoned value:

```
compressBegin(valid)    -> ok
compressBegin(INVALID)  -> ERROR_maxBlockSize_invalid
compressUpdate(1 MB)    -> heap-buffer-overflow
```

Assigning only after validation avoids this. The added test covers that sequence and fails against the one-line variant.

### Tests

`tests/frametest.c` gains four checks in `unitTests()`:

1. `LZ4F_compressBegin()` rejects `blockSizeID` ∈ `{1,2,3,8,9}`
2. `LZ4F_compressFrame()` never emits an undecodable frame for those IDs
3. valid IDs `{0 (default),4,5,6,7}` still compress
4. a failed `LZ4F_compressBegin()` leaves an already initialized `cctx` intact

The test fails on `dev` (`blockSizeID 1 not rejected !`) and passes with the fix, in a plain non-sanitizer build.

Verified: `frametest -T20s`, `frametest` under ASan, C90 and C99 builds with `-Werror -Wpedantic`, `-Wc++-compat -Wall -Wextra -Werror` on `lz4frame.c`, `unicode_lint.sh`.

### Deliberately out of scope

- `LZ4F_compressBound()` still returns a wrapped-small value for an invalid `blockSizeID`. It is harmless once `LZ4F_compressBegin()` rejects the request (nothing is ever written), and #1786 is already open on that function — keeping this patch disjoint so both can land independently.
- Check 2 above asserts "no undecodable frame" rather than plain rejection because `LZ4F_optimalBSID()` may clamp an ID *above* the range down into range when `srcSize` is small (e.g. `8` → `5` for a 256 KB input), producing a valid frame. That is pre-existing behaviour and memory-safe either way, so it is left untouched.
