### PR TITLE
decode: add optional -fbounds-safety annotations for LZ4_decompress_safe

### DIFF
--- a/build/cmake/CMakeLists.txt
+++ b/build/cmake/CMakeLists.txt
@@ -50,6 +50,9 @@ endif()
 # BUILD OPTIONS - Configure build targets and features
 #-----------------------------------------------------------------------------
 option(LZ4_BUILD_CLI "Build lz4 program" ON)
+option(LZ4_ENABLE_FBOUNDS_SAFETY
+       "Enable experimental Clang -fbounds-safety annotations (OFF by default)"
+       OFF)
 option(LZ4_BUILD_LEGACY_LZ4C "Build lz4c program with legacy argument support" OFF)
 
 
@@ -205,6 +208,16 @@ if(BUILD_STATIC_LIBS)
     XXH_NAMESPACE=LZ4_)
 endif(BUILD_STATIC_LIBS)
 
+# Optional -fbounds-safety (inert macros unless enabled)
+if(LZ4_ENABLE_FBOUNDS_SAFETY)
+  foreach(_lz4_tgt IN LISTS LZ4_LIBRARIES_BUILT)
+    if(TARGET ${_lz4_tgt} AND NOT ${_lz4_tgt} STREQUAL "lz4")
+      target_compile_definitions(${_lz4_tgt} PUBLIC LZ4_SUPPORT_FBOUNDS_SAFETY)
+      target_compile_options(${_lz4_tgt} PUBLIC -fbounds-safety)
+    endif()
+  endforeach()
+endif(LZ4_ENABLE_FBOUNDS_SAFETY)
+
 #-----------------------------------------------------------------------------
 # CLI EXECUTABLES - Configuring command-line programs
 #-----------------------------------------------------------------------------
@@ -274,6 +287,7 @@ if(NOT LZ4_BUNDLED_MODE)
     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
   install(FILES
     "${LZ4_LIB_SOURCE_DIR}/lz4.h"
+    "${LZ4_LIB_SOURCE_DIR}/lz4_bounds_safety.h"
     "${LZ4_LIB_SOURCE_DIR}/lz4hc.h"
     "${LZ4_LIB_SOURCE_DIR}/lz4frame.h"
     "${LZ4_LIB_SOURCE_DIR}/lz4file.h"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -46,6 +46,13 @@ LIBVER  := $(shell echo $(LIBVER_SCRIPT))
 BUILD_SHARED:=yes
 BUILD_STATIC:=yes
 
+# Optional Clang -fbounds-safety (OFF by default; inert macros otherwise)
+ENABLE_FBOUNDS_SAFETY ?= 0
+ifeq ($(ENABLE_FBOUNDS_SAFETY),1)
+CPPFLAGS += -DLZ4_SUPPORT_FBOUNDS_SAFETY
+CFLAGS   += -fbounds-safety
+endif
+
 CPPFLAGS+= -DXXH_NAMESPACE=LZ4_
 USERCFLAGS:= -O3 $(CFLAGS)
 DEBUGFLAGS:= -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow \
@@ -235,6 +242,7 @@ install: lib liblz4.pc
   endif
 	@echo Installing headers in $(DESTDIR)$(includedir)
 	$(INSTALL_DATA) lz4.h $(DESTDIR)$(includedir)/lz4.h
+	$(INSTALL_DATA) lz4_bounds_safety.h $(DESTDIR)$(includedir)/lz4_bounds_safety.h
 	$(INSTALL_DATA) lz4hc.h $(DESTDIR)$(includedir)/lz4hc.h
 	$(INSTALL_DATA) lz4frame.h $(DESTDIR)$(includedir)/lz4frame.h
 	@echo lz4 libraries installed
@@ -252,6 +260,7 @@ uninstall:
   endif
 	$(RM) $(DESTDIR)$(libdir)/liblz4.a
 	$(RM) $(DESTDIR)$(includedir)/lz4.h
+	$(RM) $(DESTDIR)$(includedir)/lz4_bounds_safety.h
 	$(RM) $(DESTDIR)$(includedir)/lz4hc.h
 	$(RM) $(DESTDIR)$(includedir)/lz4frame.h
 	$(RM) $(DESTDIR)$(includedir)/lz4frame_static.h

--- a/lib/lz4.h
+++ b/lib/lz4.h
@@ -41,6 +41,7 @@ extern "C" {
 
 /* --- Dependency --- */
 #include <stddef.h>   /* size_t */
+#include "lz4_bounds_safety.h"  /* optional -fbounds-safety macros */
 
 
 /**
@@ -205,7 +206,9 @@ LZ4LIB_API int LZ4_compress_default(const char* src, char* dst, int srcSize, int
  *          The implementation is free to send / store / derive this information in whichever way is most beneficial.
  *          If there is a need for a different format which bundles together both compressed data and its metadata, consider looking at lz4frame.h instead.
  */
-LZ4LIB_API int LZ4_decompress_safe (const char* src, char* dst, int compressedSize, int dstCapacity);
+LZ4LIB_API int LZ4_decompress_safe (const char* LZ4_SIZED_BY(compressedSize) src,
+                                    char* LZ4_SIZED_BY(dstCapacity) dst,
+                                    int compressedSize, int dstCapacity);
 
 
 /*-************************************

--- a/lib/lz4_bounds_safety.h
+++ b/lib/lz4_bounds_safety.h
@@ -1,0 +1,41 @@
+/*
+ * lz4_bounds_safety.h - portability macros for optional -fbounds-safety
+ *
+ * Copyright (c) 2026 Jeff Bindel <jeff@incrediblybased.co>
+ *
+ * BSD 2-Clause License (same as the LZ4 library; see LICENSE in this directory).
+ *
+ * When LZ4_SUPPORT_FBOUNDS_SAFETY is defined (typically via
+ * -DLZ4_SUPPORT_FBOUNDS_SAFETY and a Clang toolchain that implements
+ * -fbounds-safety), these macros expand to Clang bounds annotations.
+ * Otherwise they expand to nothing so default builds are unchanged.
+ *
+ * Pattern matches libwebp / libpng / giflib inert-macro -fbounds-safety
+ * adoption: annotations are inert unless explicitly enabled.
+ */
+#ifndef LZ4_BOUNDS_SAFETY_H_2983827168210
+#define LZ4_BOUNDS_SAFETY_H_2983827168210
+
+#ifdef LZ4_SUPPORT_FBOUNDS_SAFETY
+
+#  include <ptrcheck.h>
+/* Non-ABI-breaking sized-by annotations for buffer pointer parameters.
+ * Prefer LZ4_SIZED_BY for byte buffers whose companion argument is a
+ * capacity (compressedSize / dstCapacity). Use *_OR_NULL when the
+ * pointer may be NULL while the companion size is zero.
+ */
+#  define LZ4_SIZED_BY(n) __sized_by(n)
+#  define LZ4_SIZED_BY_OR_NULL(n) __sized_by_or_null(n)
+#  define LZ4_COUNTED_BY(n) __counted_by(n)
+#  define LZ4_COUNTED_BY_OR_NULL(n) __counted_by_or_null(n)
+
+#else /* !LZ4_SUPPORT_FBOUNDS_SAFETY */
+
+#  define LZ4_SIZED_BY(n)
+#  define LZ4_SIZED_BY_OR_NULL(n)
+#  define LZ4_COUNTED_BY(n)
+#  define LZ4_COUNTED_BY_OR_NULL(n)
+
+#endif /* LZ4_SUPPORT_FBOUNDS_SAFETY */
+
+#endif /* LZ4_BOUNDS_SAFETY_H_2983827168210 */


### PR DESCRIPTION
## Summary
Secure-by-design memory-safety hardening. Annotates `LZ4_decompress_safe` `src`/`dst` with optional Clang `-fbounds-safety` / sized-by-style macros bound to `compressedSize` / `dstCapacity`. Default builds unchanged (macros empty unless enabled).

Contributor: Jeff Bindel via `LaptopsPlural`. Not a vulnerability PoC. Intentionally one-API first CL.

## Test plan
- [ ] Default build / existing tests
- [ ] Optional bounds-safety ON with supporting Clang (maintainers)