### PR TITLE
fix ineffective LZ4F_getBlockSize() error check in lz4file

### DIFF
--- a/lib/lz4file.c
+++ b/lib/lz4file.c
@@ -93,7 +93,7 @@ static LZ4F_errorCode_t readAndParseHeader(LZ4_readFile_t* readFile, FILE* fp)
 
     /* Determine buffer size based on block size */
     { const size_t blockSize = LZ4F_getBlockSize(frameInfo.blockSizeID);
-      if (blockSize == 0) {
+      if (LZ4F_isError(blockSize)) {
           RETURN_ERROR(maxBlockSize_invalid);
       }
       readFile->srcBufMaxSize = blockSize;
@@ -261,7 +261,7 @@ LZ4F_errorCode_t LZ4F_writeOpen(LZ4_writeFile_t** lz4fWrite, FILE* fp, const LZ4
   /* Validate block size */
   { LZ4F_blockSizeID_t const blockSizeID = prefsPtr ? prefsPtr->frameInfo.blockSizeID : LZ4F_default;
     blockSize = LZ4F_getBlockSize(blockSizeID);
-    if (blockSize == 0) {
+    if (LZ4F_isError(blockSize)) {
         RETURN_ERROR(maxBlockSize_invalid);
   } }
 


### PR DESCRIPTION
### Summary

`lz4file.c` checks the result of `LZ4F_getBlockSize()` against `0` at both of its call sites:

```c
const size_t blockSize = LZ4F_getBlockSize(frameInfo.blockSizeID);
if (blockSize == 0) {
    RETURN_ERROR(maxBlockSize_invalid);
}
```

But `LZ4F_getBlockSize()` signals failure by returning an error code — a large `size_t` (`(size_t)-2`), never `0`. Neither check has ever been able to fire.

### Impact

In `LZ4F_writeOpen()`, `blockSizeID` comes straight from the caller's `LZ4F_preferences_t` and is otherwise unvalidated. With a value outside the documented `4..7` range, the failed check lets a huge `blockSize` through; `LZ4F_compressBound()` then wraps around to a small value, and the undersized `dstBuf` is overflowed by the subsequent `LZ4F_write()`:

```c
LZ4F_preferences_t prefs;
memset(&prefs, 0, sizeof(prefs));
prefs.frameInfo.blockSizeID = (LZ4F_blockSizeID_t)3;   /* outside 4..7 */

LZ4F_writeOpen(&wf, fp, &prefs);    /* accepted */
LZ4F_write(wf, buf, 1 MB);          /* overflows */
```

Under ASan, on `dev`:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 1048576 ... 0 bytes after 131070-byte region
    #1 LZ4F_compressUpdateImpl lz4frame.c:1112
    #2 LZ4F_write lz4file.c:316
```

With this patch, `LZ4F_writeOpen()` returns `ERROR_maxBlockSize_invalid` and nothing is allocated.

In `readAndParseHeader()` the ID has already been validated by `LZ4F_decodeHeader()` (masked to 3 bits, `< 4` rejected), so that check cannot fire either way. It is repaired for consistency.

`LZ4F_getBlockSize(0)` is unaffected: `LZ4F_default` is mapped to `LZ4F_BLOCKSIZEID_DEFAULT` before the range check, so it is not an error and the default path still works.

### Relationship to #1788

Independent and complementary — neither supersedes the other.

#1788 fixes the same unchecked return value in `LZ4F_compressBegin_internal()`, which protects every `LZ4F_*` caller. This patch validates at the point where the caller's `blockSizeID` first enters `lz4file`, so the error is returned from `LZ4F_writeOpen()` itself rather than four allocations later from inside `writeHeader()`, and `lz4file` is protected regardless of #1788.

They touch different files and can be merged in either order.

### Verification

- `lz4file` write → read round-trip (300 KB) matches under ASan
- valid `blockSizeID` values `0` (default) and `4`..`7` unchanged
- `frametest -T20s`
- C90 build with `-Werror -Wpedantic`; `-Wc++-compat -Wall -Wextra -Werror` on `lz4file.c`
- `tests/unicode_lint.sh`
