### PR TITLE
avoid redundant state init in LZ4_compress_destSize_extState_internal()

### DIFF
--- a/lib/lz4.c
+++ b/lib/lz4.c
@@ -1489,12 +1489,12 @@ int LZ4_compress_default(const char* src, char* dst, int srcSize, int dstCapacit
  * _continue() call without resetting it. */
 static int LZ4_compress_destSize_extState_internal(LZ4_stream_t* state, const char* src, char* dst, int* srcSizePtr, int targetDstSize, int acceleration)
 {
-    void* const s = LZ4_initStream(state, sizeof (*state));
-    assert(s != NULL); (void)s;
-
     if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+        /* no need to initialize @state here: LZ4_compress_fast_extState() does it */
         return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
     } else {
+        void* const s = LZ4_initStream(state, sizeof (*state));
+        assert(s != NULL); (void)s;
         if (*srcSizePtr < LZ4_64Klimit) {
             return LZ4_compress_generic(&state->internal_donotuse, src, dst, *srcSizePtr, srcSizePtr, targetDstSize, fillOutput, byU16, noDict, noDictIssue, acceleration);
         } else {


### PR DESCRIPTION
### Summary

`LZ4_compress_destSize_extState_internal()` initializes `@state` up front, then — when `targetDstSize >= LZ4_compressBound(srcSize)` — delegates to `LZ4_compress_fast_extState()`, which starts by initializing `@state` again. The ~16 KB hash table is zeroed twice on that path.

The initialization moves into the other branch, which genuinely needs it because it invokes `LZ4_compress_generic()` directly.

```c
-    void* const s = LZ4_initStream(state, sizeof (*state));
-    assert(s != NULL); (void)s;
-
     if (targetDstSize >= LZ4_compressBound(*srcSizePtr)) {  /* compression success is guaranteed */
+        /* no need to initialize @state here: LZ4_compress_fast_extState() does it */
         return LZ4_compress_fast_extState(state, src, dst, *srcSizePtr, targetDstSize, acceleration);
     } else {
+        void* const s = LZ4_initStream(state, sizeof (*state));
+        assert(s != NULL); (void)s;
         if (*srcSizePtr < LZ4_64Klimit) {
```

### Measurements

ns/call, min of 5 runs, `-O3`, on the affected branch (`targetDstSize >= LZ4_compressBound(srcSize)`):

| srcSize | `LZ4_compress_destSize` | `LZ4_compress_destSize_extState` |
|--------:|------------------------:|---------------------------------:|
|     512 |    429 -> 197 (**-54%**) |             515 -> 370 (**-28%**) |
|    8192 |    938 -> 469 (**-50%**) |            1175 -> 700 (**-40%**) |
|  262144 |       8714 -> 8604 (-1%) |                8837 -> 8767 (-1%) |

A fixed-size `memset` is being removed, so the relative gain fades as `srcSize` grows; by 256 KB it is within noise. The other branch is untouched and measures unchanged.

### Behaviour

Unchanged in every respect I could measure:

- **Compressed output is identical.** FNV hash over every output byte plus the returned `*srcSizePtr`, across 10 source sizes x 4 target sizes x both entry points: `881204296c3b9d8d` before and after.
- **Assertion coverage is identical.** `LZ4_compress_fast_extState()` derives its context as `& LZ4_initStream(...) -> internal_donotuse` and asserts on it; since `internal_donotuse` is a union member at offset 0, that is the same assertion that moved. Verified with `-DLZ4_DEBUG=1`: an invalid `@state` still aborts on both branches.

### Tests

`tests/fuzzer -T45s` and `tests/frametest -T20s` both pass (`tests/fuzzer.c` exercises `LZ4_compress_destSize` in 19 places). Also built clean with `-std=c90 -Werror -Wpedantic`, with `-Wc++-compat -Wall -Wextra -Werror`, and with `-DLZ4_DEBUG=1`.
