### PR TITLE
cli: keep source after decompression failure

### DIFF
--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -2437,7 +2437,7 @@ LZ4IO_decompressSrcFile(unsigned long long* outGenSize,
 
     /* Close input */
     fclose(finput);
-    if (prefs->removeSrcFile) {  /* --rm */
+    if (!result && prefs->removeSrcFile) {  /* --rm */
         if (remove(input_filename))
             END_PROCESS(45, "Remove error : %s: %s", input_filename, strerror(errno));
     }

--- a/tests/test-lz4-basic.sh
+++ b/tests/test-lz4-basic.sh
@@ -63,6 +63,10 @@ lz4 --list $FPREFIX-hw.lz4            # test --list on valid single-frame file
 lz4 --list < $FPREFIX-hw.lz4          # test --list from stdin (file only)
 cat $FPREFIX-hw >> $FPREFIX-hw.lz4
 lz4 -f $FPREFIX-hw.lz4 && exit 1      # uncompress valid frame followed by invalid data (must fail now)
+printf '\120\052\115\030\000\000\000\000BAD!' > $FPREFIX-bad.lz4
+cp $FPREFIX-bad.lz4 $FPREFIX-bad-before.lz4
+lz4 -d --rm -f $FPREFIX-bad.lz4 $FPREFIX-bad.out && exit 1
+diff -q $FPREFIX-bad-before.lz4 $FPREFIX-bad.lz4  # --rm keeps source after decoding failure
 lz4 -BX $FPREFIX-hw -c -q | lz4 -tv   # test block checksum
 # datagen -g20KB generates the same file every single time
 # cannot save output of datagen -g20KB as input file to lz4 because the following shell commands are run before datagen -g20KB


### PR DESCRIPTION
`--rm` is documented to remove a source after successful decompression. A recoverable trailing-data error currently sets a nonzero result and then reaches the unconditional source-removal block.

For example, an empty skippable frame followed by an unknown four-byte magic exits with status 1 while deleting the input. Gate source removal on the decompression result and add a regression that verifies the malformed input remains unchanged. Successful decompression continues to remove its source.

Validation:

- strict C90/Werror build
- baseline regression fails because the source disappears; patched regression passes
- `test-lz4-basic` under the strict build and ASan/UBSan

This change is scoped to decoder failures represented by `LZ4IO_decompressSrcFile()`'s result. Output-stream close handling is separate and unchanged.
